### PR TITLE
feat(tests): add docs freshness check to validate-content.sh (#108)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,17 @@ The `grep` filter between `sed` and `head` reduces output volume and shrinks the
 
 Audit any new shell pipeline for the same shape: any `<file-reader> | <filter> | head` under `pipefail` is suspect. When in doubt, materialize into a variable first (`fm=$(awk ...)`) and then slice — variable expansion + small pipes don't have the file-reading race.
 
+### Docs freshness check
+
+`tests/validate-content.sh` Check 19 enforces **downstream propagation** from the authoritative `CHANGELOG.md` to user-facing doc surfaces:
+
+- **`README.md`** must mention the current version from `.claude-plugin/plugin.json` (typically in the "What's New" section)
+- **`docs/wiki/Changelog.md`** must either mention the current version OR contain a relative link to `CHANGELOG.md` (pointer-based design per ADR-004)
+
+This catches the "stuck at v2.N-5" scenario at PR time instead of 4 months later when someone notices the README looks ancient. When you bump the version in `plugin.json` + `marketplace.json` + `README.md` + `SELF-CHECK.md` (the 4-file convention enforced by `validate-structure.sh`), Check 19 verifies you also wrote release notes in the user-facing surfaces. If your release is a pure pointer (e.g., wiki just links back to root `CHANGELOG.md` without its own entry), that satisfies the check — duplication is not required.
+
+See [issue #108](https://github.com/pitimon/8-habit-ai-dev/issues/108) and [issue #106](https://github.com/pitimon/8-habit-ai-dev/issues/106) for the drift incident that motivated this check.
+
 ## Version Bumping
 
 Version lives in **3 files** — all must be bumped together:

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -505,6 +505,36 @@ fi
 
 echo ""
 
+# --- Check 19: Docs freshness vs plugin.json version ---
+# Enforces downstream propagation from CHANGELOG.md to README.md and docs/wiki/Changelog.md.
+# Prevents the "stuck at v2.N-5" drift scenario (see issue #106, fix in PR #107).
+# See CONTRIBUTING.md § Testing Conventions for rationale.
+echo "--- Check 19: Docs freshness vs plugin.json version ---"
+
+# Extract current version from plugin.json — no pipe, SIGPIPE-safe (see CONTRIBUTING.md)
+current_version=$(awk -F'"' '/"version"/{print $4; exit}' .claude-plugin/plugin.json)
+
+if [ -z "$current_version" ]; then
+  fail "could not extract version from .claude-plugin/plugin.json"
+else
+  # README.md must mention the current version somewhere (typically in "What's New")
+  if grep -q "v${current_version}" README.md; then
+    pass "README.md mentions current version v${current_version}"
+  else
+    fail "README.md does not mention v${current_version} — CHANGELOG.md likely updated but downstream propagation was skipped. See CONTRIBUTING.md § Testing Conventions."
+  fi
+
+  # docs/wiki/Changelog.md must either mention the version OR point to CHANGELOG.md
+  # (pointer-based design is valid per ADR-004 — wiki references root as source of truth)
+  if grep -Eq "v${current_version}|CHANGELOG\.md" docs/wiki/Changelog.md; then
+    pass "docs/wiki/Changelog.md references v${current_version} or points to CHANGELOG.md"
+  else
+    fail "docs/wiki/Changelog.md missing v${current_version} mention AND no CHANGELOG.md pointer — wiki drift. See CONTRIBUTING.md § Testing Conventions."
+  fi
+fi
+
+echo ""
+
 # ===================================================================
 # Architecture Fitness Functions
 # These track health metrics over time. A BREACH fails the build.


### PR DESCRIPTION
## Summary

- Adds **Check 19** to `tests/validate-content.sh` enforcing docs freshness vs `plugin.json` version
- Catches the "stuck at v2.N-5" drift that caused #106, at PR time instead of 4 months later
- +41 / −0 across 2 files (`tests/validate-content.sh` + `CONTRIBUTING.md`)
- Total validator assertions: **482 → 484** (+2)

## What it checks

Check 19 reads the current version from `.claude-plugin/plugin.json` (pipe-safe awk, no `sed|head`), then asserts:

1. **`README.md`** must mention `v${version}` somewhere — typically in the "What's New" section
2. **`docs/wiki/Changelog.md`** must either mention `v${version}` OR contain a relative link to `CHANGELOG.md` — pointer-based design per ADR-004 is explicitly allowed, duplication not required

Both failure messages name the file and expected version, and point to `CONTRIBUTING.md § Testing Conventions` for context.

## Why

When #106 surfaced the drift, both `README.md` "What's New" and `docs/wiki/Changelog.md` had been stuck at v2.2.0 for **5 versions** (v2.3.0 through v2.7.0 missing). The authoritative `CHANGELOG.md` was up to date the whole time — nothing automated caught that downstream surfaces were lagging. Four releases went by with nobody noticing the "three files" → "four files" stale note in the wiki either.

No amount of "remember to update README" discipline would have caught this. An automated fitness check does.

## Testing

**Positive test** (both assertions on current green main):
```
--- Check 19: Docs freshness vs plugin.json version ---
  PASS: README.md mentions current version v2.7.0
  PASS: docs/wiki/Changelog.md references v2.7.0 or points to CHANGELOG.md
```

**Negative test 1** — stashed `v2.7.0` mentions in `README.md`:
```
--- Check 19: Docs freshness vs plugin.json version ---
  FAIL: README.md does not mention v2.7.0 — CHANGELOG.md likely updated
        but downstream propagation was skipped. See CONTRIBUTING.md § Testing Conventions.
  PASS: docs/wiki/Changelog.md references v2.7.0 or points to CHANGELOG.md
```

**Negative test 2** — stashed both `v2.7.0` and `CHANGELOG.md` pointer in wiki:
```
--- Check 19: Docs freshness vs plugin.json version ---
  PASS: README.md mentions current version v2.7.0
  FAIL: docs/wiki/Changelog.md missing v2.7.0 mention AND no CHANGELOG.md pointer
        — wiki drift. See CONTRIBUTING.md § Testing Conventions.
```

Restore verified clean via `git diff` after each negative test (only the intended 2 files show in the staged diff).

## Test Plan

- [x] `tests/validate-structure.sh` — 238/238 PASS
- [x] `tests/test-skill-graph.sh` — 57/57 PASS
- [x] `tests/validate-content.sh` — **177/177 PASS** (was 175 — +2 Check 19 assertions)
- [x] `tests/test-verbosity-hook.sh` — 12/12 PASS
- [x] **Total: 484/484 PASS** (+2 from baseline 482)
- [x] F1/F2/F3 fitness functions all HEALTHY, 0 BREACHES
- [x] Positive test: both assertions PASS on current main
- [x] Negative test 1: README drift detected correctly
- [x] Negative test 2: wiki drift detected correctly
- [x] No modification of unintended files (verified via `git diff` post-restore)
- [ ] CI validation on Linux

## Design Notes

**Pipe-safe by construction** — the awk version extractor follows the SIGPIPE-avoidance convention documented in `CONTRIBUTING.md § Testing Conventions` (added in PR #105). Zero pipes, zero race conditions, Linux CI-safe under `set -o pipefail`.

**Not a replacement for manual release notes.** This is a freshness check, not a content check. It validates that a version is mentioned somewhere, not that the mention is accurate or complete. Release notes still need human authorship.

**Extends existing 4-file version consistency.** `validate-structure.sh` already enforces version consistency across `plugin.json`, `marketplace.json`, `README.md`, `SELF-CHECK.md` (the config files). This new check extends the discipline to the **content files** (`README.md` "What's New", `docs/wiki/Changelog.md`) that `validate-structure.sh` can't meaningfully check because they're free-form prose.

**Pointer-based design explicitly allowed.** The wiki check accepts either a version mention OR a relative link to `CHANGELOG.md`. This respects ADR-004's source-of-truth architecture where `docs/wiki/Changelog.md` could legitimately defer to root `CHANGELOG.md` without its own entry. No duplication forced.

## CONTRIBUTING.md

New "Docs freshness check" subsection added to `§ Testing Conventions` explaining what Check 19 enforces, why, and when pointer-based design satisfies it. References #108 and #106 for the drift incident that motivated it.

## References

- Issue: #108
- Drift incident: #106 (README + wiki 5 versions behind) → PR #107 (the catch-up)
- Lesson file: `~/.claude/lessons/2026-04-11-issue-106-readme-wiki-catchup.md` (action item Q5 → shipped here)
- Prior art: PR #103 (SIGPIPE audit), PR #105 (CONTRIBUTING.md Testing Conventions)

Closes #108