### PR TITLE
fix(tests): audit remaining sed|head SIGPIPE flakes (#101)

### DIFF
--- a/tests/test-skill-graph.sh
+++ b/tests/test-skill-graph.sh
@@ -33,8 +33,10 @@ for skill_dir in skills/*/; do
 
   name=$(basename "$skill_dir")
 
-  prev=$(sed -n '/^---$/,/^---$/{ s/^prev-skill:[[:space:]]*//p; }' "$skill_file" | head -1 | tr -d '[:space:]')
-  next=$(sed -n '/^---$/,/^---$/{ s/^next-skill:[[:space:]]*//p; }' "$skill_file" | head -1 | tr -d '[:space:]')
+  # awk (no pipe) avoids SIGPIPE under set -o pipefail on Linux CI where GNU sed exits 4
+  # when head closes stdin mid-stream; see tests/validate-structure.sh:27 header comment.
+  prev=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^prev-skill:[[:space:]]*/, ""){gsub(/[[:space:]]/, ""); print; exit}' "$skill_file")
+  next=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^next-skill:[[:space:]]*/, ""){gsub(/[[:space:]]/, ""); print; exit}' "$skill_file")
 
   if [ -z "$prev" ]; then
     fail "$name: missing prev-skill in frontmatter"

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -52,7 +52,8 @@ for skill_dir in skills/*/; do
   [ ! -f "$skill_file" ] && continue
 
   # Extract name value from frontmatter
-  name_value=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep "^name:" | head -1 | sed 's/^name:[[:space:]]*//')
+  # awk (no pipe) avoids SIGPIPE under set -o pipefail when head closes early — see Check 1 header comment
+  name_value=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^name:[[:space:]]*/, ""){print; exit}' "$skill_file")
 
   if [ "$name_value" = "$dir_name" ]; then
     pass "$skill_file — name '$name_value' matches directory"
@@ -140,8 +141,8 @@ CHAIN_FAIL=0
 for pair in $EXPECTED_CHAIN; do
   from="${pair%%:*}"
   to="${pair##*:}"
-  from_next=$(sed -n '/^---$/,/^---$/p' "skills/$from/SKILL.md" 2>/dev/null | grep "^next-skill:" | head -1 | sed 's/^next-skill:[[:space:]]*//')
-  to_prev=$(sed -n '/^---$/,/^---$/p' "skills/$to/SKILL.md" 2>/dev/null | grep "^prev-skill:" | head -1 | sed 's/^prev-skill:[[:space:]]*//')
+  from_next=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^next-skill:[[:space:]]*/, ""){print; exit}' "skills/$from/SKILL.md" 2>/dev/null)
+  to_prev=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^prev-skill:[[:space:]]*/, ""){print; exit}' "skills/$to/SKILL.md" 2>/dev/null)
 
   if [ "$from_next" = "$to" ] && [ "$to_prev" = "$from" ]; then
     pass "$from → $to chain valid"
@@ -154,7 +155,7 @@ done
 for standalone in cross-verify whole-person-check security-check reflect workflow; do
   skill_file="skills/$standalone/SKILL.md"
   [ ! -f "$skill_file" ] && continue
-  prev=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep "^prev-skill:" | head -1 | sed 's/^prev-skill:[[:space:]]*//')
+  prev=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^prev-skill:[[:space:]]*/, ""){print; exit}' "$skill_file")
   if [ "$prev" = "any" ] || [ "$prev" = "none" ]; then
     pass "$standalone prev-skill=$prev (standalone OK)"
   else
