### PR TITLE
feat(requirements): add interview protocol template (#118)

### DIFF
--- a/docs/wiki/Step-1-Requirements.md
+++ b/docs/wiki/Step-1-Requirements.md
@@ -20,10 +20,10 @@ Define what "done" looks like before touching code. A PRD you can verify against
 
 ## Process
 
-1. Clarify intent — What · Why · Who
+1. **Interview** — follow the [Interview Protocol](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/templates/interview-protocol.md) to discover requirements through structured conversation. Adaptive depth: Quick (3 questions) for small scope, Standard (5) by default, Deep (7+) for complex features
 2. Read existing `CLAUDE.md`, `PRD.md`, `DOMAIN.md`, `README.md` — don't duplicate
 3. Draft PRD summary (10–20 lines)
-4. Define 3–5 verifiable success criteria
+4. Define 3–5 verifiable success criteria in EARS notation
 5. List what's **out of scope** explicitly
 
 ## Output

--- a/guides/templates/interview-protocol.md
+++ b/guides/templates/interview-protocol.md
@@ -1,0 +1,85 @@
+# Interview Protocol for Requirements Discovery
+
+## Purpose
+
+Guide structured conversation to surface requirements before formalizing them in EARS notation.
+
+## Adaptive Depth
+
+- **Quick** (3 core questions): When scope is small or user has clear vision
+- **Standard** (5 questions): Default for most features
+- **Deep** (7+ questions): Complex features, unclear scope, multiple stakeholders
+
+## Core Discovery Questions
+
+### Q1: What problem are you solving?
+
+**Ask**: "What specific problem or need does this address? What happens today without it?"
+**Listen for**: Pain points, workarounds, frequency of the problem
+**Red flag**: If user describes a solution instead of a problem — probe deeper
+
+### Q2: Who is affected?
+
+**Ask**: "Who are the primary users? Are there secondary stakeholders?"
+**Listen for**: User roles, personas, permission levels, edge-case users
+**Red flag**: "Everyone" — push for specifics
+
+### Q3: What does success look like?
+
+**Ask**: "If this ships perfectly, what's different? How would you demo it?"
+**Listen for**: Observable behaviors, measurable outcomes, specific scenarios
+**Red flag**: Vague outcomes like "it works better" — ask for a concrete example
+
+### Q4: What are the boundaries?
+
+**Ask**: "What is explicitly OUT of scope? What should this NOT do?"
+**Listen for**: Adjacent features to exclude, performance limits, platform constraints
+**Red flag**: No boundaries stated — every feature has limits, probe for them
+
+### Q5: What exists already?
+
+**Ask**: "Is there existing code, APIs, or patterns we should build on or avoid?"
+**Listen for**: Technical constraints, legacy systems, established patterns, tech debt
+**Red flag**: Assumptions about architecture — verify with codebase
+
+### Q6 (Deep): What could go wrong?
+
+**Ask**: "What are the riskiest parts? What would make this fail?"
+**Listen for**: Security concerns, performance bottlenecks, integration risks, data integrity
+**Red flag**: "Nothing" — every feature has risks
+
+### Q7 (Deep): How will we know it's done?
+
+**Ask**: "What specific tests or checks would prove this works?"
+**Listen for**: Acceptance criteria, edge cases, regression concerns
+**Red flag**: No testable criteria — requirements aren't ready yet
+
+## Stop Conditions
+
+Stop the interview when you can:
+
+1. Write 3+ EARS criteria (Event/Action/Response/State)
+2. Define clear scope boundaries (in-scope AND out-of-scope)
+3. Identify the primary user and their success scenario
+4. Name at least one risk or constraint
+
+If you can't do all 4, ask more questions.
+
+## "Listen For" Signal Reference
+
+| Signal | Meaning | Action |
+|--------|---------|--------|
+| Natural boundaries | User describes distinct components | Map to potential modules/phases |
+| Ordering intuition | "First we need X, then Y" | Capture dependency chain |
+| Uncertainty | "I'm not sure about..." | Flag for /design discussion |
+| Existing context | "We already have..." | Read that code before specifying |
+| Scope creep | "And also..." repeated | Gently redirect to boundaries (Q4) |
+
+## Handoff to EARS
+
+After the interview, use findings to write EARS criteria:
+
+- **Event**: "When [trigger from Q1/Q3]..."
+- **Action**: "The system shall [behavior from Q3]..."
+- **Response**: "[Observable outcome from Q3/Q7]..."
+- **State**: "While [condition from Q4/Q5]..."

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -16,11 +16,14 @@ next-skill: design
 
 ## Process
 
-1. **Clarify intent**: Ask the user (or derive from context):
-   - What are we building?
-   - Why are we building it?
-   - Who is it for?
-   - What is in scope / out of scope?
+1. **Discover requirements**: Before writing EARS criteria, follow the Interview Protocol (loaded below) to discover requirements through structured conversation. Use adaptive depth — Quick (3 questions) for small scope, Standard (5) by default, Deep (7+) for complex features.
+
+   Core questions to clarify:
+   - What problem are we solving? (not what solution — the problem)
+   - Who is affected?
+   - What does success look like?
+   - What are the boundaries? (in scope / out of scope)
+   - What exists already?
 
 2. **Check existing docs**: Read `CLAUDE.md`, `PRD.md`, `DOMAIN.md`, or `README.md` if they exist — don't duplicate what's already defined.
 
@@ -97,4 +100,5 @@ next-skill: design
 See [Step 1 wiki page](../../docs/wiki/Step-1-Requirements.md) for deeper walkthrough, examples, and common pitfalls.
 
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/prd-template.md` for the output template.
+Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/interview-protocol.md` for the structured discovery protocol.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h2-begin-with-end.md` for the full H2 principle and examples.


### PR DESCRIPTION
## Summary

- Adds `guides/templates/interview-protocol.md` — structured discovery protocol with 7 questions, adaptive depth (Quick/Standard/Deep), "listen for" signals, stop conditions, and EARS handoff
- Updates `/requirements` SKILL.md with Load directive referencing the protocol
- Updates Step-1 wiki page to mention the new interview protocol

Inspired by [piercelamb/deep-project](https://github.com/piercelamb/deep-project) interview protocol pattern. Cross-verified (14/17) and advisor-confirmed as "cleanest win."

Closes #118

## Test plan

- [x] `tests/validate-structure.sh` passes (238 PASS)
- [x] `tests/validate-content.sh` passes (177 PASS)
- [ ] Manual: invoke `/requirements` and confirm interview protocol is loaded
- [ ] Review: interview questions cover problem, users, success, boundaries, existing code, risks, done criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)