### PR TITLE
chore(release): v2.7.1 — /review-ai Performance axis + review-tests-first

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.7.1 — Review Discipline Refinement (2026-04-11)
+
+Small post-milestone patch on top of v2.7.0. Adds two review-time disciplines to `/review-ai` after a cost/benefit audit against Addy Osmani's `agent-skills` repository (MIT). Only one of six candidate mechanics was imported — the other five were explicitly rejected as duplicative of existing plugin features or out-of-scope for the `8-habit-ai-dev` plugin boundary. Scope deliberately minimal to honor the v2.7.0 "local maximum" framing from `~/.claude/lessons/2026-04-11-issue-96-reader-adoption.md`.
+
+### Added
+
+- **`/review-ai` Performance axis** ([#110](https://github.com/pitimon/8-habit-ai-dev/issues/110), [PR #111](https://github.com/pitimon/8-habit-ai-dev/pull/111)) — fourth review category alongside Security / Quality / Completeness, flagging N+1 queries, unbounded loops, missing pagination on list endpoints, unindexed queries on large tables, and memory leaks (unclosed streams, unbounded caches, retained references). Performance findings follow the same `file:line` evidence standard as the other axes.
+- **`/review-ai` review-tests-first directive** — new Process step 2 directs the reviewer to open the new or changed test files *before* judging the implementation. Tests declare the *intended* behavior; reading them first gives you the specification to review the code against. If new logic has no corresponding test, record it as a Completeness finding.
+- **Verdict output table** now lists four category rows (Security / Quality / Performance / Completeness); Definition of Done checkbox references all four categories by name.
+
+### Not Added (deliberately rejected after cost/benefit audit)
+
+The research brief evaluated six agent-skills mechanics; five were rejected. Rejection rationale is archived in PR #111's body and the local plan file `~/.claude/plans/drifting-waddling-pascal.md` so future "research hype" passes don't re-litigate the same ground:
+
+- ❌ `guides/anti-rationalization.md` — already present as 24 anti-patterns in `rules/effective-development.md` + 12 commandments in `guides/integrity-principles.md`, just in different prose form
+- ❌ `guides/red-flags.md` — `/reflect` and `/cross-verify` already provide self-detection
+- ❌ `guides/google-engineering-principles.md` (Hyrum's Law / Beyoncé Rule / Trunk-Based Development) — cultural flavor over existing substance; no new discipline the plugin lacks
+- ❌ `/cross-verify` Q18 "Beyoncé check" — existing questions already probe test coverage gaps
+- ❌ Cross-plugin hard-gate progression spec — no user demand signal; runtime enforcement belongs in `claude-governance`, not here
+
+### Fitness functions
+
+- All 4 validators green: `validate-structure.sh` 238/238, `validate-content.sh` 177/177, F1/F2/F3 HEALTHY, `test-verbosity-hook.sh` 11/11
+- `skills/review-ai/SKILL.md` word count: 890 → 1025 (F3 ceiling 2000, headroom 975 retained)
+- Validator assertion total unchanged — this patch does not add or remove assertions
+
+### Source attribution
+
+- Research source: [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) (MIT)
+- No code or text was directly copied; only the *idea* of a Performance review axis and a tests-first directive were adapted
+
+---
+
 ## v2.7.0 — Reader Adoption (2026-04-11)
 
 Closes the reader-adoption half of the `/calibrate` feature loop. v2.6.0 shipped `/calibrate` which **writes** `~/.claude/habit-profile.md`; until this release, the 17 skills did not **read** the profile, so the feature delivered discovery but not adaptation. v2.7.0 closes that gap via a hook-based adaptation directive — zero changes to individual skill files.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.7.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.7.0)
+[![Version](https://img.shields.io/badge/Version-2.7.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.7.1)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.7.0)
+│   ├── plugin.json                 # Plugin metadata (v2.7.1)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -380,6 +380,14 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.7.1
+
+**Theme: Review Discipline Refinement** — small post-milestone patch on top of v2.7.0, adding two review-time disciplines to `/review-ai` after a cost/benefit audit against `addyosmani/agent-skills` (MIT). Only the one genuine gap was imported; five other candidates were evaluated and rejected as duplicative or out-of-scope.
+
+- **`/review-ai` Performance axis** ([#110](https://github.com/pitimon/8-habit-ai-dev/issues/110), [PR #111](https://github.com/pitimon/8-habit-ai-dev/pull/111)) — fourth review category alongside Security/Quality/Completeness. Flags N+1 queries, unbounded loops, missing pagination, unindexed queries, and memory leaks. Same `file:line` evidence standard as other axes.
+- **`/review-ai` review-tests-first directive** — new Process step 2 directs the reviewer to open the new or changed test files before judging the implementation. Tests declare intent; reading them first gives the specification to review against.
+- **Rejections preserved in PR** — `guides/anti-rationalization.md`, `guides/red-flags.md`, `guides/google-engineering-principles.md`, `/cross-verify` Q18, and a cross-plugin hard-gate spec were all evaluated and rejected. Rationale archived in the PR #111 body so future "research hype" passes don't re-litigate them.
 
 ## What's New in v2.7.0
 
@@ -529,4 +537,4 @@ MIT
 
 ---
 
-_Version: 2.7.0 | Last updated: 2026-04-11_
+_Version: 2.7.1 | Last updated: 2026-04-11_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.7.0 | **Date**: 2026-04-11 | **Previous**: 2.6.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.7.1 | **Date**: 2026-04-11 | **Previous**: 2.7.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -159,7 +159,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.6.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Hermes-inspired arc: #88 persistent reflection, #89 nudge spec, #90 /calibrate + ADR-008, #91 agentskills NO-GO + ADR-007 — 443 → 470 assertions)
 - v2.6.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#92 /reflect Q6 + SKILL-EFFECTIVENESS.md, SIGPIPE CI fix — milestone v2.6.0 CLOSED 5/5)
 - v2.7.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#96 hook-based reader adoption — closes #90 feature loop, 470 → 481 assertions, zero per-skill changes)
+- v2.7.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#110 /review-ai Performance axis + review-tests-first — minimal post-milestone refinement; 5 of 6 agent-skills candidates rejected in cost/benefit audit, honoring v2.7.0 "local maximum" framing)
 
 ---
 
-_Updated with each release. Previous: 2.6.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.7.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -4,6 +4,14 @@ Release history for `8-habit-ai-dev`. This page summarizes notable changes; the 
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
 
+## v2.7.1 — Review Discipline Refinement (April 2026)
+
+Small post-milestone patch adding two disciplines to `/review-ai` after a cost/benefit audit against `addyosmani/agent-skills` (MIT). Scope deliberately minimal — only one of six candidate mechanics was imported.
+
+- **`/review-ai` Performance axis** ([#110](https://github.com/pitimon/8-habit-ai-dev/issues/110), [PR #111](https://github.com/pitimon/8-habit-ai-dev/pull/111)) — fourth review category flagging N+1 queries, unbounded loops, missing pagination, unindexed queries, and memory leaks; same `file:line` evidence standard as the other axes
+- **Review-tests-first directive** — new Process step 2 directs the reviewer to read new/changed tests before judging implementation
+- **Rejections preserved in PR #111 body** — `guides/anti-rationalization.md`, `guides/red-flags.md`, `guides/google-engineering-principles.md`, `/cross-verify` Q18, and a cross-plugin hard-gate spec were all evaluated and rejected as duplicative of existing features or out-of-scope
+
 ## v2.7.0 — Reader Adoption (April 2026)
 
 Closes the `/calibrate` feature loop by making skills read `~/.claude/habit-profile.md` via a session-start hook.


### PR DESCRIPTION
## Summary

Release PR propagating the single content change from #111 (merged as `3859bea`) and bumping the plugin version from **v2.7.0** to **v2.7.1** across the 4 canonical version files + CHANGELOG.md + `docs/wiki/Changelog.md`.

## Why v2.7.1 (patch) and not v2.8.0 (minor)?

Earlier memory notes assumed "next release will be v2.8.0". Those were pre-audit assumptions. A cost/benefit audit of `addyosmani/agent-skills` (MIT) rejected 5 of 6 candidate mechanics, leaving only a single-file discipline refinement to `/review-ai`. Calling that v2.8.0 would contradict the explicit v2.7.0 framing that the Hermes-inspired feature loop is **CLOSED** and the plugin is at a **local maximum**. v2.7.1 (patch) matches the scope and preserves the milestone semantics. Full rationale in `~/.claude/lessons/2026-04-11-issue-96-reader-adoption.md` and the plan file.

## Files bumped

| File | Change |
|------|--------|
| `.claude-plugin/plugin.json` | `"version": "2.7.0"` → `"version": "2.7.1"` |
| `.claude-plugin/marketplace.json` | `"version": "2.7.0"` → `"version": "2.7.1"` |
| `README.md` | Badge + footer + metadata comment + new "What's New in v2.7.1" section (v2.7.0 section preserved below, unchanged) |
| `SELF-CHECK.md` | Header version + Previous reference + scorecard row for v2.7.1 + footer Previous |
| `CHANGELOG.md` | New v2.7.1 entry: Added / Not Added (rejection rationale) / Fitness functions / Source attribution |
| `docs/wiki/Changelog.md` | New v2.7.1 entry summarizing changes + rejections |

## No skill files touched in this PR

The skill edit (`skills/review-ai/SKILL.md`) was shipped in PR #111. This PR is purely version propagation + release notes.

## Test plan

- [x] `bash tests/validate-structure.sh` — 238/238 PASS (Check 10 SELF-CHECK version + version consistency pass)
- [x] `bash tests/validate-content.sh` — 177/177 PASS; Check 19 docs-freshness sees `v2.7.1` in README; F1/F2/F3 HEALTHY
- [x] `bash tests/test-verbosity-hook.sh` — 12/12 PASS
- [x] `bash tests/test-skill-graph.sh` — 57/57 PASS
- [x] All 6 files show consistent `2.7.1` on `grep -r "2\.7\." .claude-plugin/ README.md SELF-CHECK.md CHANGELOG.md docs/wiki/Changelog.md`
- [ ] CI green on this PR
- [ ] Post-merge: tag `v2.7.1` created on `main` pointing at the release commit
- [ ] Post-merge: GitHub release published with the CHANGELOG v2.7.1 section as release notes
- [ ] Post-merge: `/reflect` lesson written capturing the meta-insight (most of the agent-skills blog hype was already present; the audit's real value was the 5/6 rejection, not the 1/6 import)

## Links

- Content PR: #111 (merged)
- Source issue: #110 (auto-closed)
- Research source: https://github.com/addyosmani/agent-skills (MIT)
- Plan file (local): `~/.claude/plans/drifting-waddling-pascal.md`
- Prior lesson (local maximum signal): `~/.claude/lessons/2026-04-11-issue-96-reader-adoption.md`