### PR TITLE
feat(skills): add structured output block to /design and close 8-habit gaps

### DIFF
--- a/skills/cross-verify/SKILL.md
+++ b/skills/cross-verify/SKILL.md
@@ -36,6 +36,9 @@ Before running the manual checklist, search for structured output blocks in the 
    - **Q4**: Extract `ears_count` and `success_criteria_count` from requirements block
    - **Q5**: Extract `test_coverage_checked` from review block
    - **Q8**: Compare `task_count` vs `ears_count` for scope alignment — flag if `task_count > ears_count * 3`
+   - **Q14**: Extract `decision_count` from design block — flag if only 1 option was presented (no third alternative considered)
+   - **Q16**: Extract `sticky_decisions` from design block — flag if 0 sticky decisions in a design with >3 decisions (WHY not captured)
+   - **Q4**: Cross-check `decision_count` against requirements `success_criteria_count` — flag if decisions don't cover all criteria
 4. Mark auto-populated answers with `✓A` (auto-detected) confidence level
 5. If no blocks found, proceed with manual assessment (no change to current behavior)
 
@@ -79,12 +82,12 @@ Run through this checklist. Flag any item that fails.
 
 For critical decisions (architecture, security, production deploys), mark each Pass with a confidence level. Inspired by Feynman's honest uncertainty principle — separate what you verified from what you assumed.
 
-| Level      | Mark | Meaning                                                   | Example                                                             |
-| ---------- | ---- | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| Verified   | ✓V   | Evidence checked — test ran, code read, diff reviewed     | "Read the function at api.ts:42, confirmed input validation exists" |
-| Inferred   | ✓I   | Reasonable belief based on context, not directly verified | "Codebase uses Zod throughout, likely validated here too"           |
-| Unverified | ✓U   | Assumption — should verify before proceeding              | "Assuming tests exist but haven't checked coverage"                 |
-| Auto-detected | ✓A | Evidence extracted from structured output block           | "Parsed 5 EARS criteria from PRD structured block"                 |
+| Level         | Mark | Meaning                                                   | Example                                                             |
+| ------------- | ---- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| Verified      | ✓V   | Evidence checked — test ran, code read, diff reviewed     | "Read the function at api.ts:42, confirmed input validation exists" |
+| Inferred      | ✓I   | Reasonable belief based on context, not directly verified | "Codebase uses Zod throughout, likely validated here too"           |
+| Unverified    | ✓U   | Assumption — should verify before proceeding              | "Assuming tests exist but haven't checked coverage"                 |
+| Auto-detected | ✓A   | Evidence extracted from structured output block           | "Parsed 5 EARS criteria from PRD structured block"                  |
 
 **Scoring**: All Pass levels count toward the score, but ✓U items are flagged as verification debt.
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -18,11 +18,19 @@ next-skill: breakdown
 
 1. **Read existing architecture**: Check `CLAUDE.md`, `DESIGN.md`, `ARCHITECTURE.md`, `ADR/` directory — understand current state before proposing changes.
 
+1b. **Validate scope alignment**: If a `SKILL_OUTPUT:requirements` block exists in the PRD output, read it and verify:
+
+- Proposed architecture decisions don't expand beyond `scope_in`
+- Success criteria are achievable with the proposed design
+- Identified `risks` are addressed or accepted in design constraints
+
 2. **Identify decisions** that need human input:
    - Database choice and schema
    - Authentication/authorization approach
    - API contract (REST, GraphQL, MCP)
    - Service boundaries
+   - Language and runtime (if greenfield or migration)
+   - Framework selection (when alternatives exist)
    - Third-party dependencies
 
 3. **Present options** with trade-offs (not just one recommendation):
@@ -42,16 +50,23 @@ next-skill: breakdown
 
    For each decision in step 4, ask: **"If we change this after implementation starts, how much rework does it cause?"**
 
-   | Rework Level | Classification | Example |
-   |-------------|----------------|---------|
-   | >50% redo   | **Sticky** — commit now, revisit only via new `/design` cycle | DB choice, auth model, API style |
-   | 10-50% redo | **Semi-sticky** — can adjust but flag the cost | ORM choice, test framework |
-   | <10% redo   | **Flexible** — change freely during implementation | Variable names, UI copy |
+   | Rework Level | Classification                                                | Example                          |
+   | ------------ | ------------------------------------------------------------- | -------------------------------- |
+   | >50% redo    | **Sticky** — commit now, revisit only via new `/design` cycle | DB choice, auth model, API style |
+   | 10-50% redo  | **Semi-sticky** — can adjust but flag the cost                | ORM choice, test framework       |
+   | <10% redo    | **Flexible** — change freely during implementation            | Variable names, UI copy          |
 
    Mark sticky decisions explicitly in the ADR or design doc:
