### PR TITLE
feat(release): hook-based verbosity adaptation + v2.7.0 (#96)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,3 +17,5 @@ jobs:
         run: bash tests/test-skill-graph.sh
       - name: Validate content quality and fitness functions
         run: bash tests/validate-content.sh
+      - name: Verbosity hook regression test (8 branches + override + budget)
+        run: bash tests/test-verbosity-hook.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.7.0 — Reader Adoption (2026-04-11)
+
+Closes the reader-adoption half of the `/calibrate` feature loop. v2.6.0 shipped `/calibrate` which **writes** `~/.claude/habit-profile.md`; until this release, the 17 skills did not **read** the profile, so the feature delivered discovery but not adaptation. v2.7.0 closes that gap via a hook-based adaptation directive — zero changes to individual skill files.
+
+### Added
+
+- **Hook-based verbosity adaptation** ([#96](https://github.com/pitimon/8-habit-ai-dev/issues/96)) — `hooks/session-start.sh` now reads `~/.claude/habit-profile.md` at session start and emits a level-specific one-sentence directive into session context. Claude honors the directive when invoking any skill in the session, adapting verbosity automatically from Dependence (full guidance) through Independence, Interdependence, and Significance (minimal prompts).
+- **`guides/verbosity-adaptation.md`** (new) — canonical per-level adaptation rules + worked examples across 5 skill archetypes (workflow planning, review/gate, research, implementation, retrospective). Reference material for maintainers and future skill authors. Not auto-loaded at runtime — the hook hardcodes its one-sentence directive per level from these rules.
+- **`tests/test-verbosity-hook.sh`** (new) — 11-check regression coverage for all 8 hook branches: missing profile, 4 levels (Dependence/Independence/Interdependence/Significance), 2 overrides (verbose/concise), unknown level with Dependence fallback, plus HABIT_QUIET silence check and ≤300-token budget assertion. Wired into `.github/workflows/validate.yml` alongside the 3 existing validators.
+- **`preferences.verbosity-override` precedence in the hook** — `verbose` promotes any level to Dependence; `concise` demotes any level to Significance; `none` or unset uses the profile `level` as-is. Matches the schema v1 contract documented in `guides/habit-profile-schema.md`.
+
+### Architectural constraint honored (why hook-based, not per-skill)
+
+A pre-implementation F3 word-budget audit surfaced two skills with dangerously thin headroom: `/using-8-habits` (1990/2000 words, 10 headroom) and `/eu-ai-act-check` (1989/2000 words, 11 headroom). Any per-skill text addition would have broken F3 fitness on the next edit — even a 15-word preamble like `Load guides/verbosity-adaptation.md` would overflow.
+
+The only viable runtime injection point in a pure-markdown plugin is `hooks/session-start.sh`, which outputs into session context once per session and applies globally to all subsequent skill invocations. The hook approach ships with **zero changes to individual skill files** — F3 preserved, validators untouched, existing skill bodies unchanged. Future skill authors don't need to add level-handling boilerplate; the directive is already in session context when they're invoked.
+
+### Changed
+
+- `hooks/session-start.sh` — expanded from the v2.6.0 static `/calibrate` nudge to a full 8-branch profile reader. Existing behavior preserved: when no profile exists, the v2.6.0 nudge still fires unchanged. Uses the pipe-safe `awk` pattern from v2.6.1's SIGPIPE fix to parse YAML frontmatter.
+- `.github/workflows/validate.yml` — now runs 4 validators instead of 3 (added `tests/test-verbosity-hook.sh`).
+- `CLAUDE.md` — added a Key Conventions bullet documenting the hook-based verbosity adaptation mechanism.
+
+### Milestone v2.7.0 — CLOSED (1/1)
+
+With this release, [milestone v2.7.0 — Reader Adoption](https://github.com/pitimon/8-habit-ai-dev/milestone/12) is closed. Issue #96 was the sole scope. The #90 user-calibration feature loop is now complete: write (v2.6.0) → read (v2.7.0).
+
+### Migration notes
+
+No breaking changes. Users upgrading from v2.6.1:
+- If you have a profile at `~/.claude/habit-profile.md`, the session-start hook will emit your level-specific directive on the next session start. No action needed.
+- If you don't yet have a profile, the existing v2.6.0 nudge still fires suggesting `/calibrate`. Behavior unchanged from v2.6.1.
+- `HABIT_QUIET=1` continues to silence everything (ADR-006 contract preserved).
+- If you want to override your level-default behavior, edit `~/.claude/habit-profile.md` and set `preferences.verbosity-override` to `verbose` (max guidance) or `concise` (minimum). `none` or unset uses the level as-is.
+
+### What's next (beyond v2.7.0)
+
+The Hermes-inspired feature loop (milestones v2.6.0 + v2.7.0) is complete. Further enhancements are either out-of-scope (runtime-dependent features like Honcho passive inference — would violate the pure-markdown constraint) or delegated to companion plugins (`claude-mem`, `pitimon/claude-governance`, `devsecops-ai-team`). The plugin is at a local maximum given its constraints.
+
+Potential v2.8.0+ targets, if user demand emerges:
+- Dual-artifact strategy for agentskills.io (publish individual standalone skills to the open registry while keeping the chain-enforcing SKILL.md here) — per ADR-007 §Future Triggers
+- Progressive disclosure for skill bodies (split `SKILL.md` into summary + `references/*.md` deep-dives) if token budgets get tight
+
+---
+
 ## v2.6.1 — Skill Effectiveness Tracking (2026-04-11)
 
 Closes milestone v2.6.0 by shipping the final P3 issue from the Hermes-Inspired research brief. This is a minor patch release — one question added to `/reflect` plus a new maintainer-curated report file. No breaking changes, no migrations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 - **Agent (`agents/8-habit-reviewer.md`)** uses model `sonnet` with read-only tools (`Read`, `Glob`, `Grep`) — it analyzes and reports, never edits
 - **Plugin metadata** lives in `.claude-plugin/plugin.json` (plugin config) and `.claude-plugin/marketplace.json` (marketplace listing)
 - **Lesson persistence** (v2.6.0): `/reflect` saves lesson files to `~/.claude/lessons/YYYY-MM-DD-<slug>.md`. `/research` and `/build-brief` search these before starting work. This closes the learning loop: reflect → persist → retrieve → apply
+- **Verbosity adaptation** (v2.7.0): `hooks/session-start.sh` reads `~/.claude/habit-profile.md` and emits a level-specific adaptation directive into session context. Zero per-skill changes — the directive shapes Claude's behavior at runtime for all subsequent skill invocations. Canonical rules in `guides/verbosity-adaptation.md`. 8-branch regression coverage in `tests/test-verbosity-hook.sh`. Respects existing `HABIT_QUIET=1` opt-out from ADR-006. Closes #96 (the reader half of the #90 calibrate loop)
 - **Session hook budget**: `hooks/session-start.sh` output must stay ≤300 tokens
 - **Version lives in 4 files** — must bump together: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` (badge + footer), and `SELF-CHECK.md` header. `tests/validate-structure.sh` enforces consistency across all four — CI will fail if any drifts.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.6.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.6.1)
+[![Version](https://img.shields.io/badge/Version-2.7.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.7.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.6.1)
+│   ├── plugin.json                 # Plugin metadata (v2.7.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -523,4 +523,4 @@ MIT
 
 ---
 
-_Version: 2.6.1 | Last updated: 2026-04-11_
+_Version: 2.7.0 | Last updated: 2026-04-11_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.6.1 | **Date**: 2026-04-11 | **Previous**: 2.6.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.7.0 | **Date**: 2026-04-11 | **Previous**: 2.6.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 

--- a/guides/verbosity-adaptation.md
+++ b/guides/verbosity-adaptation.md
@@ -1,0 +1,186 @@
+# Verbosity Adaptation Rules (v2.7.0)
+
+**Status**: Canonical reference (v2.7.0) | **Consumers**: `hooks/session-start.sh` (runtime); plugin maintainers (documentation) | **Related**: [Issue #96](https://github.com/pitimon/8-habit-ai-dev/issues/96), [ADR-008](../docs/adr/ADR-008-user-maturity-calibration-design.md), [`guides/habit-profile-schema.md`](habit-profile-schema.md)
+
+## Purpose
+
+Closes the reader-adoption half of the `/calibrate` feature loop (Issue #90 shipped the writer in v2.6.0; this doc is the reference material for the reader, shipped in v2.7.0).
+
+When `~/.claude/habit-profile.md` exists and contains a valid `level` field, `hooks/session-start.sh` emits a level-specific adaptation directive into session context. Claude sees the directive at session start and applies it to every subsequent skill invocation. This document is the canonical reference the hook pulls its level-specific rules from, and the reference future skill maintainers should consult when they want to know how a given skill should feel at each level.
+
+## Architectural constraint (why this file exists at all)
+
+The naive approach — add "if level is X, do Y" text to each of the 17 skills — breaks F3 fitness on `/using-8-habits` (1990/2000 words, 10 headroom) and `/eu-ai-act-check` (1989/2000 words, 11 headroom). Per-skill additions were ruled out by the v2.7.0 plan. The only viable runtime injection point is `hooks/session-start.sh`, which runs once per session and outputs into shared context. This file is the rule book the hook reads from; the hook is the mechanism that enforces the rules at runtime.
+
+**Zero changes to individual skill files** — F3 preserved, validators unaffected.
+
+## The four levels (recap from `rules/effective-development.md`)
+
+| Level | Maturity stage | One-line heuristic |
+|---|---|---|
+| **Dependence** | Getting oriented | Needs scaffolding — show everything |
+| **Independence** | Self-directed | Has foundations — skip beginner stuff |
+| **Interdependence** | Team-embedded | Leads/mentors — focus on synergy |
+| **Significance** | Sets standards | Trust judgment — minimal prompts |
+
+## Verbosity override precedence
+
+The hook respects `preferences.verbosity-override` in the profile file:
+
+| Override value | Effective behavior |
+|---|---|
+| `verbose` | Full Dependence mode regardless of `level` — user explicitly wants maximum guidance |
+| `concise` | Full Significance mode regardless of `level` — user explicitly wants minimum ceremony |
+| `none` (or unset) | Use `level` field as-is — normal behavior |
+
+**Unknown override values** (anything other than `verbose` / `concise` / `none`) are ignored — hook uses `level` as if no override were set. This is forward-compatible for future override enums.
+
+**Missing profile file** → Dependence fallback (safest for unknown users).
+**Profile exists but `level` is missing or unknown** → Dependence fallback + visible note suggesting `/calibrate` refresh.
+
+## Canonical adaptation rules per level
+
+These are the rules the `hooks/session-start.sh` directive condenses into one sentence per level. The full rules here exist as reference material — maintainer-facing, not runtime-loaded.
+
+### Dependence — "You're getting oriented"
+
+Skills should:
+
+- Show **full guidance** — every checkpoint, every section of the template
+- Include **beginner examples inline** — don't assume the user has seen EARS notation, whole-person rubrics, or the 8-habit vocabulary before
+- Explicitly state the "why" behind each step (not just "run `/cross-verify`" but "run `/cross-verify` because it catches gaps that silent confidence would miss")
+- Link to full reference material (wiki pages, ADRs) for deeper context
+- Use the word "checkpoint" liberally — the user is calibrating what "done" means
+- Offer opt-outs only when the user is clearly skipping appropriately (e.g., "you can skip `/research` for small bug fixes with obvious root causes")
+
+### Independence — "You run the workflow solo"
+
+Skills should:
+
+- Show **key checkpoints only** — skip the "why each step matters" preamble
+- Assume **fluency with plugin vocabulary** — H1-H8, EARS, Whole Person, Three Loops, dimension scores, etc.
+- Skip beginner examples — the user has seen them
+- Keep the output **concise** — 2-3 paragraphs where Dependence would use 5-6
+- Omit the "definitionally never skip" warnings (user already knows `/review-ai` is mandatory)
+- Offer the full detail as an optional expansion ("want the full 17-question walkthrough?") rather than showing it by default
+
+### Interdependence — "You lead or mentor others"
+
+Skills should:
+
+- Focus on **delegation, review, and synergy patterns** over individual-contributor ceremony
+- Emphasize **handoff clarity** — "who else needs to see this PRD?" "which of your team's conventions should this ADR cite?"
+- Prefer **team-oriented language** ("the team", "reviewers", "next maintainer") over individual framing ("you", "your next session")
+- Minimize checkpoint ceremony that the user would impose on themselves — they already do
+- Surface **cross-cutting concerns** that affect whole systems (plugin boundaries, ADR references, architectural fitness functions) more prominently than individual-task concerns
+- Assume the user will **extract patterns for team reuse** — point out when something is worth adding to a team playbook or style guide
+
+### Significance — "You set the standard"
+
+Skills should:
+
+- Show **minimal prompts** — trust user judgment
+- Surface **only non-obvious or high-consequence checkpoints** — skip the routine ones
+- Offer **optional depth** ("want the full walkthrough?") rather than showing it by default
+- Respect the user's **time budget** — if a task is obviously 5 minutes, don't impose 30 minutes of ceremony
+- Use **terse technical language** — no hand-holding, no ceremony theater
+- Surface **systemic / second-order concerns** — the user is thinking about what the plugin itself does to the ecosystem, not just what the current task does
+
+## Worked examples — representative patterns across 5 skill archetypes
+
+Full 17 × 4 = 68-cell matrix is not shipped (per OQ3 approval — representative is enough). These 5 archetypes × 4 levels = 20 examples establish the pattern.
+
+### Archetype 1: Workflow planning skill (`/requirements` representative)
+
+| Level | How `/requirements` should behave |
+|---|---|
+| **Dependence** | Walk the user through every EARS shape (Ubiquitous / Event-driven / State-driven / Unwanted / Optional) with examples. Show all 6 PRD template sections. Explicitly state that acceptance criteria are testable. Link to `guides/ears-notation.md` for full reference. |
+| **Independence** | Assume EARS familiarity. Skip the shape tutorial. Show PRD template sections but elide beginner examples. Offer the EARS reference as an optional expansion. |
+| **Interdependence** | Focus on "who else will read this PRD?" Emphasize handoff clarity between the user and their team. Skip the EARS tutorial entirely. Show a minimal PRD scaffold and ask which team conventions should shape it. |
+| **Significance** | Trust the user's PRD instinct. Surface only non-obvious constraints (compliance, plugin boundary, schema contracts). Offer: "want me to check against the 17-point cross-verify checklist?" as optional, not default. |
+
+### Archetype 2: Review/gate skill (`/cross-verify` representative)
+
+| Level | How `/cross-verify` should behave |
+|---|---|
+| **Dependence** | Walk through all 17 questions one by one. Explain each habit the question maps to. Show scoring band interpretation. Include common failure patterns. |
+| **Independence** | Present all 17 questions as a block. Assume habit names are self-explanatory. Show scoring + band without explanation. Keep the report concise. |
+| **Interdependence** | Emphasize the Whole Person dimension breakdown (Body/Mind/Heart/Spirit). Ask "what would your team's reviewer flag here?" Focus on the 5 questions most likely to catch team-facing gaps (Q1 impact scan, Q11 read-first, Q13 parallel, Q14 third alternative, Q17 empower next person). |
+| **Significance** | Offer the 17-Q pass as "want the full walkthrough?" Default to: "name the 1-2 questions you're least confident about and I'll focus there." Trust the user's self-diagnosis. |
+
+### Archetype 3: Research/discovery skill (`/research` representative)
+
+| Level | How `/research` should behave |
+|---|---|
+| **Dependence** | Explain the Quick / Standard / Deep depth levels in detail. Walk through the Compare / Audit / General mode distinction. Show source verification rigor with examples. |
+| **Independence** | Show depth + mode as a single-line choice. Skip examples. Assume the user picks the right combination for the scope. |
+| **Interdependence** | Ask "who else on the team is affected by what you find?" Prefer sources the team already trusts (ADRs, previous research briefs). Suggest cross-referencing past lessons in `~/.claude/lessons/*.md`. |
+| **Significance** | Assume Deep + Compare if the scope is non-trivial, Quick otherwise. Trust the user to pick sources. Surface only verification gaps (unverified assumptions) rather than all findings. |
+
+### Archetype 4: Implementation skill (`/build-brief` representative)
+
+| Level | How `/build-brief` should behave |
+|---|---|
+| **Dependence** | Walk through the problem-statement gate, existing-code read, pattern identification, constraint listing, and test approach. Show examples of each. Include context-boundary definitions for parallel work. |
+| **Independence** | Present the brief template as a single scaffold to fill. Skip the "problem-statement gate" explanation (assumed). Skip context boundaries unless the task is parallel. |
+| **Interdependence** | Emphasize "what does your team need to know about this change?" Focus on cross-cutting concerns: plugin boundaries, convention preservation, team-facing constants. Ask if the change should be documented in a shared playbook. |
+| **Significance** | Assume the user knows what context is needed. Ask only: "what's the ONE thing you want me to verify before coding?" Trust the rest. |
+
+### Archetype 5: Retrospective skill (`/reflect` representative)
+
+| Level | How `/reflect` should behave |
+|---|---|
+| **Dependence** | Walk through all 6 questions (5 DORA + Q6 skill effectiveness) with examples of good answers. Show the lesson-template structure. Explain the persist step. |
+| **Independence** | Present the 6 questions as a block. Show the lesson-template structure tersely. Skip persist-step explanation (assumed). |
+| **Interdependence** | Focus on "what should your team learn from this?" Emphasize Q3 (do differently) and Q4 (reusable pattern) over self-improvement Qs. Suggest sharing lessons via team playbook. |
+| **Significance** | Offer the 6-Q walkthrough as optional. Default to: "one thing to keep, one thing to change, one action item — 2 minutes." Trust the user to capture what matters. |
+
+## How `hooks/session-start.sh` uses this file
+
+The hook does **not** load this file at runtime. Instead, it hardcodes a single-sentence directive per level, distilled from the rules above:
+
+```bash
+case "$EFFECTIVE_LEVEL" in
+  Dependence)
+    ADAPT="📖 **Profile active: Dependence** — skills should show full guidance, all checkpoints, and beginner examples inline."
+    ;;
+  Independence)
+    ADAPT="📖 **Profile active: Independence** — skills should show key checkpoints only and skip beginner examples."
+    ;;
+  Interdependence)
+    ADAPT="📖 **Profile active: Interdependence** — skills should focus on delegation, review, and synergy patterns over individual ceremony."
+    ;;
+  Significance)
+    ADAPT="📖 **Profile active: Significance** — skills should show minimal prompts, trust user judgment, and surface only non-obvious checkpoints."
+    ;;
+esac
+```
+
+The one-sentence directive is strong enough because Claude treats session-start content as high-salience system context. Maintainers who want more detail (or who are adding new skills) can read this file.
+
+## For new skill authors
+
+When adding a new skill to the plugin, the skill body **does not** need explicit level-handling code. The session-start hook directive applies globally to all skill invocations.
+
+What you **should** do:
+
+1. **Classify your skill into an archetype** — workflow planning, review/gate, research/discovery, implementation, retrospective, or a new archetype (add it to this file if so)
+2. **Write the skill body in the Independence style by default** — it's the 80/20 of users who will read it
+3. **Offer optional expansions** (`want the full walkthrough?`) rather than hand-holding by default
+4. **Leave a note in your skill body** if level-specific behavior needs custom handling beyond what the hook directive provides (rare — most skills fit the archetypes cleanly)
+
+## For users
+
+- Run `/calibrate` if you haven't yet (creates the profile)
+- If you want different behavior than your level suggests, set `preferences.verbosity-override` to `verbose` or `concise` in `~/.claude/habit-profile.md` — no re-calibration needed
+- Re-calibrate every ~90 days or after a major workflow change (your level is not static)
+- If a skill feels mismatched to your level, note it in `/reflect` Q6 "Least useful / confusing" — the maintainer reads those and adjusts the rules here
+
+## References
+
+- [Issue #96](https://github.com/pitimon/8-habit-ai-dev/issues/96) — Reader adoption (this feature)
+- [Issue #90](https://github.com/pitimon/8-habit-ai-dev/issues/90) / [ADR-008](../docs/adr/ADR-008-user-maturity-calibration-design.md) — User maturity calibration (writer side, v2.6.0)
+- [`guides/habit-profile-schema.md`](habit-profile-schema.md) — v1 schema contract for `~/.claude/habit-profile.md`
+- [`rules/effective-development.md`](../rules/effective-development.md) — the maturity model source (Dependence → Significance)
+- [`hooks/session-start.sh`](../hooks/session-start.sh) — the runtime enforcement mechanism
+- [`tests/test-verbosity-hook.sh`](../tests/test-verbosity-hook.sh) — 8-branch regression coverage

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -23,11 +23,61 @@ else
   PROGRESS=""
 fi
 
-# Calibration nudge — appended only when no habit profile exists (v2.6.0)
-CALIBRATE_NUDGE=""
-if [ ! -f "${HOME}/.claude/habit-profile.md" ]; then
-  CALIBRATE_NUDGE='
-💡 **No habit profile detected** — run `/calibrate` to personalize guidance to your maturity level (H8).'
+# Habit profile state — emits level-specific adaptation directive (v2.7.0, Issue #96).
+# When ~/.claude/habit-profile.md exists with a valid level, outputs a one-sentence
+# directive that shapes how skills should adapt their verbosity in the session.
+# When the profile is missing, falls back to the v2.6.0 /calibrate nudge.
+#
+# Override precedence: preferences.verbosity-override (verbose|concise) > level field.
+# Unknown/missing level → Dependence fallback (safest for uncalibrated users).
+#
+# awk patterns use the pipe-safe "read until exit" technique from
+# tests/validate-structure.sh:27 and validate-content.sh:614 to avoid the
+# sed|head SIGPIPE flake fixed in v2.6.1.
+PROFILE_MSG=""
+PROFILE_FILE="${HOME}/.claude/habit-profile.md"
+if [ -f "$PROFILE_FILE" ] && [ -r "$PROFILE_FILE" ]; then
+  # Extract level from frontmatter (between --- markers)
+  LEVEL=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && /^level:/{sub(/^level:[[:space:]]*/, ""); print; exit}' "$PROFILE_FILE" 2>/dev/null)
+  # Extract verbosity-override (nested under preferences:)
+  OVERRIDE=$(awk '/^preferences:/{f=1; next} /^[^[:space:]]/{if(f) exit; next} f && /verbosity-override:/{sub(/^[[:space:]]*verbosity-override:[[:space:]]*/, ""); print; exit}' "$PROFILE_FILE" 2>/dev/null)
+
+  # Apply override precedence: explicit verbose/concise wins over level
+  case "$OVERRIDE" in
+    verbose)   EFFECTIVE_LEVEL="Dependence (verbose override)"; DIRECTIVE_LEVEL="Dependence" ;;
+    concise)   EFFECTIVE_LEVEL="Significance (concise override)"; DIRECTIVE_LEVEL="Significance" ;;
+    ""|none)   EFFECTIVE_LEVEL="$LEVEL"; DIRECTIVE_LEVEL="$LEVEL" ;;
+    *)         EFFECTIVE_LEVEL="$LEVEL"; DIRECTIVE_LEVEL="$LEVEL" ;;
+  esac
+
+  # Emit level-specific one-sentence directive
+  case "$DIRECTIVE_LEVEL" in
+    Dependence)
+      PROFILE_MSG="
+📖 **Profile active: ${EFFECTIVE_LEVEL}** — skills should show full guidance, all checkpoints, and beginner examples inline."
+      ;;
+    Independence)
+      PROFILE_MSG="
+📖 **Profile active: ${EFFECTIVE_LEVEL}** — skills should show key checkpoints only and skip beginner examples."
+      ;;
+    Interdependence)
+      PROFILE_MSG="
+📖 **Profile active: ${EFFECTIVE_LEVEL}** — skills should focus on delegation, review, and synergy patterns over individual ceremony."
+      ;;
+    Significance)
+      PROFILE_MSG="
+📖 **Profile active: ${EFFECTIVE_LEVEL}** — skills should show minimal prompts, trust user judgment, and surface only non-obvious checkpoints."
+      ;;
+    *)
+      # Unknown or missing level → Dependence fallback with visible note
+      PROFILE_MSG="
+⚠️ **Profile exists but level is unknown** (got: \"${LEVEL:-<missing>}\") — using Dependence (full guidance) as fallback. Run \`/calibrate\` to refresh."
+      ;;
+  esac
+else
+  # No profile file → v2.6.0 nudge (backwards compatible)
+  PROFILE_MSG="
+💡 **No habit profile detected** — run \`/calibrate\` to personalize guidance to your maturity level (H8)."
 fi
 
 cat <<EOF
@@ -46,7 +96,7 @@ cat <<EOF
 **Core 5** (80% of daily work): \`/requirements\` · \`/review-ai\` · \`/cross-verify\` · \`/research\` · \`/reflect\`
 **Assessment**: \`/workflow\` · \`/whole-person-check\` · \`/security-check\` · \`/ai-dev-log\`
 **Onboarding**: \`/using-8-habits\` (decision tree) · \`/calibrate\` (maturity profile)
-**Compliance**: \`/eu-ai-act-check\` (EU AI Act, migration to claude-governance planned)${CALIBRATE_NUDGE}
+**Compliance**: \`/eu-ai-act-check\` (EU AI Act, migration to claude-governance planned)${PROFILE_MSG}
 
 _Silence this reminder: \`export HABIT_QUIET=1\`_
 EOF

--- a/tests/test-verbosity-hook.sh
+++ b/tests/test-verbosity-hook.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# 8-Habit AI Dev — Verbosity Hook Regression Test (v2.7.0, Issue #96)
+#
+# Covers the 8 hook branches in hooks/session-start.sh:
+#   1. No profile file            → /calibrate nudge
+#   2. level: Dependence          → Dependence directive
+#   3. level: Independence        → Independence directive
+#   4. level: Interdependence     → Interdependence directive
+#   5. level: Significance        → Significance directive
+#   6. verbosity-override=verbose → Dependence (override)
+#   7. verbosity-override=concise → Significance (override)
+#   8. level: <unknown/missing>   → Dependence fallback with warning
+#
+# Plus a HABIT_QUIET=1 silence check that applies across all 8 branches.
+#
+# Usage: bash tests/test-verbosity-hook.sh
+# Called from .github/workflows/validate.yml alongside the other 3 validators.
+#
+# The test writes throwaway profile files to a temp HOME to avoid clobbering
+# the real ~/.claude/habit-profile.md. Each assertion checks the hook output
+# contains the expected substring for its branch.
+
+set -euo pipefail
+
+ERRORS=0
+PASS=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { ERRORS=$((ERRORS + 1)); echo "  FAIL: $1"; }
+
+echo "=== Verbosity Hook Regression Test (Issue #96) ==="
+echo ""
+
+# Temp sandbox — avoids touching the real ~/.claude/habit-profile.md
+TMPHOME=$(mktemp -d)
+trap 'rm -rf "$TMPHOME"' EXIT
+mkdir -p "$TMPHOME/.claude"
+HOOK="hooks/session-start.sh"
+
+if [ ! -f "$HOOK" ]; then
+  fail "$HOOK not found — must be run from repo root"
+  exit 1
+fi
+
+# Helper: run the hook against a given profile content (or nothing if "" passed)
+# and assert the output contains $expected_substring.
+run_case() {
+  local case_name="$1"
+  local profile_content="$2"  # empty string = no profile file
+  local expected_substring="$3"
+
+  if [ -n "$profile_content" ]; then
+    printf '%s' "$profile_content" > "$TMPHOME/.claude/habit-profile.md"
+  else
+    rm -f "$TMPHOME/.claude/habit-profile.md"
+  fi
+
+  local output
+  output=$(HOME="$TMPHOME" bash "$HOOK" 2>&1) || {
+    fail "$case_name — hook exited non-zero"
+    return
+  }
+
+  if echo "$output" | grep -qF "$expected_substring"; then
+    pass "$case_name"
+  else
+    fail "$case_name — expected substring not found: \"$expected_substring\""
+    echo "    got (last line): $(echo "$output" | tail -1)"
+  fi
+}
+
+# --- Branch 1: No profile file → /calibrate nudge ---
+echo "--- Branch 1: No profile → nudge ---"
+run_case "no profile emits /calibrate nudge" "" "No habit profile detected"
+echo ""
+
+# --- Branches 2-5: Each level emits its directive ---
+echo "--- Branches 2-5: Per-level directives ---"
+
+DEPENDENCE_PROFILE='---
+level: Dependence
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "first session"
+  ci-experience: "still learning"
+  team-context: "solo"
+  vocabulary-comfort: "brand new terms"
+  orientation: "mostly fixing"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile — Dependence
+'
+
+INDEPENDENCE_PROFILE='---
+level: Independence
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "a few months"
+  ci-experience: "comfortable solo"
+  team-context: "solo"
+  vocabulary-comfort: "roughly familiar"
+  orientation: "mix"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile — Independence
+'
+
+INTERDEPENDENCE_PROFILE='---
+level: Interdependence
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "several months"
+  ci-experience: "mentor peers"
+  team-context: "lead a team"
+  vocabulary-comfort: "mostly clear"
+  orientation: "mostly preventing"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile — Interdependence
+'
+
+SIGNIFICANCE_PROFILE='---
+level: Significance
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "over a year"
+  ci-experience: "set org standards"
+  team-context: "org-wide"
+  vocabulary-comfort: "teach externally"
+  orientation: "preventing for community"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile — Significance
+'
+
+run_case "Dependence level directive"    "$DEPENDENCE_PROFILE"    "Profile active: Dependence"
+run_case "Independence level directive"  "$INDEPENDENCE_PROFILE"  "Profile active: Independence"
+run_case "Interdependence level directive" "$INTERDEPENDENCE_PROFILE" "Profile active: Interdependence"
+run_case "Significance level directive"  "$SIGNIFICANCE_PROFILE"  "Profile active: Significance"
+echo ""
+
+# --- Branches 6-7: verbosity-override precedence ---
+echo "--- Branches 6-7: verbosity-override precedence ---"
+
+VERBOSE_OVERRIDE_PROFILE='---
+level: Significance
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "over a year"
+  ci-experience: "set org standards"
+  team-context: "org-wide"
+  vocabulary-comfort: "teach externally"
+  orientation: "preventing for community"
+preferences:
+  verbosity-override: verbose
+---
+
+# Habit Profile — Significance (verbose override)
+'
+
+CONCISE_OVERRIDE_PROFILE='---
+level: Dependence
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "first session"
+  ci-experience: "still learning"
+  team-context: "solo"
+  vocabulary-comfort: "brand new terms"
+  orientation: "mostly fixing"
+preferences:
+  verbosity-override: concise
+---
+
+# Habit Profile — Dependence (concise override)
+'
+
+run_case "verbose override promotes Significance → Dependence" "$VERBOSE_OVERRIDE_PROFILE" "verbose override"
+run_case "concise override demotes Dependence → Significance"  "$CONCISE_OVERRIDE_PROFILE" "concise override"
+echo ""
+
+# --- Branch 8: Unknown/missing level → Dependence fallback ---
+echo "--- Branch 8: Unknown/missing level → Dependence fallback ---"
+
+UNKNOWN_LEVEL_PROFILE='---
+level: Mastery
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "several months"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile — Mastery (not a valid level)
+'
+
+MISSING_LEVEL_PROFILE='---
+calibrated: 2026-04-11T15:00:00+07:00
+schema-version: 1
+responses:
+  plugin-experience: "several months"
+preferences:
+  verbosity-override: none
+---
+
+# Habit Profile (missing level field)
+'
+
+run_case "unknown level string → fallback warning" "$UNKNOWN_LEVEL_PROFILE" "Profile exists but level is unknown"
+run_case "missing level field → fallback warning"  "$MISSING_LEVEL_PROFILE" "Profile exists but level is unknown"
+echo ""
+
+# --- HABIT_QUIET silence check — applies to all branches ---
+echo "--- HABIT_QUIET=1 silence (ADR-006 contract preserved) ---"
+printf '%s' "$INTERDEPENDENCE_PROFILE" > "$TMPHOME/.claude/habit-profile.md"
+quiet_output=$(HOME="$TMPHOME" HABIT_QUIET=1 bash "$HOOK" 2>&1 || true)
+if [ -z "$quiet_output" ]; then
+  pass "HABIT_QUIET=1 silences hook output even with active profile"
+else
+  fail "HABIT_QUIET=1 did not silence output (got: ${quiet_output:0:100}...)"
+fi
+echo ""
+
+# --- Token budget check (≤300 per CLAUDE.md) ---
+echo "--- Token budget check ---"
+printf '%s' "$INTERDEPENDENCE_PROFILE" > "$TMPHOME/.claude/habit-profile.md"
+word_count=$(HOME="$TMPHOME" bash "$HOOK" 2>&1 | wc -w | tr -d ' ')
+# Rough token estimate: words * 1.3 for markdown + punctuation overhead
+token_estimate=$((word_count * 13 / 10))
+if [ "$token_estimate" -le 300 ]; then
+  pass "hook output fits ≤300 token budget (estimate: ~${token_estimate} tokens from ${word_count} words)"
+else
+  fail "hook output exceeds 300 token budget (estimate: ~${token_estimate} tokens from ${word_count} words)"
+fi
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $ERRORS"
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "RESULT: FAILED ($ERRORS errors)"
+  exit 1
+else
+  echo "RESULT: ALL CHECKS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Closes the reader-adoption half of the `/calibrate` feature loop. v2.6.0 shipped the **writer** (`/calibrate` → `~/.claude/habit-profile.md`); v2.7.0 ships the **reader** via a hook-based adaptation directive.

- Closes milestone [v2.7.0 — Reader Adoption](https://github.com/pitimon/8-habit-ai-dev/milestone/12) (1/1)
- **Zero changes to individual skill files** — F3 word-budget preserved
- Uses the existing `hooks/session-start.sh` as the single runtime injection point
- Batched feature + version bump per the lesson from #88 (plugin cache lag)

## Why hook-based (not per-skill)

Pre-implementation F3 word-budget audit identified two skills with dangerously thin headroom:

| Skill | Words | Headroom |
|---|---|---|
| `/using-8-habits` | 1990 | **10** |
| `/eu-ai-act-check` | 1989 | **11** |

Any per-skill text addition would have broken F3 fitness immediately — even a 15-word `Load guides/verbosity-adaptation.md` preamble would overflow. The only viable runtime injection point in a pure-markdown plugin is `hooks/session-start.sh`, which outputs into session context once per session and applies globally to all subsequent skill invocations.

The hook approach ships with **zero changes to individual skill files**. Future skill authors don't need to add level-handling boilerplate; the directive is already in session context when they're invoked.

## How it works

```
Session start
    ↓
hooks/session-start.sh reads ~/.claude/habit-profile.md
    ↓
Extracts `level` from frontmatter + `preferences.verbosity-override` from nested preferences
    ↓
Applies override precedence:
    verbose → Dependence (max guidance)
    concise → Significance (min ceremony)
    none/unset → level as-is
    ↓
Emits 1-sentence directive into session context:
    "📖 Profile active: Interdependence — skills should focus on delegation, review,
     and synergy patterns over individual ceremony."
    ↓
Claude sees directive in session context
    ↓
Every subsequent skill invocation in the session is adapted to the user's level
```

## 8 hook branches

| Branch | Trigger | Output |
|---|---|---|
| 1 | No profile file | v2.6.0 `/calibrate` nudge (unchanged, backwards compatible) |
| 2 | `level: Dependence` | Dependence directive — full guidance |
| 3 | `level: Independence` | Independence directive — key checkpoints only |
| 4 | `level: Interdependence` | Interdependence directive — delegation/review/synergy focus |
| 5 | `level: Significance` | Significance directive — minimal prompts, trust user judgment |
| 6 | `verbosity-override: verbose` | Dependence directive (override precedence) |
| 7 | `verbosity-override: concise` | Significance directive (override precedence) |
| 8 | Unknown/missing level | Dependence fallback + visible warning + `/calibrate` refresh hint |

All 8 branches are regression-tested by `tests/test-verbosity-hook.sh` (new — 11 assertions total, wired into CI).

## Files (10 total: 2 new + 8 edits)

**NEW:**
- `guides/verbosity-adaptation.md` — canonical per-level rules + worked examples across 5 skill archetypes (workflow planning, review/gate, research, implementation, retrospective). Maintainer reference; not auto-loaded at runtime.
- `tests/test-verbosity-hook.sh` — 11-check regression (8 branches + HABIT_QUIET silence + token budget). Wired into CI via `.github/workflows/validate.yml`.

**EDITED:**
- `hooks/session-start.sh` — 8-branch profile reader replacing the v2.6.0 static `/calibrate` nudge. Uses pipe-safe awk matching the v2.6.1 SIGPIPE-fix pattern (`tests/validate-content.sh:614`).
- `.github/workflows/validate.yml` — adds `tests/test-verbosity-hook.sh` as 4th CI validator step.
- `CLAUDE.md` — Key Conventions bullet documenting the mechanism.
- `CHANGELOG.md` — v2.7.0 section with architectural rationale + migration notes.
- Version bump v2.6.1 → **v2.7.0** across 4 version-locked files (`plugin.json`, `marketplace.json`, `README.md` badge + footer + ASCII tree, `SELF-CHECK.md` header).

## Verification

### Validators (481/481 PASS, +11 from v2.6.1 baseline)

- `test-skill-graph.sh`: **57 PASS** (unchanged)
- `validate-structure.sh`: **238 PASS** — version consistency verified at 2.7.0 across all 4 files
- `validate-content.sh`: **175 PASS** + F3 convention-consistency 17/17 HEALTHY
- `test-verbosity-hook.sh`: **11 PASS** (NEW)
  - 8 branches
  - HABIT_QUIET silence check (ADR-006 contract)
  - ≤300 token budget assertion (current: ~180 tokens / 139 words)

### Dog-food verification (live)

Ran `bash hooks/session-start.sh` against the actual `~/.claude/habit-profile.md` (my own profile at `level: Interdependence`, calibrated earlier in this session arc):

```
📖 Profile active: Interdependence — skills should focus on delegation, review,
   and synergy patterns over individual ceremony.
```

Correct directive emitted for my own maturity level. Token count: 139 words / ~180 tokens (under 300 budget). HABIT_QUIET=1 silences everything (verified separately).

### Cross-verify result

**Pre-implementation cross-verify on the plan**: 14/14 applicable = **100%** ([see the cross-verify report in this session's transcript](https://github.com/pitimon/8-habit-ai-dev/pull/99)). No failures, 1 minor verification debt (Q11 stale session-start.sh read) cleared as the first implementation step. Highest score across the 3 plans in this session arc (#92 was 92%, #90 was 83%).

## 5 Open Questions — all approved by user per-recommendation

| # | Question | User decision |
|---|---|---|
| 1 | Create v2.7.0 milestone? | ✅ YES — created as milestone 12 |
| 2 | Directive verbosity | ✅ SHORT (1 sentence per level) |
| 3 | Guide depth | ✅ REPRESENTATIVE (5 archetypes × 4 levels) |
| 4 | Ship test script | ✅ YES — `tests/test-verbosity-hook.sh` |
| 5 | Release style | ✅ BATCHED (feature + version bump in one PR) |

## Milestone v2.7.0 — CLOSES on merge (1/1)

With this PR merged, milestone v2.7.0 — Reader Adoption is closed. The #90 user-calibration feature loop is **complete**: write (v2.6.0) → read (v2.7.0).

## Plugin cache lag disclosure

This is a batched feature + version-bump PR. On merge + reinstall, users will immediately see the new hook behavior. Users without a profile see the unchanged v2.6.0 nudge; users with a profile (like the plugin author — me) will see the new level-specific directive on next session start. No migration required.

## Test plan

- [x] `bash tests/test-skill-graph.sh` — 57 PASS
- [x] `bash tests/validate-structure.sh` — 238 PASS, version 2.7.0 verified across 4 files
- [x] `bash tests/validate-content.sh` — 175 PASS + F3 HEALTHY
- [x] `bash tests/test-verbosity-hook.sh` — 11 PASS (all 8 branches + HABIT_QUIET + budget)
- [x] Dog-food: `bash hooks/session-start.sh` against live profile → Interdependence directive
- [x] Dog-food: `HABIT_QUIET=1 bash hooks/session-start.sh` → empty (silence preserved)
- [x] Pre-implementation cross-verify: 14/14 = 100%
- [x] Verification debt cleared (Q11: re-read session-start.sh before editing)
- [ ] CI green on push (expected — local validators all pass)
- [ ] Maintainer review
- [ ] Post-merge: tag v2.7.0 + GitHub release + close milestone + lesson file + restart session dog-food

Closes #96.