### PR TITLE
chore(release): v2.6.0 — Hermes-Inspired Improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.6.0 — Hermes-Inspired Improvements (2026-04-11)
+
+Operationalizes four user-modeling and learning-loop patterns inspired by Hermes Agent (Nous Research), filtered through plugin-boundary discipline and cross-verification. Milestone v2.6.0 scope: P1 + P2 issues shipped (4/5 closed); #92 deferred to v2.6.1 or v2.7.0.
+
+### Added
+
+- **`/calibrate` skill + habit-profile schema v1** ([#90](https://github.com/pitimon/8-habit-ai-dev/issues/90), [ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md)) — new standalone skill that asks 5-7 questions and writes `~/.claude/habit-profile.md` so other skills can adapt verbosity to the user's maturity level (Dependence → Independence → Interdependence → Significance). Uses dominant-level scoring rubric adapted from `guides/whole-person-rubrics.md`. Writer side only — reader adoption for the 16 existing skills is tracked as [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) for v2.7.0.
+- **`guides/habit-profile-schema.md`** — public schema contract (v1, YAML frontmatter + markdown body, versioned via `schema-version`). Defines the API future reader skills code against; documents reader compatibility expectations and the BSD-vs-GNU date syntax caveat for age calculations.
+- **Persistent reflection artifacts** ([#88](https://github.com/pitimon/8-habit-ai-dev/issues/88)) — `/reflect` now persists lessons to `~/.claude/lessons/YYYY-MM-DD-<slug>.md`. `/research` and `/build-brief` search these before starting work. Closes the learning loop: reflect → persist → retrieve → apply.
+- **`guides/habit-nudges.md`** ([#89](https://github.com/pitimon/8-habit-ai-dev/issues/89)) — specification document for proactive workflow reminders (hook implementation belongs in `pitimon/claude-governance` per plugin boundary — this is the spec side).
+- **`guides/agentskills-compatibility-eval.md`** + **ADR-007** ([#91](https://github.com/pitimon/8-habit-ai-dev/issues/91)) — Deep + Compare research brief evaluating migration to the agentskills.io open standard. Decision: **NO-GO**. Other tools only parse `name`/`description`, not `metadata.*`, so migrating would trade the DAG validator's chain enforcement for a prose convention — a net loss. Hands-on sandbox test included.
+- **ADR-008** — User Maturity Calibration design record with 5 interlocking decisions: Alt E hybrid, dominant-level scoring, YAML frontmatter schema, standalone chain position, user-driven re-calibration with age warning.
+- **`/calibrate` discovery nudge** in `hooks/session-start.sh` — when `~/.claude/habit-profile.md` is missing, append a one-line 💡 nudge to the Onboarding line. Fully respects existing `HABIT_QUIET=1` opt-out from ADR-006.
+
+### Changed
+
+- Skill count: **16 → 17** (`/calibrate` added). Updated across README badge, CLAUDE.md Skills → Habits table, SELF-CHECK.md, `/using-8-habits` inventory, and `validate-structure.sh` counter.
+- `skills/using-8-habits/SKILL.md` — added `/calibrate` entry to the Assessment skills inventory; trimmed existing content to stay under F3 convention-consistency fitness budget (now 1990/2000 words — monitor margin for future edits).
+- `hooks/session-start.sh` — Onboarding line now lists `/calibrate` alongside `/using-8-habits`.
+- Validators expanded: **443 → 470 PASS** across 3 validators with 17/17 F3 convention-consistency.
+
+### Not Changed (Deferred or Out-of-Scope)
+
+- **Reader adoption for the 16 pre-v2.6.0 skills** — tracked as [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) for v2.7.0. Reading the profile and adjusting verbosity is a cross-cutting change that deserves its own PR.
+- **Issue [#92](https://github.com/pitimon/8-habit-ai-dev/issues/92) Skill Effectiveness Tracking** (P3) — remains open, deferrable to v2.6.1 or v2.7.0.
+
+### Migration notes
+
+No breaking changes. New users installing v2.6.0 for the first time will be nudged to run `/calibrate` on their next session. Existing users can opt in anytime by running `/calibrate` directly. Users who prefer the previous behavior can export `HABIT_QUIET=1` to silence both the session-start reminder and the calibration nudge.
+
+---
+
 ## v2.5.0 — Testing & Discoverability (2026-04-09)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-7C3AED)](https://github.com/pitimon/8-habit-ai-dev)
-[![Skills](https://img.shields.io/badge/Skills-16-blue)]()
+[![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.5.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.5.0)
+[![Version](https://img.shields.io/badge/Version-2.6.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.6.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.5.0)
+│   ├── plugin.json                 # Plugin metadata (v2.6.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -523,4 +523,4 @@ MIT
 
 ---
 
-_Version: 2.5.0 | Last updated: 2026-04-09_
+_Version: 2.6.0 | Last updated: 2026-04-11_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.5.0 | **Date**: 2026-04-09 | **Previous**: 2.4.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.6.0 | **Date**: 2026-04-11 | **Previous**: 2.5.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 


### PR DESCRIPTION
## Summary

Release PR bumping plugin version from **2.5.0 → 2.6.0**. This is a **metadata-only release** — all features are already merged to main. The bump unblocks the plugin cache lag identified in #88's lesson file ("incremental merges create a window where main has the feature but no installed user can access it yet").

## Version changes (all 4 version-locked files)

| File | Before | After |
|---|---|---|
| `.claude-plugin/plugin.json` | 2.5.0 | **2.6.0** |
| `.claude-plugin/marketplace.json` | 2.5.0 | **2.6.0** |
| `README.md` badge + footer | 2.5.0 | **2.6.0** |
| `SELF-CHECK.md` header | 2.5.0 (Previous: 2.4.1) | **2.6.0** (Previous: 2.5.0) |

Also: `README.md` Skills badge **16 → 17** (matches the post-#90 skill count).

## CHANGELOG

New `## v2.6.0 — Hermes-Inspired Improvements` section added at the top of `CHANGELOG.md` summarizing:

- **#88** Persistent Reflection Artifacts ([PR #93](https://github.com/pitimon/8-habit-ai-dev/pull/93))
- **#89** Habit Nudge Guidance Document ([PR #94](https://github.com/pitimon/8-habit-ai-dev/pull/94))
- **#91** agentskills.io Compatibility Evaluation — NO-GO ([PR #95](https://github.com/pitimon/8-habit-ai-dev/pull/95) + ADR-007)
- **#90** User Maturity Calibration ([PR #97](https://github.com/pitimon/8-habit-ai-dev/pull/97) + ADR-008)

With explicit "Not Changed" section noting [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) (reader adoption, deferred to v2.7.0) and #92 (still open, deferrable).

## Plugin cache lag rationale

From the lesson file at `~/.claude/lessons/2026-04-11-hermes-inspired-v2-6-0.md`:

> Merging a PR updates the repo main branch but does NOT bump the installed plugin cache. Users (including me, right now) need a version bump + reinstall to see the new behavior.

This PR is the version bump. After merge, users on main who run `claude plugin marketplace update` will see v2.6.0 and can reinstall to access `/calibrate`, the persistent `/reflect` lesson files, the `habit-nudges.md` spec, and the agentskills.io NO-GO record.

## Verification

### Validators (470/470 PASS, 0 fitness breaches)

- **`test-skill-graph.sh`**: 57 PASS
- **`validate-structure.sh`**: 238 PASS — **version consistency check green across all 4 files at 2.6.0**
- **`validate-content.sh`**: 175 PASS + F3 convention-consistency 17/17 HEALTHY

### What's NOT in this PR

- No code changes. Pure metadata bump.
- No new skills. /calibrate already merged in #97.
- No breaking changes. All upgrades are additive.

## Test plan

- [x] `plugin.json` version field updated
- [x] `marketplace.json` version field updated (inside nested plugins array)
- [x] `README.md` Version badge updated + URL tag
- [x] `README.md` Skills badge bumped 16 → 17
- [x] `README.md` ASCII tree comment updated
- [x] `README.md` footer version + date updated
- [x] `SELF-CHECK.md` header version + date + Previous fields updated
- [x] `CHANGELOG.md` new v2.6.0 entry at top
- [x] All 3 validators pass with version consistency verified
- [ ] CI validate job passes on push
- [ ] Maintainer review before merge
- [ ] Post-merge: create git tag `v2.6.0` + GitHub Release with changelog excerpt

## Milestone v2.6.0 status after merge

**4/5 closed (80%)** — one remaining:

- [x] #88 Persistent Reflection Artifacts (P1) — merged
- [x] #89 Habit Nudge Guidance Document (P1) — merged
- [x] #91 agentskills.io Compatibility Evaluation (P2) — merged (NO-GO)
- [x] #90 User Maturity Calibration (P2) — merged
- [ ] #92 Skill Effectiveness Tracking (P3) — deferrable to v2.6.1 or v2.7.0

Decision on #92: per ADR-006 scope discipline, v2.6.0 can ship with 4/5 since the remaining P3 is the smallest and least urgent. v2.6.0 is the meaningful Hermes-inspired milestone; #92 can ride v2.6.1 alongside the #96 reader adoption work.