### PR TITLE
docs: add Testing Conventions section — awk-not-sed frontmatter (#104)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,44 @@ Create `guides/templates/<name>-template.md`:
 - Placeholder sections (not just headings)
 - Referenced from skills via `Load` directive
 
+## Testing Conventions
+
+Test scripts under `tests/` run in GitHub Actions on Linux with `set -o pipefail`. When shelling out, prefer patterns that cannot SIGPIPE.
+
+### Frontmatter extraction — use `awk`, not `sed | grep | head`
+
+**Anti-pattern** (SIGPIPE race under `pipefail`):
+
+```bash
+# DON'T — GNU sed exits 4 when head closes stdin mid-stream
+name_value=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep "^name:" | head -1 | sed 's/^name:[[:space:]]*//')
+```
+
+**Convention** (zero-pipe, SIGPIPE-safe):
+
+```bash
+# DO — single awk, no pipe, bounded by second frontmatter delimiter
+name_value=$(awk '/^---$/{c++; if(c==2) exit; next} c==1 && sub(/^name:[[:space:]]*/, ""){print; exit}' "$skill_file")
+```
+
+The awk pattern: count `---` delimiters, stop at the second one, inside frontmatter (`c==1`) strip the `field:[[:space:]]*` prefix and print the first match — all in one process, no pipe buffer, no race.
+
+### Why it matters
+
+On Linux CI with GNU sed, if `head` closes stdin before sed finishes writing, sed receives SIGPIPE and exits with code 4 (`couldn't flush stdout: Broken pipe`). Under `set -o pipefail` this propagates as test failure. macOS BSD sed silently ignores SIGPIPE so the anti-pattern passes locally and flakes only in CI — the worst kind of bug class.
+
+The `grep` filter between `sed` and `head` reduces output volume and shrinks the race window, but does not eliminate it. Widen the race by adding body `---` lines to any SKILL / ADR / habit doc and the flake returns.
+
+### Prior art
+
+- **First fix**: [PR #99](https://github.com/pitimon/8-habit-ai-dev/pull/99) (v2.6.1) fixed one flaking instance in `tests/validate-content.sh:614`
+- **Full audit**: [PR #103](https://github.com/pitimon/8-habit-ai-dev/pull/103) (closes #101) replaced 8 remaining instances in `tests/validate-structure.sh` and `tests/test-skill-graph.sh`
+- **Header comment**: See `tests/validate-structure.sh:27-28` and `tests/validate-content.sh:619-620` for the in-code rationale
+
+### Broader lens
+
+Audit any new shell pipeline for the same shape: any `<file-reader> | <filter> | head` under `pipefail` is suspect. When in doubt, materialize into a variable first (`fm=$(awk ...)`) and then slice — variable expansion + small pipes don't have the file-reading race.
+
 ## Version Bumping
 
 Version lives in **3 files** — all must be bumped together:


### PR DESCRIPTION
## Summary

- New `## Testing Conventions` section in `CONTRIBUTING.md` documenting the awk-not-sed frontmatter extraction pattern
- +38 / −0 in one file, purely additive
- Closes #104, follow-up to #101 / PR #103

## Why

PR #103 just removed the last 8 `sed|grep|head` SIGPIPE-prone patterns from the test suite. Without a documented convention, a contributor adding a new test script could easily re-introduce the same anti-pattern — it looks natural, it passes on macOS BSD sed, and it only flakes on Linux CI under `pipefail`. This doc section encodes the WHY so future contributors can evaluate their own shell pipelines with the same lens.

## Content

The new section includes:
1. **Before/after example** showing the exact `sed|grep|head` → `awk` transformation
2. **Root cause**: GNU sed exits 4 on SIGPIPE when `head` closes stdin; `pipefail` propagates
3. **macOS vs Linux divergence warning** — silent pass locally, flake in CI (worst kind of bug class)
4. **Prior art links**: PR #99 (first fix), PR #103 (full audit), in-code header comments at `validate-structure.sh:27-28` and `validate-content.sh:619-620`
5. **Broader lens**: audit any `<file-reader> | <filter> | head` under `pipefail` — generalizable beyond frontmatter

## Placement

Added between `## Adding an Output Template` and `## Version Bumping`. Not nested under skill authoring because it applies to test infrastructure generally.

## Test Plan

- [x] `tests/validate-structure.sh` — 238/238 PASS
- [x] `tests/test-skill-graph.sh` — 57/57 PASS
- [x] `tests/validate-content.sh` — 175/175 PASS (this one matters — validates CONTRIBUTING.md structure, my edit must not break content validation)
- [x] `tests/test-verbosity-hook.sh` — 12/12 PASS
- [x] **Total: 482/482** (no drift from main baseline)
- [ ] CI validation on Linux

## References

- Issue: #104
- Prior: #101, PR #103, PR #99
- Lesson file: `~/.claude/lessons/2026-04-11-issue-101-sigpipe-audit.md` (action item Q5 → shipped)

Closes #104