### PR TITLE
feat: v2.8.0 — Claude Code Architecture Insights (#113, #114, #115, #116)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.7.1",
+      "version": "2.8.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.8.0 — Claude Code Architecture Insights (2026-04-13)
+
+Production patterns from Anthropic's Claude Code internals — reverse-engineered in ["Claude Code from Source"](https://github.com/alejandrobalderas/claude-code-from-source) (Alejandro Balderas, 18-chapter architectural analysis of the March 2026 npm source map leak) — adapted into 4 existing skills as workflow guidance. All changes are skill-level guidance additions; no runtime hooks, no new files, no new dependencies.
+
+### Added
+
+- **`/build-brief` step 6 "Context survival"** ([#114](https://github.com/pitimon/8-habit-ai-dev/issues/114)) — guidance for briefs that survive Claude Code's 4-layer context compression pipeline. Recommends: front-load critical info, keep briefs under ~4,000 tokens, stable-first ordering for prompt cache stability. Inspired by Ch5 (Agent Loop) and Ch17 (Performance).
+- **`/design` step 5 "Identify sticky decisions"** ([#116](https://github.com/pitimon/8-habit-ai-dev/issues/116)) — rework-level classification table (Sticky >50% / Semi-sticky 10-50% / Flexible <10%). Decisions marked STICKY require a new `/design` cycle to change. Inspired by Ch17 sticky boolean latches for prompt cache stability. Maps to H2 (Begin with End in Mind).
+- **`/reflect` Step 7 "Consolidation check" + `/reflect consolidate` argument** ([#113](https://github.com/pitimon/8-habit-ai-dev/issues/113)) — nudges when lesson files exceed 10; new consolidate mode runs 4-phase cycle (Orient → Gather → Consolidate → Prune) with human approval gate before deletions. Inspired by Ch11 auto-dream memory consolidation. Added Bash to allowed-tools for prune phase.
+- **`/breakdown` step 5 "Token-efficient parallel design"** ([#115](https://github.com/pitimon/8-habit-ai-dev/issues/115)) — prompt prefix sharing guidance with efficiency table. Parallel tasks sharing context achieve ~90% input token savings via cache hits. Most valuable for 3+ parallel tasks. Inspired by Ch9 (Fork Agents).
+
+### Research
+
+- Deep research review of "Claude Code from Source" (18 chapters, 7 Parts) produced a [research brief](https://github.com/pitimon/8-habit-ai-dev/milestone/13) scoring the book 8.5/10 with live system cross-verification of Ch11 Memory claims (5/8 confirmed against running Claude Code v2.1.104).
+- KAIROS mode and `/dream` command investigated — confirmed as real feature-flagged code (not speculation), but not shipped in external builds as of April 2026.
+
+---
+
 ## v2.7.1 — Review Discipline Refinement (2026-04-11)
 
 Small post-milestone patch on top of v2.7.0. Adds two review-time disciplines to `/review-ai` after a cost/benefit audit against Addy Osmani's `agent-skills` repository (MIT). Only one of six candidate mechanics was imported — the other five were explicitly rejected as duplicative of existing plugin features or out-of-scope for the `8-habit-ai-dev` plugin boundary. Scope deliberately minimal to honor the v2.7.0 "local maximum" framing from `~/.claude/lessons/2026-04-11-issue-96-reader-adoption.md`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.7.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.7.1)
+[![Version](https://img.shields.io/badge/Version-2.8.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.8.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.7.1)
+│   ├── plugin.json                 # Plugin metadata (v2.8.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -380,6 +380,15 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.8.0
+
+**Theme: Claude Code Architecture Insights** — production patterns from Anthropic's Claude Code internals (reverse-engineered by [Alejandro Balderas](https://github.com/alejandrobalderas/claude-code-from-source)) adapted into plugin workflow guidance.
+
+- **`/build-brief` context compression awareness** ([#114](https://github.com/pitimon/8-habit-ai-dev/issues/114)) — new step 6 "Context survival" guides users to front-load critical info, keep briefs under ~4,000 tokens, and order stable content before volatile content. Based on Claude Code's 4-layer context compression pipeline (Ch5) and prompt cache stability pattern (Ch17).
+- **`/design` sticky latch principle** ([#116](https://github.com/pitimon/8-habit-ai-dev/issues/116)) — new step 5 "Identify sticky decisions" with rework-level classification table. Decisions marked STICKY (>50% rework to reverse) require a new `/design` cycle to change, preventing costly mid-session pivots. Inspired by Claude Code's sticky boolean latches for prompt cache stability.
+- **`/reflect` lesson consolidation** ([#113](https://github.com/pitimon/8-habit-ai-dev/issues/113)) — new Step 7 "Consolidation check" nudges when lesson files exceed 10. New `/reflect consolidate` argument runs a 4-phase cycle (Orient → Gather → Consolidate → Prune) inspired by Claude Code's auto-dream memory consolidation. Human approval gate before any deletions.
+- **`/breakdown` fork agent pattern** ([#115](https://github.com/pitimon/8-habit-ai-dev/issues/115)) — new step 5 "Token-efficient parallel design" with prompt prefix sharing guidance. Parallel tasks sharing context achieve ~90% input token savings via cache hits. Most valuable for 3+ parallel tasks.
 
 ## What's New in v2.7.1
 
@@ -537,4 +546,4 @@ MIT
 
 ---
 
-_Version: 2.7.1 | Last updated: 2026-04-11_
+_Version: 2.8.0 | Last updated: 2026-04-13_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.7.1 | **Date**: 2026-04-11 | **Previous**: 2.7.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.8.0 | **Date**: 2026-04-13 | **Previous**: 2.7.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -160,7 +160,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.6.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#92 /reflect Q6 + SKILL-EFFECTIVENESS.md, SIGPIPE CI fix — milestone v2.6.0 CLOSED 5/5)
 - v2.7.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#96 hook-based reader adoption — closes #90 feature loop, 470 → 481 assertions, zero per-skill changes)
 - v2.7.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#110 /review-ai Performance axis + review-tests-first — minimal post-milestone refinement; 5 of 6 agent-skills candidates rejected in cost/benefit audit, honoring v2.7.0 "local maximum" framing)
+- v2.8.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Claude Code Architecture Insights: #113 /reflect consolidation, #114 /build-brief compression awareness, #115 /breakdown fork agent pattern, #116 /design sticky latches — 4 skills enhanced with production patterns from "Claude Code from Source" analysis)
 
 ---
 
-_Updated with each release. Previous: 2.7.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.7.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -4,6 +4,15 @@ Release history for `8-habit-ai-dev`. This page summarizes notable changes; the 
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
 
+## v2.8.0 — Claude Code Architecture Insights (April 2026)
+
+Production patterns from Anthropic's Claude Code internals (reverse-engineered in ["Claude Code from Source"](https://github.com/alejandrobalderas/claude-code-from-source)) adapted into 4 existing skills as workflow guidance.
+
+- **`/build-brief` context compression awareness** ([#114](https://github.com/pitimon/8-habit-ai-dev/issues/114)) — step 6 "Context survival" for briefs that survive the 4-layer compression pipeline
+- **`/design` sticky latch principle** ([#116](https://github.com/pitimon/8-habit-ai-dev/issues/116)) — step 5 "Sticky decisions" with rework-level classification table
+- **`/reflect` lesson consolidation** ([#113](https://github.com/pitimon/8-habit-ai-dev/issues/113)) — Step 7 + `/reflect consolidate` argument with 4-phase dream-inspired cycle
+- **`/breakdown` fork agent pattern** ([#115](https://github.com/pitimon/8-habit-ai-dev/issues/115)) — step 5 "Token-efficient parallel design" with ~90% cache hit guidance
+
 ## v2.7.1 — Review Discipline Refinement (April 2026)
 
 Small post-milestone patch adding two disciplines to `/review-ai` after a cost/benefit audit against `addyosmani/agent-skills` (MIT). Scope deliberately minimal — only one of six candidate mechanics was imported.

--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -51,16 +51,32 @@ next-skill: build-brief
    | T3   | sequential | — | T1, T2 |
    ```
 
-5. **Lazy Parallelism Gate**: Before spawning parallel agents, ask:
+5. **Token-efficient parallel design** (for `parallel-safe` and `parallel-worktree` tasks):
+
+   Claude Code's fork agents share a byte-identical prompt prefix with their parent, achieving ~90% input token savings. Apply this principle when designing parallel tasks:
+
+   - **Maximize shared context**: Group tasks that read the same files and share the same architectural understanding. Their `/build-brief` context sections will overlap, and the shared prefix stays cached.
+   - **Minimize divergence point**: Put the task-specific instruction LAST in the agent prompt. Everything before it is the shared prefix that gets cached.
+   - **Avoid redundant reads**: If 3 agents all need to read `schema.prisma`, include it in the shared brief rather than having each agent read it independently (3x the token cost).
+
+   | Pattern | When | Token Efficiency |
+   |---------|------|-----------------|
+   | Sequential (no sharing) | Tasks depend on each other | 1x (baseline) |
+   | Parallel, independent briefs | Tasks touch different areas | ~1.3x (overhead from duplicate system prompts) |
+   | Parallel, shared prefix brief | Tasks share context | ~0.3x (90% cache hit on shared prefix) |
+
+   This step is most valuable for 3+ parallel tasks. For 2 tasks, the overhead of optimizing the prefix rarely pays off.
+
+6. **Lazy Parallelism Gate**: Before spawning parallel agents, ask:
    - Can I do this sequentially in ≤5 tool calls? If yes, sequential is cheaper.
    - Are the tasks meaningfully disjoint (different files, different concerns)?
    - Will coordinating results add complexity that outweighs time savings?
 
    Parallel agents have overhead: context loading, coordination, result merging. Only parallelize when decomposition is genuinely independent and substantial enough to justify the cost.
 
-6. **Scope guard**: For each task ask — "Is this in scope? Will this prevent future problems (Q2) or is it gold-plating (Q4)?"
+7. **Scope guard**: For each task ask — "Is this in scope? Will this prevent future problems (Q2) or is it gold-plating (Q4)?"
 
-7. **H3 Checkpoint**: "Am I doing what's important, or what's interesting?"
+8. **H3 Checkpoint**: "Am I doing what's important, or what's interesting?"
 
 ## Rule of Thumb
 

--- a/skills/build-brief/SKILL.md
+++ b/skills/build-brief/SKILL.md
@@ -76,13 +76,25 @@ next-skill: review-ai
 
    Skip this step for single-agent sequential work. Required when `/breakdown` classified tasks as `parallel-safe` or `parallel-worktree`.
 
-6. **H5 Checkpoint**: "Have I fully understood the problem before proposing a solution?"
+6. **Context survival** (brief longevity in long sessions):
+
+   Claude Code uses a 4-layer context compression pipeline that progressively removes older content as the context window fills. Briefs written early in a session may be summarized or removed mid-implementation. Structure your brief to survive compression:
+
+   - **Front-load critical info**: Success criteria, key constraints, and file paths go at the TOP of the brief. Compression removes from the middle first.
+   - **Keep briefs under ~4,000 tokens**: Longer briefs are prime compression targets. If your brief exceeds this, split into one brief per implementation phase rather than one mega-brief.
+   - **Stable content first, volatile last**: Architecture decisions and conventions at the top; current task specifics at the bottom. This mirrors Claude Code's own prompt cache stability pattern — stable prefixes stay cached, volatile suffixes get refreshed.
+   - **Self-contained references**: Use "see file X at line Y" instead of pasting large code blocks. Compression can't remove external files.
+
+   Skip this step for quick tasks that will complete within a few exchanges.
+
+7. **H5 Checkpoint**: "Have I fully understood the problem before proposing a solution?"
 
 ## Common Mistakes
 
 - Writing new code without reading what already exists
 - Assuming a utility function exists when it doesn't
 - Duplicating logic that's already implemented elsewhere
+- Writing a 10,000-token mega-brief that gets compressed away mid-session
 
 ## Handoff
 
@@ -102,6 +114,7 @@ next-skill: review-ai
 - [ ] Existing patterns and naming conventions documented in brief
 - [ ] Constraints listed (backward compatibility, file size, performance)
 - [ ] Test approach defined (what to test, TDD if applicable)
+- [ ] Brief is ≤4,000 tokens (or split into per-phase briefs for complex tasks)
 - [ ] Context boundaries defined for parallel tasks (must-know / must-not-know / merge contract)
 
 ## Further Reading

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -36,7 +36,24 @@ next-skill: breakdown
 
 4. **Human must decide**: AI proposes, human disposes. Mark each decision as In-the-Loop.
 
-5. **Article 14 Human-Oversight Checkpoint** (for AI-system designs):
+5. **Identify sticky decisions** (decisions that should not change mid-implementation):
+
+   Some decisions act as **sticky latches** — once set, reversing them mid-session wastes all context built on top of them. Claude Code uses this pattern internally: boolean flags that once true, never revert, because toggling would invalidate the prompt cache (90% cost saving lost).
+
+   For each decision in step 4, ask: **"If we change this after implementation starts, how much rework does it cause?"**
+
+   | Rework Level | Classification | Example |
+   |-------------|----------------|---------|
+   | >50% redo   | **Sticky** — commit now, revisit only via new `/design` cycle | DB choice, auth model, API style |
+   | 10-50% redo | **Semi-sticky** — can adjust but flag the cost | ORM choice, test framework |
+   | <10% redo   | **Flexible** — change freely during implementation | Variable names, UI copy |
+
+   Mark sticky decisions explicitly in the ADR or design doc:
+   > **STICKY**: This decision is load-bearing. Changing it requires re-running `/design`, not patching mid-build.
+
+   This is H2 in practice: define done before starting, including which decisions ARE the definition of done.
+
+6. **Article 14 Human-Oversight Checkpoint** (for AI-system designs):
 
    If the system being designed is an **AI system that may target the EU market** (or any high-risk AI system regardless of market), confirm the design satisfies EU AI Act Article 14 capabilities. Answer for each:
 
@@ -54,12 +71,12 @@ next-skill: breakdown
    >
    > 🔗 **Three Loops — use claude-governance for the formal model**: The 5-capability table above is a lightweight design-time sanity check. For **formal Three Loops classification per decision** (Out-of / On-the / In-the-Loop with consequence-based gating for irreversible ops), install [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) alongside this plugin. The Three Loops Decision Model and its ADR-002 live in governance by design — `8-habit-ai-dev` references it rather than reimplementing (see `CLAUDE.md` → Plugin Boundary). Three Loops originates from human-autonomy teaming literature (Endsley 1999, DARPA) — it is a design pattern that _satisfies_ EU AI Act Article 14 ¶4(a-e), not a term used by EU law itself. Cite Article 14 ¶ refs in audits, not Three Loops labels.
 
-6. **Document as ADR** if the decision is:
+7. **Document as ADR** if the decision is:
    - Hard to reverse
    - Affects >3 files
    - Changes public API
 
-7. **H8 Checkpoint**: "Do I understand WHY we're building it this way, not just WHAT?"
+8. **H8 Checkpoint**: "Do I understand WHY we're building it this way, not just WHAT?"
 
 ## Handoff
 

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -6,8 +6,8 @@ description: >
   including a skill-effectiveness signal that feeds SKILL-EFFECTIVENESS.md.
   Maps to H7 (Sharpen the Saw — invest in capability, not just output).
 user-invocable: true
-argument-hint: "[task or feature just completed]"
-allowed-tools: ["Read", "Glob", "Grep", "Write"]
+argument-hint: "[task just completed] or 'consolidate' to merge lessons"
+allowed-tools: ["Read", "Glob", "Grep", "Write", "Bash"]
 prev-skill: any
 next-skill: none
 ---
@@ -81,6 +81,40 @@ After the 6 questions are answered, persist the reflection as a lesson file for 
 4. **Confirm**: Print a one-line confirmation: `Lesson saved: ~/.claude/lessons/<filename>`
 5. **Graceful failure**: If the write fails (permissions, disk full), warn the user but do NOT block the reflection output. The conversation-level reflection is more valuable than persistence.
 
+## Step 7: Consolidation check (periodic)
+
+After saving the lesson file, check if lessons need consolidation. Inspired by Claude Code's auto-dream 4-phase consolidation pattern (Orient → Gather → Consolidate → Prune) — applied here as manual guidance, not automation.
+
+1. **Count lessons**: `Glob ~/.claude/lessons/*.md`
+2. **If count ≤ 10**: Skip — not enough lessons to consolidate yet.
+3. **If count > 10**: Print a consolidation nudge:
+
+   > **Consolidation suggested** — You have [N] lesson files. Consider running:
+   > `/reflect consolidate` to merge duplicates and prune stale lessons.
+
+4. **If the user runs `/reflect consolidate`** (argument = "consolidate"):
+
+   Run the 4-phase cycle on `~/.claude/lessons/`:
+
+   | Phase | Action | Tools |
+   |-------|--------|-------|
+   | **Orient** | Glob all lesson files, Read frontmatter (first 10 lines each) to build inventory | Glob, Read |
+   | **Gather** | Group lessons by `tags` overlap and `project` match | Grep |
+   | **Consolidate** | For each group with 2+ lessons: propose a merged lesson that combines insights, resolves contradictions, and keeps the most recent "do differently" actions. Present merge plan to user for approval before writing. | Read |
+   | **Prune** | After user approves merges: delete superseded lesson files, keep merged files | Bash |
+
+   **Human approval gate**: The consolidate phase MUST show the merge plan and get explicit user approval before deleting any files. This is In-the-Loop per governance — deletion is irreversible.
+
+   Output after consolidation:
+   ```
+   ## Consolidation Report
+   **Before**: [N] lesson files
+   **After**: [M] lesson files
+   **Merged**: [list of merged groups]
+   **Pruned**: [list of deleted files]
+   **Kept unchanged**: [list]
+   ```
+
 ## When to Skip
 
 - Task took less than 15 minutes
@@ -93,6 +127,7 @@ After the 6 questions are answered, persist the reflection as a lesson file for 
 - [ ] Action item has an owner and deadline (or explicitly "none needed")
 - [ ] Skill effectiveness signal captured (Q6) — up to one "most useful" and one "least useful/confusing" skill, or "n/a"
 - [ ] Lesson file persisted to `~/.claude/lessons/` (or warning printed if write failed)
+- [ ] Consolidation check performed if lesson count > 10
 - [ ] Took no more than 5 minutes
 
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h7-sharpen-saw.md` for the full H7 principle and examples.


### PR DESCRIPTION
## Summary

Production patterns from Anthropic's Claude Code internals — reverse-engineered in ["Claude Code from Source"](https://github.com/alejandrobalderas/claude-code-from-source) (Alejandro Balderas) — adapted into 4 existing skills as workflow guidance.

- **`/build-brief` context compression awareness** (#114) — step 6 "Context survival" for briefs that survive the 4-layer compression pipeline
- **`/design` sticky latch principle** (#116) — step 5 "Sticky decisions" with rework-level classification (Sticky >50% / Semi-sticky / Flexible)
- **`/reflect` lesson consolidation** (#113) — Step 7 + `/reflect consolidate` with dream-inspired 4-phase cycle + human approval gate
- **`/breakdown` fork agent pattern** (#115) — step 5 "Token-efficient parallel design" with ~90% cache hit guidance

### Research basis

Deep `/research` review (Deep mode) of the 18-chapter book scored 8.5/10:
- Ch11 Memory claims cross-verified against live system (5/8 confirmed)
- KAIROS mode confirmed as real feature-flagged code, not shipped
- 10 sources verified by research-verifier agent (7 confirmed, 1 dead, 2 inaccessible)

### Changes per file

| File | Lines | Change |
|------|-------|--------|
| `skills/build-brief/SKILL.md` | 113→128 | +step 6, +1 DoD item, +1 common mistake |
| `skills/design/SKILL.md` | 88→107 | +step 5 sticky decisions, renumbered 6→7→8 |
| `skills/reflect/SKILL.md` | 100→137 | +Step 7 consolidation, +Bash allowed-tool, +argument-hint |
| `skills/breakdown/SKILL.md` | 98→117 | +step 5 token-efficient parallel, renumbered 6→7→8 |
| Version files (4) | — | 2.7.1→2.8.0 |
| CHANGELOG.md, README.md, SELF-CHECK.md, wiki/Changelog.md | — | v2.8.0 release notes |

### Validation

All 4 validators pass (472 assertions, 0 failures):
- `validate-structure.sh`: 238 PASS
- `test-skill-graph.sh`: 57 PASS  
- `validate-content.sh`: 177 PASS

## Test plan

- [ ] CI passes (validate + linkcheck workflows)
- [ ] `validate-structure.sh` — 238 assertions green
- [ ] `test-skill-graph.sh` — 57 assertions green, no broken edges
- [ ] `validate-content.sh` — 177 assertions green, docs freshness OK
- [ ] `/build-brief test` shows "Context survival" step
- [ ] `/design test` shows "Sticky decisions" step
- [ ] `/reflect test` with >10 lessons shows consolidation nudge
- [ ] `/breakdown test` shows "Token-efficient parallel design" section

Closes #113, #114, #115, #116