### PR TITLE
feat: persistent reflection artifacts — close the learning loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 - **`habits/`, `guides/`, `rules/` are reference content** — never generated or modified by skills
 - **Agent (`agents/8-habit-reviewer.md`)** uses model `sonnet` with read-only tools (`Read`, `Glob`, `Grep`) — it analyzes and reports, never edits
 - **Plugin metadata** lives in `.claude-plugin/plugin.json` (plugin config) and `.claude-plugin/marketplace.json` (marketplace listing)
+- **Lesson persistence** (v2.6.0): `/reflect` saves lesson files to `~/.claude/lessons/YYYY-MM-DD-<slug>.md`. `/research` and `/build-brief` search these before starting work. This closes the learning loop: reflect → persist → retrieve → apply
 - **Session hook budget**: `hooks/session-start.sh` output must stay ≤300 tokens
 - **Version lives in 4 files** — must bump together: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` (badge + footer), and `SELF-CHECK.md` header. `tests/validate-structure.sh` enforces consistency across all four — CI will fail if any drifts.
 
@@ -85,5 +86,5 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 | `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                   |
 | `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation tiered checklist (v2.3.0, migrating to claude-governance) |
 | `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                    |
-| `/reflect`            | —    | H7 Sharpen the Saw    | 5-question post-task retrospective                                               |
+| `/reflect`            | —    | H7 Sharpen the Saw    | 5-question post-task retrospective + persistent lesson file (`~/.claude/lessons/`) |
 | `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                        |

--- a/docs/wiki/Step-0-Research.md
+++ b/docs/wiki/Step-0-Research.md
@@ -22,10 +22,11 @@ Investigate the problem space **before** writing requirements. Prevents specifyi
 ## Process
 
 1. **Define the question** — 1 sentence, specific
-2. **Gather prior art** — existing code, docs, web research, comparable libraries
-3. **Compare** — if evaluating alternatives, produce a trade-off matrix
-4. **Surface constraints** — legal, performance, team skills, budget
-5. **Recommend** (not decide) — AI recommends; human decides in Step 2
+2. **Check past lessons** — search `~/.claude/lessons/` for relevant lessons from prior sessions (v2.6.0+)
+3. **Gather prior art** — existing code, docs, web research, comparable libraries
+4. **Compare** — if evaluating alternatives, produce a trade-off matrix
+5. **Surface constraints** — legal, performance, team skills, budget
+6. **Recommend** (not decide) — AI recommends; human decides in Step 2
 
 ## Output
 

--- a/guides/templates/lesson-template.md
+++ b/guides/templates/lesson-template.md
@@ -1,0 +1,58 @@
+# Lesson Template
+
+Output template for `/reflect` Step 6 (Persist). Lessons are saved to `~/.claude/lessons/` for cross-session retrieval by `/research` and `/build-brief`.
+
+## File Naming
+
+`YYYY-MM-DD-<slug>.md` where `<slug>` is a lowercase, hyphenated summary of the task (max 50 chars).
+
+Example: `2026-04-11-auth-middleware-race-condition.md`
+
+## Template
+
+```markdown
+---
+date: YYYY-MM-DD
+task: "[task or feature name]"
+project: "[project name from working directory]"
+tags: ["tag1", "tag2", "tag3"]
+habit: "H[N]"
+---
+
+# Lesson: [task or feature name]
+
+## Went well
+[Brief answer from Question 1]
+
+## Surprised
+[Brief answer from Question 2]
+
+## Do differently
+[Brief answer from Question 3]
+
+## Reusable pattern
+[Brief answer from Question 4, or "none this time"]
+
+## Action item
+[Specific action] — **Owner**: [who] — **By**: [date]
+```
+
+## Field Descriptions
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `date` | Yes | Date of reflection (YYYY-MM-DD) |
+| `task` | Yes | Name of the task or feature reflected on |
+| `project` | Yes | Project name (basename of working directory) |
+| `tags` | Yes | 2-5 keywords for search — include domain, technology, and pattern names |
+| `habit` | No | Primary habit that applied (e.g., "H1", "H5") — helps track which habits surface most |
+
+## Tagging Guidelines
+
+Good tags enable retrieval. Include:
+- **Domain**: `auth`, `api`, `database`, `frontend`, `infra`, `ci`
+- **Technology**: `typescript`, `python`, `docker`, `k8s`
+- **Pattern**: `race-condition`, `migration`, `error-handling`, `testing`
+- **Workflow**: `review`, `deploy`, `refactor`, `security`
+
+Avoid generic tags: `code`, `fix`, `update`, `work`

--- a/skills/build-brief/SKILL.md
+++ b/skills/build-brief/SKILL.md
@@ -27,6 +27,13 @@ next-skill: review-ai
 
 1. **Read existing code first**: Before writing anything new, read the files in the affected area. Understand current patterns, naming conventions, and architecture.
 
+1b. **Check past lessons** (if `~/.claude/lessons/` exists):
+   - Grep `~/.claude/lessons/` for tags or keywords matching the task name, affected file paths, or domain
+   - Search by tags first: `Grep pattern="tags:.*<keyword>" path="~/.claude/lessons/"`
+   - Fall back to keyword search: `Grep pattern="<keyword>" path="~/.claude/lessons/"`
+   - If relevant lessons found, include them in the context brief under "Lessons from past work"
+   - If no lessons directory or no matches, skip silently
+
 2. **Build the context brief**:
 
    ```

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Maps to H7 (Sharpen the Saw — invest in capability, not just output).
 user-invocable: true
 argument-hint: "[task or feature just completed]"
