### PR TITLE
feat(skills): machine-readable structured output blocks (#120)

### DIFF
--- a/guides/structured-output-protocol.md
+++ b/guides/structured-output-protocol.md
@@ -1,0 +1,96 @@
+# Structured Output Protocol
+
+## Purpose
+
+Enable cross-skill data handoff via machine-readable blocks embedded in markdown output. Blocks are HTML comments — invisible when rendered, parseable by consuming skills.
+
+## Format
+
+```
+<!-- SKILL_OUTPUT:<skill-name>
+key: value
+list_key:
+  - "item 1"
+  - "item 2"
+END_SKILL_OUTPUT -->
+```
+
+### Rules
+
+1. **Block delimiters**: `<!-- SKILL_OUTPUT:<name>` opens, `END_SKILL_OUTPUT -->` closes
+2. **Content format**: YAML-like key-value pairs (human-readable, not strict YAML)
+3. **Placement**: At the END of skill output, after all human-readable content
+4. **Optional**: Skills SHOULD emit blocks but output remains valid without them
+5. **Invisible**: HTML comments don't render in markdown viewers — zero visual impact
+
+## Producer Skills
+
+### `/requirements` → `SKILL_OUTPUT:requirements`
+
+```
+<!-- SKILL_OUTPUT:requirements
+ears_count: 5
+ears_criteria:
+  - "When user submits login form, system shall validate credentials"
+  - "While session is active, system shall refresh token every 15min"
+scope_in: "Authentication with email/password"
+scope_out: "RBAC, OAuth, SSO"
+primary_user: "End user"
+risks:
+  - "Token expiry during long operations"
+  - "Concurrent session handling"
+success_criteria_count: 3
+END_SKILL_OUTPUT -->
+```
+
+### `/breakdown` → `SKILL_OUTPUT:breakdown`
+
+```
+<!-- SKILL_OUTPUT:breakdown
+task_count: 5
+tasks:
+  - "01: Create auth middleware"
+  - "02: Add input validation"
+  - "03: Implement token refresh"
+  - "04: Write unit tests"
+  - "05: Update API docs"
+dependencies:
+  - "03 depends on 01"
+estimated_complexity: "medium"
+END_SKILL_OUTPUT -->
+```
+
+### `/review-ai` → `SKILL_OUTPUT:review`
+
+```
+<!-- SKILL_OUTPUT:review
+files_reviewed: 4
+findings_critical: 0
+findings_high: 1
+findings_medium: 3
+findings_low: 2
+pass: true
+test_coverage_checked: true
+security_checked: true
+END_SKILL_OUTPUT -->
+```
+
+## Consumer Skills
+
+### `/cross-verify` reads all blocks
+
+When `/cross-verify` runs, it should:
+
+1. Search for `<!-- SKILL_OUTPUT:` blocks in recent files (PRD, task list, review report) in the current directory
+2. If blocks found, auto-populate evidence for relevant questions:
+   - **Q4** (success criteria): Check `ears_count > 0` and `success_criteria_count > 0` from requirements block
+   - **Q5** (test plan): Check `test_coverage_checked: true` from review block
+   - **Q8** (scope creep): Compare `task_count` from breakdown vs `ears_count` from requirements — flag if tasks >> criteria
+3. If no blocks found, fall back to manual assessment (current behavior)
+4. Report which blocks were found and which were missing
+
+## Adoption
+
+- Blocks are **opt-in** — skills work fine without them
+- Consuming skills **degrade gracefully** — missing blocks = manual check
+- No Python, no parsing scripts — Claude reads blocks directly as text

--- a/guides/templates/prd-template.md
+++ b/guides/templates/prd-template.md
@@ -38,3 +38,15 @@ Output template for `/requirements` (Step 1).
 ## Open Questions
 
 - [Anything unresolved that needs human decision]
+
+<!-- SKILL_OUTPUT:requirements
+ears_count: [N]
+ears_criteria:
+  - "[criterion 1]"
+scope_in: "[in-scope description]"
+scope_out: "[out-of-scope description]"
+primary_user: "[user role]"
+risks:
+  - "[risk 1]"
+success_criteria_count: [N]
+END_SKILL_OUTPUT -->

--- a/guides/templates/task-list-template.md
+++ b/guides/templates/task-list-template.md
@@ -23,3 +23,12 @@ Output template for `/breakdown` (Step 3).
 - Total tasks: [N]
 - Total files affected: [N] (if >15, consider splitting the feature)
 - Estimated complexity: [small | medium | large]
+
+<!-- SKILL_OUTPUT:breakdown
+task_count: [N]
+tasks:
+  - "[task 1]"
+dependencies:
+  - "[dependency description]"
+estimated_complexity: "[low|medium|high]"
+END_SKILL_OUTPUT -->

--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -104,6 +104,24 @@ next-skill: build-brief
 - [ ] No task touches more than 5 files
 - [ ] Orchestration classification assigned to each task (sequential/parallel-safe/parallel-worktree)
 
+## Structured Output Block
+
+After writing the task list, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check scope alignment:
+
+```
+<!-- SKILL_OUTPUT:breakdown
+task_count: [N]
+tasks:
+  - "[task 1]"
+  - "[task 2]"
+dependencies:
+  - "[dependency description]"
+estimated_complexity: "[low|medium|high]"
+END_SKILL_OUTPUT -->
+```
+
+Place this at the very end of the task list output, after all human-readable content.
+
 ## Further Reading
 
 See [Step 3 wiki page](../../docs/wiki/Step-3-Breakdown.md) for deeper walkthrough, examples, and common pitfalls.
@@ -111,3 +129,4 @@ See [Step 3 wiki page](../../docs/wiki/Step-3-Breakdown.md) for deeper walkthrou
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/task-list-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h3-first-things-first.md` for the full H3 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/orchestration-patterns.md` for worktree isolation and context boundary patterns.
+Load `${CLAUDE_PLUGIN_ROOT}/guides/structured-output-protocol.md` for the structured output block format specification.

--- a/skills/cross-verify/SKILL.md
+++ b/skills/cross-verify/SKILL.md
@@ -26,6 +26,19 @@ next-skill: any
 - Formatting or linting changes
 - Dependency version bumps with passing CI
 
+## Auto-Detection (Structured Output Blocks)
+
+Before running the manual checklist, search for structured output blocks in the current directory:
+
+1. Glob for `*-prd.md`, `*-requirements.md`, `*-tasks.md`, `*-breakdown.md`, `*-review.md` files
+2. Read each file and look for `<!-- SKILL_OUTPUT:` blocks
+3. If found, pre-populate evidence for:
+   - **Q4**: Extract `ears_count` and `success_criteria_count` from requirements block
+   - **Q5**: Extract `test_coverage_checked` from review block
+   - **Q8**: Compare `task_count` vs `ears_count` for scope alignment — flag if tasks >> criteria
+4. Mark auto-populated answers with `✓A` (auto-detected) confidence level
+5. If no blocks found, proceed with manual assessment (no change to current behavior)
+
 ## Process
 
 Run through this checklist. Flag any item that fails.
@@ -71,6 +84,7 @@ For critical decisions (architecture, security, production deploys), mark each P
 | Verified   | ✓V   | Evidence checked — test ran, code read, diff reviewed     | "Read the function at api.ts:42, confirmed input validation exists" |
 | Inferred   | ✓I   | Reasonable belief based on context, not directly verified | "Codebase uses Zod throughout, likely validated here too"           |
 | Unverified | ✓U   | Assumption — should verify before proceeding              | "Assuming tests exist but haven't checked coverage"                 |
+| Auto-detected | ✓A | Evidence extracted from structured output block           | "Parsed 5 EARS criteria from PRD structured block"                 |
 
 **Scoring**: All Pass levels count toward the score, but ✓U items are flagged as verification debt.
 
@@ -138,3 +152,4 @@ Domain questions are scored separately and do not affect the main 17-question sc
 
 Load `${CLAUDE_PLUGIN_ROOT}/guides/cross-verification.md` for detailed guidance on each question.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards when using confidence levels.
+Load `${CLAUDE_PLUGIN_ROOT}/guides/structured-output-protocol.md` for the structured output block format specification.

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -95,6 +95,27 @@ next-skill: design
 - [ ] Scope boundaries clear — both "in scope" and "out of scope" listed
 - [ ] Stakeholder/target user identified
 
+## Structured Output Block
+
+After writing the PRD, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check coverage:
+
+```
+<!-- SKILL_OUTPUT:requirements
+ears_count: [N]
+ears_criteria:
+  - "[criterion 1]"
+  - "[criterion 2]"
+scope_in: "[in-scope description]"
+scope_out: "[out-of-scope description]"
+primary_user: "[user role]"
+risks:
+  - "[risk 1]"
+success_criteria_count: [N]
+END_SKILL_OUTPUT -->
+```
+
+Place this at the very end of the PRD output, after all human-readable content.
+
 ## Further Reading
 
 See [Step 1 wiki page](../../docs/wiki/Step-1-Requirements.md) for deeper walkthrough, examples, and common pitfalls.
@@ -102,3 +123,4 @@ See [Step 1 wiki page](../../docs/wiki/Step-1-Requirements.md) for deeper walkth
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/prd-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/interview-protocol.md` for the structured discovery protocol.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h2-begin-with-end.md` for the full H2 principle and examples.
+Load `${CLAUDE_PLUGIN_ROOT}/guides/structured-output-protocol.md` for the structured output block format specification.

--- a/skills/review-ai/SKILL.md
+++ b/skills/review-ai/SKILL.md
@@ -144,6 +144,25 @@ If Heart or Spirit scores lag Body/Mind by ≥2 categories, add:
 - [ ] Every finding cites specific evidence (file:line, test output, or diff)
 - [ ] Summary table shows findings count for all four categories (Security, Quality, Performance, Completeness)
 
+## Structured Output Block
+
+After rendering the review verdict, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check review coverage:
+
+```
+<!-- SKILL_OUTPUT:review
+files_reviewed: [N]
+findings_critical: [N]
+findings_high: [N]
+findings_medium: [N]
+findings_low: [N]
+pass: [true|false]
+test_coverage_checked: [true|false]
+security_checked: [true|false]
+END_SKILL_OUTPUT -->
+```
+
+Place this at the very end of the review report, after all human-readable content.
+
 ## Further Reading
 
 See [Step 5 wiki page](../../docs/wiki/Step-5-Review-AI.md) for deeper walkthrough, examples, and common pitfalls.
@@ -153,3 +172,4 @@ See [Step 5 wiki page](../../docs/wiki/Step-5-Review-AI.md) for deeper walkthrou
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/review-report-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h4-win-win.md` for the full H4 principle and examples.
 Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards (the 12 commandments).
+Load `${CLAUDE_PLUGIN_ROOT}/guides/structured-output-protocol.md` for the structured output block format specification.


### PR DESCRIPTION
## Summary

- Adds `guides/structured-output-protocol.md` — format spec for `SKILL_OUTPUT` HTML comment blocks
- **Producers**: `/requirements`, `/breakdown`, `/review-ai` now emit structured blocks after output
- **Consumer**: `/cross-verify` reads blocks to auto-populate Q4, Q5, Q8 evidence (new `✓A` confidence level)
- Templates (`prd-template.md`, `task-list-template.md`) updated with block placeholders
- Blocks are opt-in, invisible in rendered markdown, graceful degradation when missing

Upgraded from discussion to enhancement based on memforge evidence:
- deskcon #168536: user needed 3 cross-verify attempts due to incomplete manual reviews
- deskcon #168537: 23-gap plan only covered 4/8 habits
- ai-trading-agent #241409: cross-verify 11/16 missed DoD and test plan checks

Closes #120

## Files changed (7)

- NEW: `guides/structured-output-protocol.md`
- EDIT: `skills/requirements/SKILL.md` (structured block + Load directive)
- EDIT: `skills/breakdown/SKILL.md` (structured block + Load directive)
- EDIT: `skills/review-ai/SKILL.md` (structured block + Load directive)
- EDIT: `skills/cross-verify/SKILL.md` (auto-detection section + ✓A confidence + Load directive)
- EDIT: `guides/templates/prd-template.md` (block placeholder)
- EDIT: `guides/templates/task-list-template.md` (block placeholder)

## Test plan

- [x] `tests/validate-structure.sh` passes (238 PASS)
- [x] `tests/validate-content.sh` passes (177 PASS)
- [ ] Manual: run `/requirements` → verify SKILL_OUTPUT block emitted
- [ ] Manual: run `/breakdown` → verify SKILL_OUTPUT block emitted
- [ ] Manual: run `/cross-verify` → verify auto-detection of blocks with ✓A evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)