+
    > **STICKY**: This decision is load-bearing. Changing it requires re-running `/design`, not patching mid-build.
 
    This is H2 in practice: define done before starting, including which decisions ARE the definition of done.
+
+5b. **Decision granularity heuristic** (H3):
+
+- If one decision affects >3 layers (data + API + auth + UI), split into sub-decisions
+- If multiple decisions share the same trade-offs, group them into one ADR
+- Each ADR should have exactly one "Decision maker" — avoid committee deadlock
 
 6. **Article 14 Human-Oversight Checkpoint** (for AI-system designs):
 
@@ -77,6 +92,7 @@ next-skill: breakdown
    - Changes public API
 
 8. **H8 Checkpoint**: "Do I understand WHY we're building it this way, not just WHAT?"
+   Also check all 4 dimensions: Body (CI/infra ready?), Mind (serves roadmap?), Heart (good DX/UX?), Spirit (security/ethics defaults baked in?).
 
 ## Handoff
 
@@ -95,6 +111,29 @@ next-skill: breakdown
 - [ ] Human has explicitly decided (not AI default) — decision recorded
 - [ ] ADR created for decisions affecting >3 files or changing public API
 - [ ] Constraints and non-goals documented
+
+## Structured Output
+
+After documenting design decisions, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check design coverage:
+
+```
+<!-- SKILL_OUTPUT:design
+decision_count: [N]
+decisions:
+  - "[decision 1: e.g., PostgreSQL for persistence]"
+  - "[decision 2: e.g., REST API with versioned endpoints]"
+sticky_decisions:
+  - "[sticky 1: e.g., PostgreSQL — >50% rework to change]"
+constraints:
+  - "[constraint 1]"
+adr_references:
+  - "[ADR-NNN: title]"
+article_14_applicable: [true|false]
+article_14_pass: [true|false|n/a]
+END_SKILL_OUTPUT -->
+```
+
+Place this at the very end of the design output, after all human-readable content.
 
 ## Further Reading
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -56,6 +56,8 @@ What do we need to know before specifying requirements?
 - What prior art or patterns exist in the codebase?
 - What domain constraints should we respect?
 - What have others tried? What worked? What failed?
+- What technology options (language, framework, runtime) fit this problem? What are the ecosystem trade-offs?
+- Are there maturity, community, or licensing concerns with candidate technologies?
 
 ### 2. Search existing solutions
 


### PR DESCRIPTION
## Summary

- **[HIGH]** Add `SKILL_OUTPUT:design` structured block — closes the only pipeline gap in the `/requirements` → `/design` → `/breakdown` → `/review-ai` chain
- **[MEDIUM]** Add tech stack bullets to `/design` Step 2 + `/research` Step 1 research questions
- **[MEDIUM]** Expand H8 Checkpoint with Whole Person dimensions (Body/Mind/Heart/Spirit)
- **[MEDIUM]** `/design` now validates scope alignment against `/requirements` structured output
- **[LOW]** Decision granularity heuristic (H3) + `/cross-verify` auto-check wiring (Q4, Q14, Q16)

### Pipeline Before/After

```
Before: /requirements ✅ → /design ❌ → /breakdown ✅ → /review-ai ✅
After:  /requirements ✅ → /design ✅ → /breakdown ✅ → /review-ai ✅
```

### Files Changed (3)

| File | Changes |
|------|---------|
| `skills/design/SKILL.md` | +SKILL_OUTPUT block, +tech stack bullets, +scope validation, +H8 dimensions, +decision heuristic |
| `skills/research/SKILL.md` | +tech stack evaluation questions in Step 1 |
| `skills/cross-verify/SKILL.md` | +auto-check wiring for design block (Q4, Q14, Q16) |

### Version

Version bump deferred to next release batch (content-only, no structural changes). `validate-structure.sh` passes (243/243).

## Test plan

- [x] `bash tests/validate-structure.sh` — 243 PASS, 0 FAIL
- [ ] Manually invoke `/design` on a sample task — verify SKILL_OUTPUT block is produced
- [ ] Invoke `/cross-verify` after `/design` — verify Q4/Q14/Q16 auto-populate from design block
- [ ] Invoke `/research` with tech stack topic — verify new questions appear in research brief

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)