-allowed-tools: ["Read", "Glob", "Grep"]
+allowed-tools: ["Read", "Glob", "Grep", "Write"]
 prev-skill: any
 next-skill: none
 ---
@@ -59,6 +59,22 @@ One specific, assigned action with a deadline. Not "we should improve testing" b
 | 5 | Action item | [specific action] — **Owner**: [who] — **By**: [date] |
 ```
 
+## Step 6: Persist Lesson (automatic)
+
+After the 5 questions are answered, persist the reflection as a lesson file for future sessions. This step should be automatic — do not ask the user additional questions.
+
+1. **Create directory** if needed: `~/.claude/lessons/` (skip silently if it already exists)
+2. **Generate filename**: `YYYY-MM-DD-<slug>.md` where `<slug>` is a lowercase, hyphenated summary of the task (max 50 chars, no spaces or special characters)
+3. **Write the lesson file** using the template from `${CLAUDE_PLUGIN_ROOT}/guides/templates/lesson-template.md`:
+   - `date`: today's date
+   - `task`: the task/feature name from the reflection argument
+   - `project`: basename of the current working directory
+   - `tags`: 2-5 keywords extracted from the reflection answers (domain, technology, pattern)
+   - `habit`: the primary habit that applied during this task (if identifiable)
+   - Body: the 5-question answers from the reflection output
+4. **Confirm**: Print a one-line confirmation: `Lesson saved: ~/.claude/lessons/<filename>`
+5. **Graceful failure**: If the write fails (permissions, disk full), warn the user but do NOT block the reflection output. The conversation-level reflection is more valuable than persistence.
+
 ## When to Skip
 
 - Task took less than 15 minutes
@@ -69,6 +85,8 @@ One specific, assigned action with a deadline. Not "we should improve testing" b
 
 - [ ] All 5 questions answered (even if briefly)
 - [ ] Action item has an owner and deadline (or explicitly "none needed")
+- [ ] Lesson file persisted to `~/.claude/lessons/` (or warning printed if write failed)
 - [ ] Took no more than 5 minutes
 
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h7-sharpen-saw.md` for the full H7 principle and examples.
+Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/lesson-template.md` for the lesson file format.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -59,16 +59,25 @@ What do we need to know before specifying requirements?
 
 ### 2. Search existing solutions
 
+**Before external search — check past lessons** (all depth levels):
+
+- Glob `~/.claude/lessons/*.md` to check if lesson files exist
+- If lessons exist, Grep for tags or keywords matching the research topic: `Grep pattern="tags:.*<keyword>" path="~/.claude/lessons/"` then fall back to `Grep pattern="<keyword>" path="~/.claude/lessons/"` for body matches
+- If relevant lessons are found, Read them and include findings under "Prior lessons learned" in the research brief
+- If `~/.claude/lessons/` does not exist or is empty, skip silently
+
 Route by depth level:
 
 **Quick** (codebase only):
 
+- Search past lessons (see above)
 - Glob/Grep the codebase for related patterns
 - Read existing implementations, ADRs, and documentation
 - Skip WebSearch/WebFetch entirely
 
 **Standard** (codebase + external):
 
+- Search past lessons (see above)
 - Glob/Grep the codebase for related patterns
 - WebSearch for existing tools, libraries, or approaches
 - WebFetch to read key external documentation


### PR DESCRIPTION
## Summary

- **Close the learning loop**: `/reflect` now saves lesson files to `~/.claude/lessons/YYYY-MM-DD-<slug>.md` after the 5-question micro-retro (H7 Sharpen the Saw)
- **Retrieve in future sessions**: `/research` and `/build-brief` search past lessons (tags first, keyword fallback) before starting work
- **Inspired by**: Hermes Agent (Nous Research) closed learning loop pattern — identified as top gap in Deep research brief (cross-verify 15/17, whole-person 4.75/5)

Closes #88 | Milestone: v2.6.0 — Hermes-Inspired Improvements

### Files changed (6)
| File | Change |
|------|--------|
| `skills/reflect/SKILL.md` | Step 6 persist + `Write` in allowed-tools + graceful failure |
| `skills/research/SKILL.md` | Lesson search before external search (all depth levels) |
| `skills/build-brief/SKILL.md` | Step 1b lesson search |
| `guides/templates/lesson-template.md` | **New** — YAML frontmatter template with tagging guidelines |
| `CLAUDE.md` | Document lesson persistence in Key Conventions + Skills table |
| `docs/wiki/Step-0-Research.md` | Add "Check past lessons" step |

## Test plan

- [x] `bash tests/validate-structure.sh` — 228/228 PASS
- [x] `bash tests/validate-content.sh` — 160/160 PASS
- [x] `bash tests/test-skill-graph.sh` — 55/55 PASS (DAG unchanged)
- [ ] Manual: run `/reflect` on a completed task → verify lesson file created at `~/.claude/lessons/`
- [ ] Manual: run `/research` with a topic matching a saved lesson → verify lesson surfaces in findings
- [ ] Manual: run `/build-brief` on a task matching a saved lesson → verify lesson included in context