### PR TITLE
feat(hooks): workflow step awareness in session hook (#119)

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -80,6 +80,40 @@ else
 💡 **No habit profile detected** — run \`/calibrate\` to personalize guidance to your maturity level (H8)."
 fi
 
+# Workflow step awareness — detect highest completed step and suggest next skill
+WORKFLOW_HINT=""
+if [ "${HABIT_QUIET:-0}" != "1" ]; then
+  HIGHEST_STEP=0
+
+  # Check each step — use compgen (bash builtin) to test globs without ls exit-code issues
+  has_glob() { compgen -G "$1" >/dev/null 2>&1; }
+
+  # Check for Step 4 artifacts (build brief) — highest priority
+  if has_glob "*-brief.md" || has_glob "*build-brief*"; then
+    HIGHEST_STEP=4
+  # Check for Step 3 artifacts (breakdown/tasks)
+  elif has_glob "*-tasks.md" || has_glob "*-breakdown.md" || has_glob "*task-list*"; then
+    HIGHEST_STEP=3
+  # Check for Step 2 artifacts (design/architecture)
+  elif has_glob "*-design.md" || has_glob "*-architecture.md" || has_glob "*ADR*"; then
+    HIGHEST_STEP=2
+  # Check for Step 1 artifacts (PRD/requirements)
+  elif has_glob "*-prd.md" || has_glob "*-requirements.md" || has_glob "*PRD*"; then
+    HIGHEST_STEP=1
+  fi
+
+  if [ "$HIGHEST_STEP" -gt 0 ]; then
+    case $HIGHEST_STEP in
+      1) NEXT_SKILL="/design" ;;
+      2) NEXT_SKILL="/breakdown" ;;
+      3) NEXT_SKILL="/build-brief" ;;
+      4) NEXT_SKILL="/review-ai" ;;
+    esac
+    WORKFLOW_HINT="
+📍 Workflow: artifacts suggest Step ${HIGHEST_STEP} done — next: \`${NEXT_SKILL}\`"
+  fi
+fi
+
 cat <<EOF
 ## 8-Habit AI Dev Active (v${VERSION})
 
@@ -96,7 +130,7 @@ cat <<EOF
 **Core 5** (80% of daily work): \`/requirements\` · \`/review-ai\` · \`/cross-verify\` · \`/research\` · \`/reflect\`
 **Assessment**: \`/workflow\` · \`/whole-person-check\` · \`/security-check\` · \`/ai-dev-log\`
 **Onboarding**: \`/using-8-habits\` (decision tree) · \`/calibrate\` (maturity profile)
-**Compliance**: \`/eu-ai-act-check\` (EU AI Act, migration to claude-governance planned)${PROFILE_MSG}
+**Compliance**: \`/eu-ai-act-check\` (EU AI Act, migration to claude-governance planned)${WORKFLOW_HINT}${PROFILE_MSG}
 
 _Silence this reminder: \`export HABIT_QUIET=1\`_
 EOF

--- a/tests/test-verbosity-hook.sh
+++ b/tests/test-verbosity-hook.sh
@@ -263,6 +263,76 @@ else
 fi
 echo ""
 
+# --- Workflow step awareness: artifact detection ---
+echo "--- Workflow step awareness: artifact detection ---"
+
+# Absolute path to hook for use in subshells that cd elsewhere
+HOOK_ABS="$(cd "$(dirname "$HOOK")" && pwd)/$(basename "$HOOK")"
+
+# Helper: run hook in a tmpdir with given files, assert output contains/excludes substring
+run_workflow_case() {
+  local case_name="$1"
+  local expect_mode="$2"       # "contains" or "excludes"
+  local expected_substring="$3"
+  shift 3
+  # Remaining args are files to create (may be empty)
+
+  local workdir
+  workdir=$(mktemp -d)
+
+  for f in "$@"; do
+    touch "$workdir/$f"
+  done
+
+  local output
+  output=$(cd "$workdir" && HOME="$TMPHOME" bash "$HOOK_ABS" 2>&1) || {
+    fail "$case_name — hook exited non-zero"
+    rm -rf "$workdir"
+    return
+  }
+  rm -rf "$workdir"
+
+  if [ "$expect_mode" = "contains" ]; then
+    if echo "$output" | grep -qF "$expected_substring"; then
+      pass "$case_name"
+    else
+      fail "$case_name — expected substring not found: \"$expected_substring\""
+      echo "    got (last 3 lines): $(echo "$output" | tail -3)"
+    fi
+  else
+    if echo "$output" | grep -qF "$expected_substring"; then
+      fail "$case_name — should NOT contain: \"$expected_substring\""
+    else
+      pass "$case_name"
+    fi
+  fi
+}
+
+# Ensure a profile exists so hook doesn't exit early on HABIT_QUIET
+printf '%s' "$INTERDEPENDENCE_PROFILE" > "$TMPHOME/.claude/habit-profile.md"
+
+run_workflow_case "PRD artifact → Step 1" "contains" "Step 1 done" "feature-prd.md"
+run_workflow_case "design artifact → Step 2" "contains" "Step 2 done" "feature-design.md"
+run_workflow_case "tasks artifact → Step 3" "contains" "Step 3 done" "feature-tasks.md"
+run_workflow_case "brief artifact → Step 4" "contains" "Step 4 done" "feature-brief.md"
+
+run_workflow_case "no artifacts → no workflow line" "excludes" "Workflow:"
+
+run_workflow_case "highest step wins (multiple artifacts)" "contains" "Step 3 done" \
+  "feature-prd.md" "feature-design.md" "feature-tasks.md"
+
+# HABIT_QUIET suppresses workflow hint
+workdir_quiet=$(mktemp -d)
+touch "$workdir_quiet/feature-prd.md"
+quiet_wf_output=$(cd "$workdir_quiet" && HOME="$TMPHOME" HABIT_QUIET=1 bash "$HOOK_ABS" 2>&1 || true)
+rm -rf "$workdir_quiet"
+if echo "$quiet_wf_output" | grep -qF "Workflow:"; then
+  fail "HABIT_QUIET=1 should suppress workflow hint"
+else
+  pass "HABIT_QUIET=1 suppresses workflow hint"
+fi
+echo ""
+
 # --- Token budget check (≤300 per CLAUDE.md) ---
 echo "--- Token budget check ---"
 printf '%s' "$INTERDEPENDENCE_PROFILE" > "$TMPHOME/.claude/habit-profile.md"


### PR DESCRIPTION
## Summary

- Extends `hooks/session-start.sh` with artifact detection (PRD, design, tasks, brief)
- Uses `compgen -G` (bash builtin) for reliable glob matching
- Prints `📍 Workflow: artifacts suggest Step N done — next: /skill-name` when artifacts found
- Silent when no artifacts detected (no noise)
- Respects `HABIT_QUIET=1` opt-out
- Stays within 300-token session hook budget (~192 tokens with hint)
- Adds 7 new test cases to `test-verbosity-hook.sh`

Inspired by [deep-project](https://github.com/piercelamb/deep-project) file-based state detection, reframed as lightweight awareness per advisor feedback.

Closes #119

## Test plan

- [x] `tests/test-verbosity-hook.sh` passes (19/19 including 7 new cases)
- [x] `tests/validate-structure.sh` passes (238 PASS)
- [ ] Manual: create `test-prd.md` in a directory, start session, verify hint appears
- [ ] Manual: verify no hint when directory is clean
- [ ] Manual: verify `HABIT_QUIET=1` suppresses hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)