### PR TITLE
docs: sync README "What's New" and wiki Changelog to v2.7.0 (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,34 +381,40 @@ Both agents use the `sonnet` model for fast, focused analysis.
 
 ---
 
-## What's New in v2.2.0
+## What's New in v2.7.0
 
-**Theme: Body Dimension Level-Up** — content validation and architecture fitness functions to reach Whole Person Body Level 3 "Significant."
+**Theme: Reader Adoption** — closes the `/calibrate` feature loop (v2.6.0 wrote the profile, v2.7.0 makes the other 16 skills read it).
 
-- **Content validation** (`tests/validate-content.sh`) — section depth, markdown integrity, ADR format, handoff completeness
-- **Architecture fitness functions** — 3 tracked metrics: Skill Complexity Budget, Validation Coverage Ratio, Convention Consistency Score
-- **Extended structure validation** — `allowed-tools` field validation, README ↔ skills cross-reference, agent definition checks
-- **17 check categories, 221 assertions** (up from 10 checks / 133 assertions in v2.1.0)
-- **CI enforces both scripts** — fitness function breach fails the build
-- **[ADR-003](docs/adr/ADR-003-content-validation.md)** — documents why bash content validation was chosen over npm linting or agent-driven validation
-- **Zero new dependencies** — pure bash, as always
+- **Hook-based verbosity adaptation** ([#96](https://github.com/pitimon/8-habit-ai-dev/issues/96)) — `hooks/session-start.sh` reads `~/.claude/habit-profile.md` at session start and emits a level-specific directive into context. Skills auto-adapt from Dependence (full guidance) through Significance (minimal prompts) with **zero changes to individual skill files** — F3 word budget preserved
+- **`guides/verbosity-adaptation.md`** — canonical per-level adaptation rules with worked examples across 5 skill archetypes
+- **`tests/test-verbosity-hook.sh`** — 12-assertion regression coverage for all 8 hook branches plus HABIT_QUIET opt-out and ≤300-token budget check
+- **`preferences.verbosity-override`** in habit-profile schema — `verbose` promotes any level to Dependence, `concise` demotes to Significance
+- **4 validators in CI** (up from 3) — total **482 assertions** across validate-structure, test-skill-graph, validate-content, test-verbosity-hook
+- **Milestone v2.7.0 CLOSED** — Hermes-inspired feature loop (v2.6.0 + v2.7.0) complete; plugin at a local maximum given pure-markdown constraints
 
-## What's New in v2.1.0
+## What's New in v2.6.0 / v2.6.1
 
-**Theme: Multi-Agent Research** — deeper investigation with Feynman-inspired depth levels, research modes, and source verification.
+**Theme: Hermes-Inspired Improvements** — user-modeling + learning-loop patterns filtered through plugin-boundary discipline.
 
-- **Research depth levels** in `/research` — Quick (codebase only), Standard (default), Deep (multi-agent + verification)
-- **Research modes** in `/research` — General (default), Compare (comparison matrix), Audit (code vs docs)
-- **[`research-verifier` agent](agents/research-verifier.md)** — validates URLs, checks file paths, flags dead links in Deep mode
-- **[Research brief template](guides/templates/research-brief-template.md)** — structured output with optional comparison matrix, audit results, and verification report
-- **[ADR-002](docs/adr/ADR-002-research-modes.md)** — documents why modes integrate into `/research` rather than becoming separate skills
+- **`/calibrate` skill + habit-profile schema v1** ([#90](https://github.com/pitimon/8-habit-ai-dev/issues/90), [ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md)) — 5-7 question self-assessment that writes `~/.claude/habit-profile.md` for other skills to adapt to. Dominant-level scoring across Dependence → Independence → Interdependence → Significance
+- **`guides/habit-profile-schema.md`** — public schema contract (YAML + markdown, `schema-version: 1`) defining the writer-reader API future skills code against
+- **Persistent reflection artifacts** ([#88](https://github.com/pitimon/8-habit-ai-dev/issues/88)) — `/reflect` persists lessons to `~/.claude/lessons/YYYY-MM-DD-<slug>.md`; `/research` and `/build-brief` search these before starting work. Closes the loop: reflect → persist → retrieve → apply
+- **`/reflect` Q6 Skill Effectiveness signal** ([#92](https://github.com/pitimon/8-habit-ai-dev/issues/92)) — new 6th retro question naming "most useful" and "least useful/confusing" skill this session. Feeds maintainer-curated `SKILL-EFFECTIVENESS.md` trend tracker — **H7 applied to the plugin itself**
+- **`guides/habit-nudges.md`** + **ADR-007** — nudge specification (hook implementation delegated to `claude-governance` per plugin boundary) + agentskills.io NO-GO decision record
+- **Skill count: 16 → 17** (`/calibrate` added)
 
 ### Earlier Versions
 
-- **v2.0.0** — Orchestration-Aware Development (ULW-inspired): task classification in `/breakdown`, context boundaries in `/build-brief`, [orchestration patterns guide](guides/orchestration-patterns.md), [ADR-001](docs/adr/ADR-001-orchestration-patterns.md)
+- **v2.5.0** (2026-04-09) — Testing & Discoverability: `test-skill-graph.sh` DAG validator, `pre-commit.sh.example` template, bidirectional wiki ↔ skills linking
+- **v2.4.1** (2026-04-09) — Honest Correction: removed `/brainstorm` after finding `superpowers:brainstorming` is a better implementation; added `HABIT_QUIET=1` opt-out; introduced "Core 5" tier (ADR-006)
+- **v2.4.0** (2026-04-09) — Workflow Completions: `/brainstorm` (later removed), EARS-notation in `/requirements`, `/using-8-habits` onboarding meta-skill
+- **v2.3.0** (2026-04-09) — EU AI Act Compliance Toolkit (flagship): `/eu-ai-act-check` 9-obligation tiered checklist, `/ai-dev-log` AI transparency, `/design` Article 14 human-oversight checkpoint, `docs/research/eu-ai-act-obligations.md` primary-source research, [ADR-005](docs/adr/ADR-005-eu-ai-act-toolkit.md), Plugin Boundary section
+- **v2.2.0** (2026-04-07) — Body Dimension Level-Up: content validation (`validate-content.sh`), 3 architecture fitness functions, [ADR-003](docs/adr/ADR-003-content-validation.md)
+- **v2.1.0** (2026-04-07) — Multi-Agent Research (Feynman-inspired): research depth levels, research modes, `research-verifier` agent, [ADR-002](docs/adr/ADR-002-research-modes.md)
+- **v2.0.0** (2026-04-07) — Orchestration-Aware Development (ULW-inspired): task classification in `/breakdown`, context boundaries in `/build-brief`, [ADR-001](docs/adr/ADR-001-orchestration-patterns.md)
 - **v1.9.0** — Feynman-inspired: `/research` skill, evidence grounding, [12 AI Integrity Commandments](guides/integrity-principles.md), confidence levels, lazy parallelism gate
 
-Full release history: [GitHub Releases](https://github.com/pitimon/8-habit-ai-dev/releases)
+Full release history: [`CHANGELOG.md`](CHANGELOG.md) (v2.3.0+) · [`docs/wiki/Changelog.md`](docs/wiki/Changelog.md) (v2.2.0 and earlier) · [GitHub Releases](https://github.com/pitimon/8-habit-ai-dev/releases)
 
 ---
 

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,6 +1,69 @@
 # Changelog
 
-Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative source is the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases) and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
+Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
+
+> Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.7.0 — Reader Adoption (April 2026)
+
+Closes the `/calibrate` feature loop by making skills read `~/.claude/habit-profile.md` via a session-start hook.
+
+- **Hook-based verbosity adaptation** ([#96](https://github.com/pitimon/8-habit-ai-dev/issues/96)) — `hooks/session-start.sh` emits a per-level directive into session context; 16 existing skills auto-adapt with zero file changes
+- **`guides/verbosity-adaptation.md`** — canonical per-level rules with 5 skill-archetype examples
+- **`tests/test-verbosity-hook.sh`** — 12-assertion regression coverage for all 8 hook branches + HABIT_QUIET opt-out + ≤300-token budget check
+- **4 validators in CI, 482 total assertions** (up from 3 / 470)
+- **Milestone v2.7.0 CLOSED** — Hermes-inspired feature loop (v2.6.0 + v2.7.0) complete
+
+## v2.6.1 — Skill Effectiveness Tracking (April 2026)
+
+- **`/reflect` Q6 Skill Effectiveness signal** ([#92](https://github.com/pitimon/8-habit-ai-dev/issues/92)) — 6th retro question captures "most useful" and "least useful/confusing" skill
+- **`SKILL-EFFECTIVENESS.md`** (repo root) — maintainer-curated trend tracker; H7 applied to the plugin itself
+- **`guides/templates/lesson-template.md`** — new `## Skill effectiveness` section for consistent Q6 capture
+- **Fix**: SIGPIPE flake in `validate-content.sh` F3 extractor — replaced `sed | head` with pipe-safe awk
+
+## v2.6.0 — Hermes-Inspired Improvements (April 2026)
+
+- **`/calibrate` skill + habit-profile schema v1** ([#90](https://github.com/pitimon/8-habit-ai-dev/issues/90), [ADR-008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md)) — 5-7 question self-assessment writing `~/.claude/habit-profile.md` with dominant-level scoring
+- **`guides/habit-profile-schema.md`** — public schema contract (YAML + markdown body, versioned via `schema-version`)
+- **Persistent reflection artifacts** ([#88](https://github.com/pitimon/8-habit-ai-dev/issues/88)) — `/reflect` writes lessons to `~/.claude/lessons/`; `/research` and `/build-brief` read them before starting work
+- **`guides/habit-nudges.md`** + **ADR-007** — nudge spec (hook delegated to claude-governance) + agentskills.io NO-GO decision
+- **Skill count: 16 → 17** (`/calibrate` added)
+
+## v2.5.0 — Testing & Discoverability (April 2026)
+
+- **`tests/test-skill-graph.sh`** — DAG validator for `prev-skill` / `next-skill` chains (#79): cycles, dangling refs, symmetric edges, orphans
+- **`hooks/pre-commit.sh.example`** — template running `/review-ai` on staged files (opt-in, not auto-installed)
+- **Bidirectional wiki ↔ skills linking** (#81) — each workflow skill has a `## Further Reading` section linking to its wiki page
+- CI now runs 3 validators; 443 total assertions
+
+## v2.4.1 — Honest Correction (April 2026)
+
+Same-day correction after comparing `/brainstorm` to `superpowers:brainstorming`.
+
+- **Removed `/brainstorm` skill** (breaking) — superpowers' 500+ line hard-gate discipline suite is a better fit; `/research` now references it for fuzzy problem statements
+- **`HABIT_QUIET=1` opt-out** for `hooks/session-start.sh` — users who internalize the workflow can silence the reminder
+- **"Core 5" tier** in `/using-8-habits` — 80/20 reality acknowledgment
+- [ADR-006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-opt-out.md) — audience-honesty + opt-out + "check peer plugins before building parity" lesson
+
+## v2.4.0 — Workflow Completions (April 2026)
+
+- **`/brainstorm`** (Step 0a, later removed in v2.4.1) — 5 Whys, alternative framings, hidden assumptions
+- **EARS-notation in `/requirements`** — 5 structured acceptance criteria templates from Rolls-Royce (Mavin et al. 2009)
+- **`/using-8-habits`** — onboarding meta-skill with decision tree and complete walkthrough example
+- Validators: +52 assertions, anti-drift check ensures meta-skill references every directory skill
+- Fix: `validate-structure.sh` regex allowing digits in skill names
+
+## v2.3.0 — EU AI Act Compliance Toolkit (April 2026)
+
+Flagship blue-ocean feature: first Claude Code plugin with explicit EU AI Act compliance toolkit, shipped ~4 months before 2 August 2026 enforcement.
+
+- **`/eu-ai-act-check`** — 9-obligation tiered checklist (25 MUST + 27 SHOULD + 8 COULD) covering Articles 9-15
+- **`/ai-dev-log`** + **`scripts/generate-ai-dev-log.sh`** — AI-assisted development log from `git log` + Co-Authored-By trailers (4 modes: markdown/json/summary/out)
+- **`/design` Step 5** — Article 14 human-oversight 5-capability checkpoint (Understand / Automation bias / Interpret / Override / Stop button)
+- **`docs/research/eu-ai-act-obligations.md`** — primary-source research with Verified Quotes for all 7 articles
+- **[ADR-005](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-005-eu-ai-act-toolkit.md)** + **Plugin Boundary section** in `CLAUDE.md` — documents complementary relationship with [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance)
+- Version file convention corrected to **4 files** (added `SELF-CHECK.md`)
+- Fix: `validate-structure.sh` SIGPIPE race replaced `sed | head` with awk
 
 ## v2.2.0 — April 2026
 
@@ -40,11 +103,12 @@ This plugin follows [semantic versioning](https://semver.org/):
 - **Minor** — new skills, new habits content, backward-compatible additions
 - **Patch** — documentation fixes, typo corrections, clarifications
 
-Version is tracked in three files that must bump together:
+Version is tracked in four files that must bump together (enforced by `tests/validate-structure.sh`):
 
 - `.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
-- `README.md` footer
+- `README.md` (badge + footer)
+- `SELF-CHECK.md` header
 
 ## Full history
 


### PR DESCRIPTION
## Summary

- Propagates `CHANGELOG.md` entries for v2.3.0–v2.7.0 down to `README.md` and `docs/wiki/Changelog.md`
- Both user-facing surfaces had drifted 5 versions behind the authoritative `CHANGELOG.md`
- Also fixes stale "three files" → "four files" version-tracking note in the wiki (the 3→4 correction actually shipped with v2.3.0 but never propagated here)
- +91 / −21 across 2 files

## Why

`CHANGELOG.md` (root) is the source of truth and correctly covers v2.3.0 through v2.7.0. But:

| Surface | Latest shown | Gap |
|---|---|---|
| `README.md` "What's New" | v2.2.0 | v2.3.0, v2.4.0, v2.4.1, v2.5.0, v2.6.0, v2.6.1, v2.7.0 |
| `docs/wiki/Changelog.md` | v2.2.0 | Same 5-version gap |

Users visiting the README on GitHub or the public Wiki see the plugin as "stuck at v2.2.0" when it's actually at v2.7.0 with several high-value features shipped since.

## Design (Medium scope)

Matches the existing README pattern: **2 latest detailed + rest condensed**.

### README.md
- `## What's New in v2.7.0` — detailed (hook-based verbosity adaptation, closes `/calibrate` reader loop, 4 validators, F3 budget preserved)
- `## What's New in v2.6.0 / v2.6.1` — detailed (bundled because v2.6.1 is the P3 patch to v2.6.0's milestone: `/calibrate` writer, habit-profile schema, persistent reflection artifacts, `/reflect` Q6, `SKILL-EFFECTIVENESS.md`)
- `### Earlier Versions` — added one-liners for v2.5.0, v2.4.1, v2.4.0, v2.3.0; **moved existing** v2.2.0 / v2.1.0 from detailed to one-liners in the same list; preserved v2.0.0 / v1.9.0
- Footer cite updated to reference both `CHANGELOG.md` (v2.3.0+) and `docs/wiki/Changelog.md` (v2.2.0 and earlier)

### docs/wiki/Changelog.md
- Prepended 7 new version sections (v2.7.0 / v2.6.1 / v2.6.0 / v2.5.0 / v2.4.1 / v2.4.0 / v2.3.0), each 3-6 bullets — more concise than README's bullet detail
- Top-of-page pointer to root `CHANGELOG.md` as source of truth for v2.3.0+, avoiding full-detail duplication
- Existing v2.2.0 / v2.1.0 / v2.0.0 / v1.x sections unchanged
- **Bonus fix**: version-tracking note said "three files" (`plugin.json`, `marketplace.json`, `README.md`) but `CLAUDE.md` and `validate-structure.sh` enforce **four** files including `SELF-CHECK.md`. The 3→4 correction shipped in v2.3.0 but was missed here — fixed in the same edit

## Propagation

`docs/wiki/**` changes on main trigger `.github/workflows/wiki-sync.yml` which auto-publishes to the public GitHub Wiki (ADR-004). No manual wiki edit needed.

## Test Plan

- [x] `tests/validate-structure.sh` — 238/238 PASS
- [x] `tests/test-skill-graph.sh` — 57/57 PASS
- [x] `tests/validate-content.sh` — 175/175 PASS (inspects README.md structure — no regression)
- [x] `tests/test-verbosity-hook.sh` — 12/12 PASS
- [x] **Total: 482/482** (zero drift from baseline)
- [x] Manual diff review — no factual errors vs. `CHANGELOG.md` source
- [ ] CI validation on Linux
- [ ] Wiki-sync workflow runs successfully after merge and publishes to public Wiki

## References

- Issue: #106
- Source of truth: [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md)
- Propagation mechanism: [ADR-004 Wiki as Artifact](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-004-wiki-as-artifact.md)

Closes #106