@@ -218,7 +219,7 @@ for skill_dir in skills/*/; do
   [ ! -f "$skill_file" ] && continue
   skill_name=$(basename "$skill_dir")
 
-  tools_line=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep "^allowed-tools:" | head -1)
+  tools_line=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && /^allowed-tools:/{print; exit}' "$skill_file")
   if [ -z "$tools_line" ]; then
     fail "$skill_name — missing allowed-tools field"
     TOOLS_FAIL=$((TOOLS_FAIL + 1))
@@ -287,7 +288,8 @@ AGENT_FAIL=0
 if [ -d "agents" ]; then
   while read -r agent_file; do
     agent_name=$(basename "$agent_file")
-    frontmatter=$(sed -n '/^---$/,/^---$/p' "$agent_file" | head -20)
+    # awk (no pipe) avoids SIGPIPE; bound to 20 content lines to match prior `head -20` cap
+    frontmatter=$(awk '/^---$/{c++; print; if(c==2) exit; next} c==1 {print; if(++n>=20) exit}' "$agent_file")
 
     if [ -z "$frontmatter" ]; then
       fail "$agent_name — no YAML frontmatter"


### PR DESCRIPTION
## Summary

- Replaces 8 remaining `sed -n '...' | grep | head` patterns with single-awk frontmatter extraction in `tests/validate-structure.sh` (×6) and `tests/test-skill-graph.sh` (×2)
- Follow-up audit to v2.6.1 PR #99 which fixed one instance at `tests/validate-content.sh:614` after it flaked on Linux CI (GNU sed exits 4 on SIGPIPE under `set -o pipefail`)
- Purely mechanical fix — no functional change

## Why

The `sed|grep|head` pattern carries a latent race: when `head` closes stdin early, GNU `sed` gets SIGPIPE → exits 4 → `pipefail` propagates failure. The remaining 8 locations hadn't flaked yet because the `grep` filter between `sed` and `head` reduces output volume — but the race window widens whenever a contributor adds body `---` delimiters to any SKILL, ADR, or habit doc, making the next CI flake an unpredictable timing bomb. This is H1 (proactive) + H7 (sharpen the saw) preventive maintenance.

## Fix Pattern

Already proven in-repo at `tests/validate-structure.sh:27` and `tests/validate-content.sh:621`. Single awk, zero pipes, zero SIGPIPE risk:

```bash
# Before (SIGPIPE-prone under pipefail)
name_value=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep "^name:" | head -1 | sed 's/^name:[[:space:]]*//')

# After
name_value=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^name:[[:space:]]*/, ""){print; exit}' "$skill_file")
```

## Design Decision (Option A vs Option B)

Cross-verify Q14 flagged "third alternative not considered." Evaluated:

- **Option A (chosen)**: Inline awk at 8 call sites — minimal diff, no cross-file coupling, easy to review
- **Option B (rejected)**: Extract shared helper `_extract_frontmatter_field "$file" "$field"` sourced by both validators

Rejected Option B because: (1) issue emphasized "purely mechanical, same semantics" (2) introduces coupling between currently-independent validators (3) H3 resist-scope-creep > H6 synergize for internal test infra (4) if a third validator ever needs the same extraction, revisit then.

## Test Plan

- [x] `tests/validate-structure.sh` — 238/238 PASS (identical to baseline)
- [x] `tests/test-skill-graph.sh` — 57/57 PASS
- [x] `tests/validate-content.sh` — 175/175 PASS (untouched, sanity check)
- [x] `tests/test-verbosity-hook.sh` — 12/12 PASS (untouched, sanity check)
- [x] **Total: 482/482 PASS** (pre-fix baseline = post-fix = no drift)
- [x] Stability test: 5× consecutive runs of `validate-structure.sh` — all stable
- [x] Race-window fixture: synthetic SKILL with body `---` × 3 — awk correctly stops at 2nd frontmatter delimiter
- [x] Field extraction sanity: `awk ... skills/cross-verify/SKILL.md` → returns `cross-verify`
- [ ] CI validation (GitHub Actions will verify on Linux — this is the environment where original flake surfaced)

## Edge Case Notes

Line 290 `frontmatter=$(...head -20)` replaced with bounded awk:
```bash
awk '/^---$/{c++; print; if(c==2) exit; next} c==1 {print; if(++n>=20) exit}'
```
Caps to 20 content lines (matches `head -20` semantics for typical agent frontmatter which is always <20 lines). If an agent ever exceeds 20 frontmatter lines, the hard cap still applies — same as prior behavior.

## References

- Issue: #101
- Prior art: v2.6.1 PR #99 (first SIGPIPE fix)
- Lesson file: `~/.claude/lessons/2026-04-11-issue-92-skill-effectiveness.md`
- Pattern source: `tests/validate-structure.sh:27` (header comment)

Closes #101