### PR TITLE
feat: v2.5.0 — DAG validator, wiki↔skills linking, pre-commit template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,5 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate structure and conventions
         run: bash tests/validate-structure.sh
+      - name: Validate skill graph DAG
+        run: bash tests/test-skill-graph.sh
       - name: Validate content quality and fitness functions
         run: bash tests/validate-content.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.5.0 — Testing & Discoverability (2026-04-09)
+
+### Added
+
+- **`tests/test-skill-graph.sh`** — DAG validator for `prev-skill`/`next-skill` chains (#79). Checks: cycles, dangling refs, symmetric edges, chain anchors, orphans. 55 assertions. Wired into CI.
+- **`hooks/pre-commit.sh.example`** — template that runs `/review-ai` on staged files before commit (#80). Copy to `.git/hooks/pre-commit` to opt in. NOT auto-installed.
+- **Bidirectional wiki ↔ skills linking** (#81) — each workflow skill (Steps 0-7) now has a `## Further Reading` section linking to its wiki page. Validator Check 15b enforces both directions.
+- **Validator Check 15a** — asserts `pre-commit.sh.example` exists and is NOT executable.
+
+### Changed
+
+- CI now runs 3 validators: `validate-structure.sh` + `test-skill-graph.sh` + `validate-content.sh`
+- Version bump 2.4.1 → 2.5.0
+
+---
+
 ## v2.4.1 — Honest Correction (2026-04-09)
 
 Same-day correction after reading the `claude-plugins-official:superpowers` `brainstorming` source and confirming our `/brainstorm` (shipped in v2.4.0) was a weaker reimplementation of ~60% of its functionality.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-16-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.4.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.4.1)
+[![Version](https://img.shields.io/badge/Version-2.5.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.5.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -306,7 +306,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.4.1)
+│   ├── plugin.json                 # Plugin metadata (v2.5.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 16 skills (8 workflow + 8 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -522,4 +522,4 @@ MIT
 
 ---
 
-_Version: 2.4.1 | Last updated: 2026-04-09_
+_Version: 2.5.0 | Last updated: 2026-04-09_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.4.1 | **Date**: 2026-04-09 | **Previous**: 2.4.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.5.0 | **Date**: 2026-04-09 | **Previous**: 2.4.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 

--- a/hooks/pre-commit.sh.example
+++ b/hooks/pre-commit.sh.example
@@ -1,0 +1,58 @@
+#!/bin/bash
+# 8-Habit AI Dev — Pre-Commit Hook (EXAMPLE — not auto-installed)
+#
+# Runs /review-ai on staged files before each commit.
+# Returns non-zero on REWORK or FAIL verdict, blocking the commit.
+#
+# Installation:
+#   cp hooks/pre-commit.sh.example .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# Uninstall:
+#   rm .git/hooks/pre-commit
+#
+# Opt out for a single commit:
+#   git commit --no-verify
+#
+# Requirements:
+#   - Claude Code CLI (claude) must be on PATH
+
+set -euo pipefail
+
+# Skip if claude CLI is not available
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[8-habit] claude CLI not found — skipping /review-ai pre-commit check"
+  exit 0
+fi
+
+# Get staged files (exclude deletions and mode-only changes)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+  # Nothing substantive staged (rename-only or pure deletions)
+  exit 0
+fi
+
+FILE_COUNT=$(echo "$STAGED_FILES" | wc -l | tr -d ' ')
+echo "[8-habit] Running /review-ai on $FILE_COUNT staged file(s)..."
+
+# Build file list for review context
+FILE_LIST=$(echo "$STAGED_FILES" | tr '\n' ' ')
+
+# Run review-ai via claude CLI in non-interactive print mode
+# Capture output and check for REWORK/FAIL verdicts
+REVIEW_OUTPUT=$(claude --print "/review-ai on staged files: $FILE_LIST" 2>&1) || true
+
+echo "$REVIEW_OUTPUT"
+
+# Check verdict — block on REWORK or FAIL
+if echo "$REVIEW_OUTPUT" | grep -qiE "verdict.*:.*\b(REWORK|FAIL)\b"; then
+  echo ""
+  echo "[8-habit] Pre-commit blocked: /review-ai returned REWORK or FAIL."
+  echo "[8-habit] Fix the issues above, then re-stage and commit."
+  echo "[8-habit] To bypass: git commit --no-verify"
+  exit 1
+fi
+
+echo "[8-habit] /review-ai passed — proceeding with commit."
+exit 0

--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -88,6 +88,10 @@ next-skill: build-brief
 - [ ] No task touches more than 5 files
 - [ ] Orchestration classification assigned to each task (sequential/parallel-safe/parallel-worktree)
 
+## Further Reading
+
+See [Step 3 wiki page](../../docs/wiki/Step-3-Breakdown.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/task-list-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h3-first-things-first.md` for the full H3 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/orchestration-patterns.md` for worktree isolation and context boundary patterns.

--- a/skills/build-brief/SKILL.md
+++ b/skills/build-brief/SKILL.md
@@ -97,5 +97,9 @@ next-skill: review-ai
 - [ ] Test approach defined (what to test, TDD if applicable)
 - [ ] Context boundaries defined for parallel tasks (must-know / must-not-know / merge contract)
 
+## Further Reading
+
+See [Step 4 wiki page](../../docs/wiki/Step-4-Build-Brief.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h5-understand-first.md` for the full H5 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/orchestration-patterns.md` for context boundary and orchestration patterns.

--- a/skills/deploy-guide/SKILL.md
+++ b/skills/deploy-guide/SKILL.md
@@ -67,4 +67,8 @@ next-skill: monitor-setup
 - [ ] Post-deploy health check confirmed (smoke test passed)
 - [ ] Error rate monitored for at least 5 minutes after deploy
 
+## Further Reading
+
+See [Step 6 wiki page](../../docs/wiki/Step-6-Deploy-Guide.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h1-be-proactive.md` for the full H1 principle and examples.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -79,5 +79,9 @@ next-skill: breakdown
 - [ ] ADR created for decisions affecting >3 files or changing public API
 - [ ] Constraints and non-goals documented
 
+## Further Reading
+
+See [Step 2 wiki page](../../docs/wiki/Step-2-Design.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/adr-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h8-find-voice.md` for the full H8 principle and examples.

--- a/skills/monitor-setup/SKILL.md
+++ b/skills/monitor-setup/SKILL.md
@@ -74,4 +74,8 @@ If you only invest in P and neglect PC, eventually the saw is too dull to cut.
 - [ ] Error tracking active (logs accessible, not just stdout)
 - [ ] Recovery runbook exists for each critical dependency
 
+## Further Reading
+
+See [Step 7 wiki page](../../docs/wiki/Step-7-Monitor-Setup.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h7-sharpen-saw.md` for the full H7 principle and examples.

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -92,5 +92,9 @@ next-skill: design
 - [ ] Scope boundaries clear — both "in scope" and "out of scope" listed
 - [ ] Stakeholder/target user identified
 
+## Further Reading
+
+See [Step 1 wiki page](../../docs/wiki/Step-1-Requirements.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/prd-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h2-begin-with-end.md` for the full H2 principle and examples.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -162,6 +162,10 @@ No unsourced claims. If you can't cite it, mark it as "unverified assumption."
 - [ ] Audit results included (if Audit mode) with file:line per row
 - [ ] Research brief ready for handoff to /requirements
 
+## Further Reading
+
+See [Step 0 wiki page](../../docs/wiki/Step-0-Research.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h5-understand-first.md` for the full H5 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/research-brief-template.md` for the output template.

--- a/skills/review-ai/SKILL.md
+++ b/skills/review-ai/SKILL.md
@@ -132,6 +132,10 @@ If Heart or Spirit scores lag Body/Mind by ≥2 categories, add:
 - [ ] Every finding cites specific evidence (file:line, test output, or diff)
 - [ ] Summary table shows findings count per category
 
+## Further Reading
+
+See [Step 5 wiki page](../../docs/wiki/Step-5-Review-AI.md) for deeper walkthrough, examples, and common pitfalls.
+
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/review-report-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h4-win-win.md` for the full H4 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards (the 12 commandments).

--- a/tests/test-skill-graph.sh
+++ b/tests/test-skill-graph.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# 8-Habit AI Dev — Skill Graph DAG Validator
+# Validates prev-skill/next-skill chains form a consistent directed acyclic graph.
+# Checks: cycles, dangling refs, symmetric edges, chain start/end, orphans.
+#
+# Compatible with bash 3.x (macOS default) — no associative arrays.
+# Usage: bash tests/test-skill-graph.sh
+# Called from .github/workflows/validate.yml
+
+set -euo pipefail
+
+ERRORS=0
+PASS=0
+WARNINGS=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { ERRORS=$((ERRORS + 1)); echo "  FAIL: $1"; }
+warn() { WARNINGS=$((WARNINGS + 1)); echo "  WARN: $1"; }
+
+echo "=== Skill Graph DAG Validation ==="
+echo ""
+
+# --- Step 1: Extract graph into temp file ---
+echo "--- Step 1: Extract skill graph ---"
+
+GRAPH_FILE=$(mktemp)
+trap 'rm -f "$GRAPH_FILE"' EXIT
+
+TOTAL=0
+for skill_dir in skills/*/; do
+  skill_file="${skill_dir}SKILL.md"
+  [ ! -f "$skill_file" ] && continue
+
+  name=$(basename "$skill_dir")
+
+  prev=$(sed -n '/^---$/,/^---$/{ s/^prev-skill:[[:space:]]*//p; }' "$skill_file" | head -1 | tr -d '[:space:]')
+  next=$(sed -n '/^---$/,/^---$/{ s/^next-skill:[[:space:]]*//p; }' "$skill_file" | head -1 | tr -d '[:space:]')
+
+  if [ -z "$prev" ]; then
+    fail "$name: missing prev-skill in frontmatter"
+    prev="MISSING"
+  fi
+  if [ -z "$next" ]; then
+    fail "$name: missing next-skill in frontmatter"
+    next="MISSING"
+  fi
+
+  echo "$name $prev $next" >> "$GRAPH_FILE"
+  TOTAL=$((TOTAL + 1))
+done
+
+echo "  Found $TOTAL skills"
+echo ""
+
+# Helper: lookup prev for a skill
+get_prev() { awk -v s="$1" '$1 == s { print $2 }' "$GRAPH_FILE"; }
+get_next() { awk -v s="$1" '$1 == s { print $3 }' "$GRAPH_FILE"; }
+skill_exists() { awk -v s="$1" '$1 == s { found=1 } END { exit !found }' "$GRAPH_FILE"; }
+
+# --- Step 2: Dangling references ---
+echo "--- Step 2: Dangling references ---"
+
+while read -r name prev next; do
+  for field_name in prev next; do
+    ref=$(eval echo "\$$field_name")
+    field_label="${field_name}-skill"
+    if [ "$ref" = "none" ] || [ "$ref" = "any" ] || [ "$ref" = "MISSING" ]; then
+      [ "$ref" != "MISSING" ] && pass "$name: $field_label '$ref' valid"
+    elif skill_exists "$ref"; then
+      pass "$name: $field_label '$ref' valid"
+    else
+      fail "$name: $field_label '$ref' references non-existent skill"
+    fi
+  done
+done < "$GRAPH_FILE"
+echo ""
+
+# --- Step 3: Symmetric edges ---
+echo "--- Step 3: Symmetric edges ---"
+
+while read -r name prev next; do
+  # If A says next-skill: B, then B should say prev-skill: A (or 'any')
+  if [ "$next" != "none" ] && [ "$next" != "any" ] && [ "$next" != "MISSING" ]; then
+    target_prev=$(get_prev "$next")
+    if [ "$target_prev" = "$name" ] || [ "$target_prev" = "any" ]; then
+      pass "$name → $next: symmetric (target prev=$target_prev)"
+    else
+      fail "$name says next-skill: $next, but $next says prev-skill: ${target_prev:-MISSING} (expected '$name' or 'any')"
+    fi
+  fi
+
+  # If A says prev-skill: B, then B should say next-skill: A (or 'any')
+  if [ "$prev" != "none" ] && [ "$prev" != "any" ] && [ "$prev" != "MISSING" ]; then
+    target_next=$(get_next "$prev")
+    if [ "$target_next" = "$name" ] || [ "$target_next" = "any" ]; then
+      pass "$prev → $name: symmetric (source next=$target_next)"
+    else
+      fail "$name says prev-skill: $prev, but $prev says next-skill: ${target_next:-MISSING} (expected '$name' or 'any')"
+    fi
+  fi
+done < "$GRAPH_FILE"
+echo ""
+
+# --- Step 4: Chain anchors ---
+echo "--- Step 4: Chain anchors ---"
+
+HAS_START=false
+HAS_END=false
+
+while read -r name prev next; do
+  [ "$prev" = "none" ] && [ "$next" != "none" ] && [ "$next" != "any" ] && HAS_START=true
+  [ "$next" = "none" ] && [ "$prev" != "none" ] && [ "$prev" != "any" ] && HAS_END=true
+done < "$GRAPH_FILE"
+
+if $HAS_START; then
+  pass "At least one chain-start skill exists (prev-skill: none + concrete next)"
+else
+  fail "No chain-start skill found"
+fi
+
+if $HAS_END; then
+  pass "At least one chain-end skill exists (next-skill: none + concrete prev)"
+else
+  fail "No chain-end skill found"
+fi
+echo ""
+
+# --- Step 5: Cycle detection (walk each chain from start nodes) ---
+echo "--- Step 5: Cycle detection ---"
+
+CYCLE_FOUND=false
+VISITED_FILE=$(mktemp)
+trap 'rm -f "$GRAPH_FILE" "$VISITED_FILE"' EXIT
+
+# Walk forward from each skill following next-skill edges
+while read -r start_name _ _; do
+  : > "$VISITED_FILE"
+  current="$start_name"
+  while [ -n "$current" ] && [ "$current" != "none" ] && [ "$current" != "any" ] && [ "$current" != "MISSING" ]; do
+    if grep -qx "$current" "$VISITED_FILE" 2>/dev/null; then
+      fail "Cycle detected: chain from $start_name revisits $current"
+      CYCLE_FOUND=true
+      break
+    fi
+    echo "$current" >> "$VISITED_FILE"
+    current=$(get_next "$current")
+  done
+done < "$GRAPH_FILE"
+
+if ! $CYCLE_FOUND; then
+  pass "No cycles detected in skill graph"
+fi
+echo ""
+
+# --- Step 6: Orphan detection ---
+echo "--- Step 6: Orphan detection ---"
+
+while read -r name prev next; do
+  if [ "$prev" = "none" ] && [ "$next" = "none" ]; then
+    # Check if any other skill references this one
+    if grep -qE "^[^ ]+ $name | $name$" "$GRAPH_FILE" 2>/dev/null && \
+       [ "$(grep -cE " $name( |$)" "$GRAPH_FILE")" -gt 0 ]; then
+      # Exclude self-references
+      refs=$(awk -v s="$name" '$1 != s && ($2 == s || $3 == s)' "$GRAPH_FILE" | wc -l | tr -d ' ')
+      if [ "$refs" -gt 0 ]; then
+        warn "$name: prev=none, next=none but referenced by other skills"
+      else
+        pass "$name: standalone (prev=none, next=none, unreferenced)"
+      fi
+    else
+      pass "$name: standalone (prev=none, next=none, unreferenced)"
+    fi
+  elif [ "$prev" = "any" ] && [ "$next" = "any" ]; then
+    pass "$name: standalone assessment skill (any/any)"
+  fi
+done < "$GRAPH_FILE"
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+echo "Skills: $TOTAL"
+echo "PASS: $PASS"
+echo "FAIL: $ERRORS"
+echo "WARN: $WARNINGS"
+echo ""
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "RESULT: FAILED ($ERRORS errors)"
+  exit 1
+else
+  echo "RESULT: ALL CHECKS PASSED"
+  exit 0
+fi

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -391,6 +391,62 @@ else
 fi
 echo ""
 
+# --- Check 15a: pre-commit.sh.example template ---
+echo "--- Check 15a: pre-commit.sh.example ---"
+PRECOMMIT="hooks/pre-commit.sh.example"
+if [ -f "$PRECOMMIT" ]; then
+  pass "$PRECOMMIT exists"
+  if [ -x "$PRECOMMIT" ]; then
+    fail "$PRECOMMIT should NOT be executable (prevents accidental auto-install)"
+  else
+    pass "$PRECOMMIT is not executable"
+  fi
+  if head -1 "$PRECOMMIT" | grep -q '^#!/bin/bash'; then
+    pass "$PRECOMMIT has bash shebang"
+  else
+    fail "$PRECOMMIT missing bash shebang"
+  fi
+else
+  fail "$PRECOMMIT not found"
+fi
+echo ""
+
+# --- Check 15b: Bidirectional wiki ↔ skills linking ---
+echo "--- Check 15: Wiki ↔ Skills bidirectional linking ---"
+WIKI_SKILL_MAP="
+Step-0-Research:research
+Step-1-Requirements:requirements
+Step-2-Design:design
+Step-3-Breakdown:breakdown
+Step-4-Build-Brief:build-brief
+Step-5-Review-AI:review-ai
+Step-6-Deploy-Guide:deploy-guide
+Step-7-Monitor-Setup:monitor-setup
+"
+for pair in $WIKI_SKILL_MAP; do
+  wiki_page=$(echo "$pair" | cut -d: -f1)
+  skill_name=$(echo "$pair" | cut -d: -f2)
+  wiki_file="docs/wiki/${wiki_page}.md"
+  skill_file="skills/${skill_name}/SKILL.md"
+
+  # Wiki → Skill (forward link)
+  if [ -f "$wiki_file" ] && [ -f "$skill_file" ]; then
+    if grep -q "$skill_name" "$wiki_file"; then
+      pass "$wiki_page → $skill_name (wiki links to skill)"
+    else
+      fail "$wiki_file missing reference to $skill_name"
+    fi
+
+    # Skill → Wiki (back-reference via Further Reading)
+    if grep -q "$wiki_page" "$skill_file"; then
+      pass "$skill_name → $wiki_page (skill links back to wiki)"
+    else
+      fail "$skill_file missing back-reference to $wiki_page"
+    fi
+  fi
+done
+echo ""
+
 # --- Summary ---
 echo "=== Summary ==="
 echo "PASS: $PASS"


### PR DESCRIPTION
## Summary

Closes #79, #80, #81 — all remaining open issues.

- **`tests/test-skill-graph.sh`** (#79) — DAG validator for `prev-skill`/`next-skill` chains. Checks cycles, dangling refs, symmetric edges, chain anchors, orphans. 55 assertions. Wired into CI.
- **Bidirectional wiki ↔ skills linking** (#81) — each workflow skill (Steps 0-7) has a `## Further Reading` section back-linking to its wiki page. Validator Check 15b enforces both directions.
- **`hooks/pre-commit.sh.example`** (#80) — template that runs `/review-ai` on staged files. Copy to `.git/hooks/pre-commit` to opt in. NOT auto-installed.
- Version bump 2.4.1 → 2.5.0

## Test plan

- [x] `bash tests/validate-structure.sh` → 228/228 PASS
- [x] `bash tests/test-skill-graph.sh` → 55/55 PASS
- [x] `bash tests/validate-content.sh` → 160/160 PASS, 0 fitness breaches
- [x] CI runs all 3 validators in sequence
- [x] `pre-commit.sh.example` exists and is NOT executable