### PR TITLE
feat(release): /reflect Q6 skill effectiveness + v2.6.1 (#92)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Closes milestone v2.6.0 by shipping the final P3 issue from the Hermes-Inspired 
 
 `SKILL-EFFECTIVENESS.md` is **maintainer-curated, not auto-generated**. A runtime aggregator that scans `~/.claude/lessons/*.md` across users would need to be a hook (belongs in `pitimon/claude-governance` per plugin boundary) or would violate the "skills are read-only guidance" principle. The chosen design — maintainer reads lessons periodically, updates the report, commits — respects both constraints and matches ADR-008's schema-as-contract pattern (report format is a stable contract between `/reflect` writers and maintainer readers).
 
+### Fixed
+
+- **`tests/validate-content.sh` F3 convention-consistency check** — replaced `sed -n '/^---$/,/^---$/p' "$skill_file" | head -20` with an awk-based frontmatter extractor that exits cleanly at the second `---` marker. The old pattern was flaky under `set -o pipefail` on Linux CI (GNU sed) because `skills/ai-dev-log/SKILL.md` has a body horizontal rule at line 65, causing sed to emit 187 lines from a 239-line file; `head -20` closed early, sed hit SIGPIPE, and CI failed with exit code 4. BSD sed on macOS silently ignores SIGPIPE which masked the bug locally. Fix uses the same awk pattern already documented at `tests/validate-structure.sh:27`. The bug was latent since ai-dev-log gained its body `---` rule and caught PR #99 on its first CI run. No functional change to the F3 check — only the extraction mechanism.
+
 ### Milestone v2.6.0 — now CLOSED (5/5)
 
 With this release, all five Hermes-Inspired issues are shipped:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.6.1 — Skill Effectiveness Tracking (2026-04-11)
+
+Closes milestone v2.6.0 by shipping the final P3 issue from the Hermes-Inspired research brief. This is a minor patch release — one question added to `/reflect` plus a new maintainer-curated report file. No breaking changes, no migrations.
+
+### Added
+
+- **`/reflect` Q6 — Skill effectiveness signal** ([#92](https://github.com/pitimon/8-habit-ai-dev/issues/92)) — `/reflect` now asks "which skill was most useful this session, and which was least useful or confusing?" after the 5 standard retro questions. Answer can be `n/a` if no skills were invoked. Feeds periodic maintainer trend analysis.
+- **`SKILL-EFFECTIVENESS.md`** (repo root) — maintainer-curated trend tracker aggregating Q6 signals from `~/.claude/lessons/*.md` across time. Ships empty (initial state, awaiting data). Includes explicit update protocol, "what this is NOT" boundaries, and per-skill tally table for all 17 skills. This is **H7 (Sharpen the Saw) applied to the plugin itself** — invest in the capability of the skills, not just their output.
+- **`guides/templates/lesson-template.md`** — added `## Skill effectiveness` section to the lesson template body so Q6 answers are captured consistently across user lesson files.
+
+### Changed
+
+- `skills/reflect/SKILL.md` — updated description from "5 questions" to "6 questions" (still fits the "5 minutes" DORA budget — Q6 is a 30-second signal question). Output table, Persist step, and Definition of Done all updated. Word count: 561 → 711 (well under 2000 F3 fitness budget).
+- `CLAUDE.md` Skills → Habits table — `/reflect` row now notes the skill-effectiveness signal.
+
+### Architectural constraint honored
+
+`SKILL-EFFECTIVENESS.md` is **maintainer-curated, not auto-generated**. A runtime aggregator that scans `~/.claude/lessons/*.md` across users would need to be a hook (belongs in `pitimon/claude-governance` per plugin boundary) or would violate the "skills are read-only guidance" principle. The chosen design — maintainer reads lessons periodically, updates the report, commits — respects both constraints and matches ADR-008's schema-as-contract pattern (report format is a stable contract between `/reflect` writers and maintainer readers).
+
+### Milestone v2.6.0 — now CLOSED (5/5)
+
+With this release, all five Hermes-Inspired issues are shipped:
+
+- ✅ #88 Persistent Reflection Artifacts (v2.6.0)
+- ✅ #89 Habit Nudge Guidance Document (v2.6.0)
+- ✅ #91 agentskills.io Compatibility Evaluation — NO-GO (v2.6.0)
+- ✅ #90 User Maturity Calibration — `/calibrate` (v2.6.0)
+- ✅ #92 Skill Effectiveness Tracking — `/reflect` Q6 + report (v2.6.1, **this release**)
+
+Follow-up [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) (16-skill reader adoption for `habit-profile.md`) remains open for v2.7.0.
+
+### Migration notes
+
+No breaking changes. Users upgrading from v2.6.0:
+- Next `/reflect` invocation will include Q6. Answer `n/a` if no skills apply.
+- Your existing lesson files at `~/.claude/lessons/*.md` are unchanged. New lessons written after upgrade will include the `## Skill effectiveness` section.
+- `SKILL-EFFECTIVENESS.md` ships empty — data accumulates as you reflect.
+
+---
+
 ## v2.6.0 — Hermes-Inspired Improvements (2026-04-11)
 
 Operationalizes four user-modeling and learning-loop patterns inspired by Hermes Agent (Nous Research), filtered through plugin-boundary discipline and cross-verification. Milestone v2.6.0 scope: P1 + P2 issues shipped (4/5 closed); #92 deferred to v2.6.1 or v2.7.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,6 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 | `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                   |
 | `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation tiered checklist (v2.3.0, migrating to claude-governance) |
 | `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                    |
-| `/reflect`            | —    | H7 Sharpen the Saw    | 5-question post-task retrospective + persistent lesson file (`~/.claude/lessons/`) |
+| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question post-task retrospective + persistent lesson file (`~/.claude/lessons/`) + skill-effectiveness signal (v2.6.1, Q6 → `SKILL-EFFECTIVENESS.md`) |
 | `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` so other skills adapt verbosity to maturity level (v2.6.0) |
 | `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                        |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.6.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.6.0)
+[![Version](https://img.shields.io/badge/Version-2.6.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.6.1)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.6.0)
+│   ├── plugin.json                 # Plugin metadata (v2.6.1)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -523,4 +523,4 @@ MIT
 
 ---
 
-_Version: 2.6.0 | Last updated: 2026-04-11_
+_Version: 2.6.1 | Last updated: 2026-04-11_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.6.0 | **Date**: 2026-04-11 | **Previous**: 2.5.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.6.1 | **Date**: 2026-04-11 | **Previous**: 2.6.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 

--- a/SKILL-EFFECTIVENESS.md
+++ b/SKILL-EFFECTIVENESS.md
@@ -1,0 +1,86 @@
+# Skill Effectiveness Report
+
+**Status**: Maintainer-curated trend tracker (v2.6.1) | **Updated by**: Plugin maintainer | **Data source**: `~/.claude/lessons/*.md` — `## Skill effectiveness` section | **Related**: [Issue #92](https://github.com/pitimon/8-habit-ai-dev/issues/92), [`skills/reflect/SKILL.md`](skills/reflect/SKILL.md) Q6
+
+## Purpose
+
+Systematic tracking of which 8-habit skills users find **most useful** and which they find **least useful or confusing** over time. This is **H7 (Sharpen the Saw) applied to the plugin itself** — invest in the capability of the skills, not just the output they produce.
+
+Without a signal like this, skills drift: some become verbose padding, some get forgotten, some quietly confuse users who never say so. `/reflect` Q6 is the cheapest possible signal — one skill name per session, or "n/a".
+
+## How the data flows
+
+```
+User runs a task → invokes /reflect → answers Q6 (most useful / least useful)
+  ↓
+/reflect writes ~/.claude/lessons/YYYY-MM-DD-<slug>.md with `## Skill effectiveness` section
+  ↓
+(user-local — lives in user home, not plugin repo, not shared automatically)
+  ↓
+Periodically (monthly / per release), maintainer reads their own lessons
+  (and contributor reports if shared) and updates this file
+  ↓
+Trend analysis informs /skill-improve cycles, skill deprecation, and scope decisions
+```
+
+## What this file is NOT
+
+- ❌ **Not auto-generated** — skills are read-only guidance, not runtime aggregators. Cross-file lesson scanning would need either a runtime component (belongs in `claude-governance` per plugin boundary) or a manual maintainer step. This doc chooses manual.
+- ❌ **Not enforcement** — low scores do not block skill invocation or trigger automated deprecation. Humans read, humans decide.
+- ❌ **Not a ranking** — "least useful in context A" can be "most useful in context B". Trend notes capture nuance the raw count cannot.
+- ❌ **Not a leaderboard** — the goal is improvement signal, not competition between skills.
+
+## Maintainer update protocol
+
+When updating this file:
+
+1. **Read lesson files**: `ls ~/.claude/lessons/*.md` on the maintainer's machine, plus any contributor reports shared via PR or issue.
+2. **Extract Q6 data**: `grep -A 3 '## Skill effectiveness' ~/.claude/lessons/*.md` — harvest "Most useful" and "Least useful / confusing" lines.
+3. **Tally**: increment per-skill counters in the table below. Skip `n/a` entries.
+4. **Update `Last updated`**, `Lessons analyzed`, and any **trend notes** per skill.
+5. **Flag for action**: if a skill accumulates ≥5 "least useful/confusing" signals without offsetting "most useful" signals over a rolling 3-release window, add it to the Action Items section below for `/skill-improve` review or scope reconsideration.
+6. **Commit** the updated report alongside other maintenance in a `chore(skill-eff): update report` commit.
+
+## Current tally
+
+**Last updated**: 2026-04-11 (initial state, ships with v2.6.1)
+**Lessons analyzed**: 0
+**Status**: Awaiting data — no user reflections captured since Q6 was added
+
+| Skill | Most useful | Least useful / confusing | Trend notes |
+|---|---|---|---|
+| `/research` | 0 | 0 | — |
+| `/requirements` | 0 | 0 | — |
+| `/design` | 0 | 0 | — |
+| `/breakdown` | 0 | 0 | — |
+| `/build-brief` | 0 | 0 | — |
+| `/review-ai` | 0 | 0 | — |
+| `/deploy-guide` | 0 | 0 | — |
+| `/monitor-setup` | 0 | 0 | — |
+| `/cross-verify` | 0 | 0 | — |
+| `/whole-person-check` | 0 | 0 | — |
+| `/security-check` | 0 | 0 | — |
+| `/using-8-habits` | 0 | 0 | — |
+| `/eu-ai-act-check` | 0 | 0 | — |
+| `/ai-dev-log` | 0 | 0 | — |
+| `/reflect` | 0 | 0 | — |
+| `/calibrate` | 0 | 0 | — |
+| `/workflow` | 0 | 0 | — |
+
+**Total skills tracked**: 17 (matches v2.6.0+ skill count)
+
+## Action items (from trend analysis)
+
+_None yet — awaiting data accumulation._
+
+Future entries here will look like:
+
+> **[Skill name] trending negative (v2.6.x)**: N reflections flagged this as least useful/confusing without offsetting positive signal. Common confusion: [brief pattern]. Recommended action: `/skill-improve` cycle focusing on [dimension]. Owner: [maintainer].
+
+## References
+
+- **Issue [#92](https://github.com/pitimon/8-habit-ai-dev/issues/92)**: Skill Effectiveness Tracking — H7 applied to the plugin itself
+- **`skills/reflect/SKILL.md` Q6**: the data source (skill effectiveness signal)
+- **`guides/templates/lesson-template.md`**: template that defines the `## Skill effectiveness` section structure
+- **Issue #88**: Persistent Reflection Artifacts — the underlying persistence layer this builds on
+- **Plugin boundary note**: this is a maintainer-curated report, **not** an auto-aggregator. A runtime aggregator that scans `~/.claude/lessons/*.md` across users would belong in [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance), not here — per [CLAUDE.md § Plugin Boundary](CLAUDE.md).

--- a/guides/templates/lesson-template.md
+++ b/guides/templates/lesson-template.md
@@ -35,6 +35,10 @@ habit: "H[N]"
 
 ## Action item
 [Specific action] — **Owner**: [who] — **By**: [date]
+
+## Skill effectiveness
+**Most useful**: [skill name, e.g., `/cross-verify`, or "n/a" if no skills invoked]
+**Least useful / confusing**: [skill name, or "n/a"]
 ```
 
 ## Field Descriptions

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: reflect
 description: >
-  Post-task micro-retrospective — 5 questions, 5 minutes.
-  Use AFTER completing a task or workflow to capture lessons learned.
+  Post-task micro-retrospective — 6 questions, 5 minutes.
+  Use AFTER completing a task or workflow to capture lessons learned,
+  including a skill-effectiveness signal that feeds SKILL-EFFECTIVENESS.md.
   Maps to H7 (Sharpen the Saw — invest in capability, not just output).
 user-invocable: true
 argument-hint: "[task or feature just completed]"
@@ -17,11 +18,11 @@ next-skill: none
 
 ## Why This Exists
 
-DORA research shows per-task micro-retros (3-5 questions, 5 minutes) are more effective than monthly hour-long retrospectives. The key differentiator: teams that assign action items with owners improve; teams that just "discuss" don't.
+DORA research shows per-task micro-retros (3-5 questions, 5 minutes) are more effective than monthly hour-long retrospectives. The key differentiator: teams that assign action items with owners improve; teams that just "discuss" don't. Q6 below extends the DORA pattern with a skill-effectiveness signal specific to this plugin (H7 applied to the plugin itself, per Issue #92).
 
 ## Process
 
-Ask these 5 questions. Keep answers brief — this should take no more than 5 minutes.
+Ask these 6 questions. Keep answers brief — this should take no more than 5 minutes.
 
 ### 1. What went well?
 
@@ -43,6 +44,10 @@ Extract for the team. Is there a script, template, or approach worth sharing?
 
 One specific, assigned action with a deadline. Not "we should improve testing" but "create a test template for API endpoints by Friday."
 
+### 6. Skill effectiveness signal
+
+Which 8-habit skill was **most useful** this session, and which was **least useful or confusing**? Answer "n/a" if no skills were invoked (e.g., quick fix outside the 7-step workflow). This signal feeds `SKILL-EFFECTIVENESS.md` during periodic maintainer review — H7 applied to the plugin itself. Do not overthink it: name up to one skill per side, or "n/a".
+
 ## Output
 
 ```
@@ -57,11 +62,12 @@ One specific, assigned action with a deadline. Not "we should improve testing" b
 | 3 | Do differently | [brief answer] |
 | 4 | Reusable pattern | [brief answer or "none this time"] |
 | 5 | Action item | [specific action] — **Owner**: [who] — **By**: [date] |
+| 6 | Skill effectiveness | Most useful: [skill or "n/a"] · Least/confusing: [skill or "n/a"] |
 ```
 
 ## Step 6: Persist Lesson (automatic)
 
-After the 5 questions are answered, persist the reflection as a lesson file for future sessions. This step should be automatic — do not ask the user additional questions.
+After the 6 questions are answered, persist the reflection as a lesson file for future sessions. This step should be automatic — do not ask the user additional questions.
 
 1. **Create directory** if needed: `~/.claude/lessons/` (skip silently if it already exists)
 2. **Generate filename**: `YYYY-MM-DD-<slug>.md` where `<slug>` is a lowercase, hyphenated summary of the task (max 50 chars, no spaces or special characters)
@@ -71,7 +77,7 @@ After the 5 questions are answered, persist the reflection as a lesson file for 
    - `project`: basename of the current working directory
    - `tags`: 2-5 keywords extracted from the reflection answers (domain, technology, pattern)
    - `habit`: the primary habit that applied during this task (if identifiable)
-   - Body: the 5-question answers from the reflection output
+   - Body: the 6-question answers from the reflection output, including the `## Skill effectiveness` section (Q6) which is parsed during periodic maintainer review for `SKILL-EFFECTIVENESS.md`
 4. **Confirm**: Print a one-line confirmation: `Lesson saved: ~/.claude/lessons/<filename>`
 5. **Graceful failure**: If the write fails (permissions, disk full), warn the user but do NOT block the reflection output. The conversation-level reflection is more valuable than persistence.
 
@@ -83,8 +89,9 @@ After the 5 questions are answered, persist the reflection as a lesson file for 
 
 ## Definition of Done
 
-- [ ] All 5 questions answered (even if briefly)
+- [ ] All 6 questions answered (even if briefly; Q6 can be "n/a")
 - [ ] Action item has an owner and deadline (or explicitly "none needed")
+- [ ] Skill effectiveness signal captured (Q6) — up to one "most useful" and one "least useful/confusing" skill, or "n/a"
 - [ ] Lesson file persisted to `~/.claude/lessons/` (or warning printed if write failed)
 - [ ] Took no more than 5 minutes
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -611,7 +611,14 @@ for skill_dir in skills/*/; do
   skill_ok=1
 
   # Check: frontmatter exists with 3 required fields
-  fm=$(sed -n '/^---$/,/^---$/p' "$skill_file" | head -20)
+  # Use awk (not sed|head) to avoid SIGPIPE under set -o pipefail when
+  # head closes stdout early — same fix pattern as validate-structure.sh:27.
+  # Triggered by skills/ai-dev-log/SKILL.md body `---` horizontal rule at
+  # line 65 which makes `sed -n '/^---$/,/^---$/p'` emit 187 lines (12
+  # frontmatter + 175 body-past-rule), overflowing head -20 and causing
+  # GNU sed exit 4 "couldn't flush stdout: Broken pipe" on Linux CI while
+  # BSD sed on macOS silently ignores SIGPIPE → intermittent CI failure.
+  fm=$(awk '/^---$/{c++; print; if(c==2) exit; next} c==1' "$skill_file")
   for field in "name:" "description:" "user-invocable:"; do
     echo "$fm" | grep -q "$field" || skill_ok=0
   done


### PR DESCRIPTION
## Summary

Closes milestone v2.6.0 by shipping the final **P3** issue from the Hermes-Inspired research brief. Ships as a **minor patch release batched with the feature** (per lesson from #88 — avoid separate feature + version-bump PR cycles).

## What's new

### `/reflect` Q6 — Skill effectiveness signal (feature)

After the 5 standard DORA-inspired retro questions, `/reflect` now asks:

> **Which 8-habit skill was most useful this session, and which was least useful or confusing?** Answer "n/a" if no skills were invoked.

One line, ~30 seconds. Fits inside the existing 5-minute `/reflect` budget. The answer is persisted in `~/.claude/lessons/YYYY-MM-DD-<slug>.md` under a new `## Skill effectiveness` section.

### `SKILL-EFFECTIVENESS.md` (new, repo root)

Maintainer-curated trend tracker aggregating Q6 signals over time. Ships **empty** with an explicit update protocol + "what this is NOT" boundaries. Per-skill tally table for all 17 skills.

**Update flow** (manual, maintainer-curated):
1. User runs `/reflect` → writes Q6 signal to `~/.claude/lessons/*.md`
2. Maintainer periodically reads lessons, tallies Q6 data, updates `SKILL-EFFECTIVENESS.md`
3. Skills trending negative → flagged for `/skill-improve` cycle

### Architectural constraint honored

`SKILL-EFFECTIVENESS.md` is **maintainer-curated, not auto-generated**. A runtime aggregator that scans `~/.claude/lessons/*.md` across users would need to be a hook (belongs in [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) per plugin boundary) OR would violate the "skills are read-only guidance" principle. The chosen design respects both constraints and matches ADR-008's schema-as-contract pattern.

## Version bump (v2.6.0 → v2.6.1)

Batched in this PR to avoid a separate release PR cycle per [#88 lesson on plugin cache lag](https://github.com/pitimon/8-habit-ai-dev/issues/88).

| File | Before | After |
|---|---|---|
| `.claude-plugin/plugin.json` | 2.6.0 | **2.6.1** |
| `.claude-plugin/marketplace.json` | 2.6.0 | **2.6.1** |
| `README.md` badge + footer + ASCII tree | 2.6.0 | **2.6.1** |
| `SELF-CHECK.md` header (Previous: 2.6.0) | 2.6.0 | **2.6.1** |

`CHANGELOG.md` gets a new `## v2.6.1 — Skill Effectiveness Tracking` section at the top with full release notes.

## Files changed (9)

**Feature (4 files)**:
- `skills/reflect/SKILL.md` — Q6 added, word count 561 → 711 (safe under 2000 F3 budget)
- `guides/templates/lesson-template.md` — `## Skill effectiveness` section in lesson template body
- `SKILL-EFFECTIVENESS.md` — NEW, repo root, maintainer-curated report
- `CLAUDE.md` — `/reflect` row in Skills → Habits table updated

**Release (5 files)**:
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `README.md` (3 places: badge, ASCII tree comment, footer)
- `SELF-CHECK.md`
- `CHANGELOG.md`

## Milestone v2.6.0 — CLOSED (5/5)

| # | Title | Priority | Shipped in |
|---|---|---|---|
| #88 | Persistent Reflection Artifacts | P1 | v2.6.0 |
| #89 | Habit Nudge Guidance Document | P1 | v2.6.0 |
| #91 | agentskills.io Compatibility Evaluation (NO-GO) | P2 | v2.6.0 |
| #90 | User Maturity Calibration (`/calibrate`) | P2 | v2.6.0 |
| **#92** | **Skill Effectiveness Tracking** | **P3** | **v2.6.1 (this PR)** |

Follow-up [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) (16-skill reader adoption for `habit-profile.md`) remains open, targeted at v2.7.0.

## Verification

### Validators (470/470 PASS)

- **`test-skill-graph.sh`**: 57 PASS
- **`validate-structure.sh`**: 238 PASS — version consistency verified across all 4 files at 2.6.1
- **`validate-content.sh`**: 175 PASS + F3 convention-consistency 17/17 HEALTHY

### Scope discipline

Per the approved plan (Interdependence-level concise workflow):
- ⏭ Skipped `/research` — already done at milestone level
- ⏭ Skipped `/requirements` — scope locked by issue body
- ⏭ Skipped `/design` — no architecture decisions, pattern follows `/reflect` + ADR-008 schema-contract
- ⏭ Skipped `/breakdown` — 3-task linear
- ⏭ Skipped `/build-brief` — full context from this session
- ⏭ Skipped Deep Review Mode — small patch, pattern-match to existing code, verified by validators + self-review

## No breaking changes

Users upgrading from v2.6.0:
- Next `/reflect` invocation includes Q6. Answer `n/a` if no skills apply.
- Existing `~/.claude/lessons/*.md` files are unchanged. New lessons include the `## Skill effectiveness` section.
- `SKILL-EFFECTIVENESS.md` ships empty — data accumulates as you reflect.

## Test plan

- [x] Q6 added after Q5 in `/reflect` Process section
- [x] Output table includes row 6
- [x] Persist step references new field
- [x] Definition of Done updated for 6 questions + Q6 "n/a" explicit
- [x] `lesson-template.md` has `## Skill effectiveness` body section
- [x] `SKILL-EFFECTIVENESS.md` ships with 17-skill tally table and update protocol
- [x] `/reflect` word count: 711/2000 (safe)
- [x] Version consistency across 4 files at 2.6.1
- [x] `test-skill-graph.sh` — 57 PASS
- [x] `validate-structure.sh` — 238 PASS
- [x] `validate-content.sh` — 175 PASS + F3 HEALTHY
- [ ] CI validate passes on push
- [ ] Maintainer review
- [ ] Post-merge: `gh release create v2.6.1` with CHANGELOG excerpt
- [ ] Post-merge: write lesson file for this session

Closes #92.