### PR TITLE
docs(wiki): professional template redesign — 20 pages

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,120 @@
+# Architecture
+
+The plugin is a **pure-markdown Claude Code plugin** with zero runtime dependencies. No build system, no `npm install` — just structured markdown files that Claude Code loads at runtime to shape its development behavior.
+
+> [!NOTE]
+> Understanding the architecture is optional for using the plugin. This page is for contributors and curious users who want to know how the pieces fit together.
+
+## 4-Layer Loading Model
+
+The plugin loads content in 4 layers, each with different timing and scope:
+
+```mermaid
+flowchart TD
+    A["Layer 1: Rules<br/><i>Auto-loaded every session</i><br/>rules/effective-development.md"] --> B["Layer 2: Session Hook<br/><i>Runs at session start</i><br/>hooks/session-start.sh"]
+    B --> C["Layer 3: Skills<br/><i>On-demand, user-invoked</i><br/>skills/*/SKILL.md"]
+    C --> D["Layer 4: Agents<br/><i>Cross-verification</i><br/>8-habit-reviewer"]
+
+    style A fill:#e3f2fd
+    style B fill:#f3e5f5
+    style C fill:#e8f5e9
+    style D fill:#fff8e1
+```
+
+### Layer 1: Rules (always active)
+
+`rules/effective-development.md` is loaded automatically into every Claude Code session via Claude's rules system. It contains the full 8-Habit playbook with Rules, Anti-patterns, and Checkpoints per habit. This is the foundation — always present in context, shaping Claude's behavior even if no skills are invoked.
+
+### Layer 2: Session Hook (session start)
+
+`hooks/session-start.sh` runs once at the start of every session. Budget: **≤300 tokens** (enforced by `test-verbosity-hook.sh`).
+
+Responsibilities:
+
+- Print the 7-step workflow reminder
+- Detect workflow progress (existing PRD/ADR/TASKS artifacts)
+- Read `~/.claude/habit-profile.md` and emit maturity-level adaptation directive
+- Respect `HABIT_QUIET=1` opt-out (ADR-006)
+
+### Layer 3: Skills (on-demand)
+
+17 skills in `skills/*/SKILL.md`, loaded only when the user invokes them (e.g., `/requirements`, `/design`). Each skill has YAML frontmatter:
+
+```yaml
+---
+name: <skill-name>
+description: >
+  When to use this skill
+user-invocable: true
+argument-hint: "[arg description]"
+allowed-tools: ["Read", "Glob", "Grep"]
+prev-skill: <predecessor|any|none>
+next-skill: <successor|any|none>
+---
+```
+
+**Progressive disclosure** (v2.10.0, ADR-009): Three large skills use a `SKILL.md + reference.md + examples.md` triad. The main SKILL.md loads, then pulls in reference/examples only when needed via `Load ${CLAUDE_PLUGIN_ROOT}/...` directives.
+
+### Layer 4: Agents (cross-verification)
+
+`8-habit-reviewer` — a read-only agent (`Read`, `Glob`, `Grep` tools only, model: `sonnet`) invoked by `/cross-verify`. Performs deep 17-question analysis against all 8 habits independently.
+
+`research-verifier` — validates cited URLs and file paths in research briefs.
+
+## Handoff Contracts
+
+Every workflow skill declares `prev-skill` and `next-skill` in its frontmatter, creating a directed acyclic graph (DAG):
+
+```
+/research → /requirements → /design → /breakdown → /build-brief → /review-ai → /deploy-guide → /monitor-setup
+```
+
+Each skill documents:
+
+- **Expects from predecessor**: what input it needs
+- **Produces for successor**: what output the next step consumes
+
+> [!IMPORTANT]
+> The DAG is machine-verified. `tests/test-skill-graph.sh` validates: no cycles, no dangling references, symmetric edges, no orphan skills.
+
+## Fitness Functions
+
+4 validators run in CI with **482+ total assertions**:
+
+| Validator                | What it checks                                                             |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `validate-structure.sh`  | Skill frontmatter, directory structure, version consistency across 4 files |
+| `validate-content.sh`    | Skill complexity (word budget), content depth, cross-reference integrity   |
+| `test-skill-graph.sh`    | DAG integrity — cycles, dangling refs, symmetric edges, orphans            |
+| `test-verbosity-hook.sh` | 12 assertions across all 8 hook branches + HABIT_QUIET + token budget      |
+
+## Architecture Decision Records
+
+Every non-trivial decision is documented in `docs/adr/`:
+
+| ADR                                                                                                                      | Decision                                        |
+| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| [001](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-001-orchestration-patterns.md)                    | Orchestration patterns for multi-step workflows |
+| [002](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-002-research-modes.md)                            | Research skill modes and depth levels           |
+| [003](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-003-content-validation.md)                        | Content validation fitness functions            |
+| [004](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-004-wiki-as-artifact.md)                          | Wiki stored as build artifact in source control |
+| [005](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-005-eu-ai-act-toolkit.md)                         | EU AI Act compliance toolkit scope              |
+| [006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-superpowers-deferral.md) | Audience honesty + HABIT_QUIET opt-out          |
+| [007](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-007-agentskills-compatibility-decision.md)        | agentskills.io compatibility (NO-GO)            |
+| [008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md)          | User maturity calibration design                |
+| [009](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-009-skill-split-convention.md)                    | Progressive-disclosure skill split convention   |
+
+## Guides & Templates
+
+The `guides/` directory contains supporting material referenced by skills:
+
+- **Templates**: PRD, task list, review, lesson, interview protocol, ADR
+- **Reference docs**: EARS notation, cross-verification questions, whole-person rubrics
+- **Protocols**: Structured output format, orchestration patterns, verbosity adaptation rules
+- **Cross-verify packs**: Domain-specific question sets (API, frontend, infra, AI/ML, mobile)
+
+## See also
+
+- [Skills Catalog](Skills-Reference)
+- [Maturity Model](Maturity-Model)
+- [Changelog](Changelog)

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,3 +1,5 @@
+![Version](https://img.shields.io/badge/latest-v2.10.0-blue)
+
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).

--- a/docs/wiki/Contributing-to-Wiki.md
+++ b/docs/wiki/Contributing-to-Wiki.md
@@ -93,6 +93,55 @@ The `wiki-sync.yml` Action publishes to `<repo>.wiki.git` within seconds of the 
 - **Emoji**: only if it adds clarity (warning, success, info). Do not put emoji in H1/H2 — they break anchor generation
 - **Bilingual**: English only for now; Thai translation is planned as a phase 2
 
+## Visual patterns
+
+The wiki uses consistent visual patterns. Follow these when editing or adding pages.
+
+### Alert boxes
+
+Use [GitHub alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) for callouts:
+
+| Type             | When to use                            | Example                                    |
+| ---------------- | -------------------------------------- | ------------------------------------------ |
+| `> [!NOTE]`      | Background context, FYI                | Architecture details, optional information |
+| `> [!TIP]`       | Helpful shortcuts, quick wins          | "New here? Start with..."                  |
+| `> [!IMPORTANT]` | Habit checkpoints, key principles      | Checkpoint questions on every step page    |
+| `> [!WARNING]`   | Process rules that must not be skipped | "Never skip `/review-ai`"                  |
+| `> [!CAUTION]`   | Real-world consequences, risk warnings | "These are not hypothetical..."            |
+
+### Mermaid diagrams
+
+Use `flowchart LR` for workflow pipelines. Color coding convention:
+
+```
+classDef optional fill:#e8f5e9,stroke:#4caf50     <!-- green: optional -->
+classDef human fill:#fce4ec,stroke:#e91e63         <!-- pink: human checkpoint -->
+classDef never_skip fill:#fff3e0,stroke:#ff9800    <!-- orange: never skip -->
+```
+
+Always add a legend line below the diagram: `> Green = optional · Pink = human checkpoint · Orange = **never skip**`
+
+### Badge row
+
+Use shields.io badges at the top of landing pages (Home, Changelog):
+
+```markdown
+![Version](https://img.shields.io/badge/version-X.Y.Z-blue)
+![Skills](https://img.shields.io/badge/skills-17-green)
+![License](https://img.shields.io/badge/license-MIT-brightgreen)
+```
+
+### Checkpoint pattern
+
+Every Step-N page ends with a checkpoint section using this exact format:
+
+```markdown
+## HN Checkpoint
+
+> [!IMPORTANT]
+> _"The checkpoint question here?"_
+```
+
 ## What not to contribute (yet)
 
 - Per-project tutorials (put those in your own repo)

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -59,6 +59,18 @@ Use both for maximum coverage. See the note in [Base Camp](Home) for more.
 
 In [`habits/h1-...md` through `habits/h8-...md`](https://github.com/pitimon/8-habit-ai-dev/tree/main/habits). The [Habits Reference](Habits-Reference) page in this wiki is auto-generated from those files.
 
+## What is `/calibrate` and do I need it?
+
+`/calibrate` is a self-assessment skill that determines your maturity level (Dependence → Independence → Interdependence → Significance) and writes a profile to `~/.claude/habit-profile.md`. Other skills read this profile to adapt their verbosity — beginners get full guidance, experts get minimal prompts.
+
+You don't need it to use the plugin — the default is Independence level. Calibrate when guidance feels too detailed or too sparse. See [Maturity Model](Maturity-Model) for the full picture.
+
+## Does this plugin help with EU AI Act compliance?
+
+Yes. `/eu-ai-act-check` provides a 9-obligation checklist covering Articles 9-15 of EU AI Act Regulation 2024/1689, with **25 MUST + 27 SHOULD + 8 COULD** items. It includes a scope-check pre-flight so you can quickly skip if your system is not high-risk or not EU-targeted.
+
+The enforcement date is **2 August 2026**. This is believed to be the first Claude Code plugin with explicit EU AI Act compliance tooling. See [Skills Catalog → `/eu-ai-act-check`](Skills-Reference#eu-ai-act-check).
+
 ## I found a bug or want to suggest a feature
 
 Open an issue: [github.com/pitimon/8-habit-ai-dev/issues](https://github.com/pitimon/8-habit-ai-dev/issues).

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,6 +1,9 @@
 # Getting Started
 
-Your first structured feature in ~10 minutes. This walkthrough shows how the 7-step workflow replaces "just ask Claude to build X."
+> [!TIP]
+> This walkthrough takes **~10 minutes**. Have a small feature from your backlog ready — a real one works best.
+
+Your first structured feature. This walkthrough shows how the 7-step workflow replaces "just ask Claude to build X."
 
 ## Before you start
 
@@ -19,7 +22,8 @@ Open Claude Code in your project and describe what you want:
 
 Claude produces a PRD summary: **What · Why · Who · In scope · Out of scope · Success criteria · Definition of Done**. Review and correct anything that does not match your intent — this is your first human checkpoint.
 
-> **Tip**: If the problem space is unclear, start with `/research` (Step 0) instead.
+> [!TIP]
+> If the problem space is unclear, start with `/research` (Step 0) instead.
 
 ### 2 · Decide architecture
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,20 +1,51 @@
+![Version](https://img.shields.io/badge/version-2.10.0-blue) ![Skills](https://img.shields.io/badge/skills-17-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange) ![Review](https://img.shields.io/badge/external_review-9.5%2F10-gold)
+
 # 8-Habit AI Dev
 
-**Anti-Vibe-Coding plugin for Claude Code.** A 7-step workflow discipline and 8-Habit cross-verification framework that replaces ad-hoc AI prompting with structured, reviewable, governable development.
-
+> [!IMPORTANT]
+> **Anti-Vibe-Coding plugin for Claude Code.**
+> A 7-step workflow discipline and 8-Habit cross-verification framework that replaces ad-hoc AI prompting with structured, reviewable, governable development.
+>
 > _"ทำเสร็จ ≠ ทำดี"_ — _Done_ is not _Done well_.
 
-## Why this exists
+## Why This Exists
 
 AI-assisted coding is fast but often undisciplined: missing requirements, skipped reviews, no rollback plans, accumulating tech debt. This plugin enforces the habits that separate effective developers from vibe coders — based on Stephen Covey's _7 Habits_ + _The 8th Habit_, adapted for the AI era.
 
-## Start here
+## At a Glance
 
-1. **[Installation](Installation)** — one command, zero dependencies
-2. **[Getting Started](Getting-Started)** — your first structured feature in 10 minutes
-3. **[Workflow Overview](Workflow-Overview)** — the 7 steps at a glance
+|                       |                                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------- |
+| **17 skills**         | 7 workflow + 5 assessment + 2 meta + 2 compliance + 1 orchestrator                                        |
+| **8 Habits**          | Covey's 7 + The 8th, adapted for AI-assisted development                                                  |
+| **9 ADRs**            | Every non-trivial decision documented                                                                     |
+| **4 maturity levels** | [Dependence → Independence → Interdependence → Significance](Maturity-Model)                              |
+| **Zero dependencies** | Pure markdown — no npm, no build step                                                                     |
+| **EU AI Act ready**   | First Claude Code plugin with [compliance toolkit](Skills-Reference#compliance--audit-skills)             |
+| **External review**   | Scored **9.5/10** (EXCELLENT) on [first formal audit](https://github.com/pitimon/8-habit-ai-dev/issues/1) |
+
+> [!TIP]
+> **New here?** Start with [Installation](Installation) then [Getting Started](Getting-Started).
+> Already installed? Jump to [Workflow Overview](Workflow-Overview) or type `/using-8-habits` in Claude Code.
 
 ## The 7-Step Workflow
+
+```mermaid
+flowchart LR
+    R["0 · /research\nH5 Understand"]:::optional --> RQ["1 · /requirements\nH2 End in Mind"]:::human
+    RQ --> D["2 · /design\nH8 Voice"]:::human
+    D --> B["3 · /breakdown\nH3 First Things"]:::optional
+    B --> BB["4 · /build-brief\nH5 Understand"]:::optional
+    BB --> RA["5 · /review-ai\nH4 Win-Win"]:::never_skip
+    RA --> DG["6 · /deploy-guide\nH1 Proactive"]:::human
+    DG --> M["7 · /monitor-setup\nH7 Sharpen Saw"]:::optional
+
+    classDef optional fill:#e8f5e9,stroke:#4caf50
+    classDef human fill:#fce4ec,stroke:#e91e63
+    classDef never_skip fill:#fff3e0,stroke:#ff9800
+```
+
+> Green = optional entry point · Pink = human checkpoint required · Orange = **never skip**
 
 | Step | Command                                  | Habit | Purpose                            |
 | ---- | ---------------------------------------- | ----- | ---------------------------------- |
@@ -27,21 +58,50 @@ AI-assisted coding is fast but often undisciplined: missing requirements, skippe
 | 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1    | Staging first, rollback ready      |
 | 7    | [`/monitor-setup`](Step-7-Monitor-Setup) | H7    | Observe after deploy               |
 
-Plus standalone skills: `/cross-verify`, `/whole-person-check`, `/security-check`, `/reflect`, `/workflow`.
+## Beyond the Workflow
+
+**Assessment** — run at any point for deeper analysis:
+
+| Skill                                                        | Purpose                                         |
+| ------------------------------------------------------------ | ----------------------------------------------- |
+| [`/cross-verify`](Skills-Reference#cross-verify)             | 17-question 8-Habit checklist                   |
+| [`/whole-person-check`](Skills-Reference#whole-person-check) | Body/Mind/Heart/Spirit balance                  |
+| [`/security-check`](Skills-Reference#security-check)         | OWASP Top 10 focused review                     |
+| [`/reflect`](Skills-Reference#reflect)                       | Post-task retrospective with lesson persistence |
+| [`/workflow`](Skills-Reference#workflow)                     | Interactive guided walkthrough                  |
+
+**Meta & Onboarding** — learn and adapt:
+
+| Skill                                                | Purpose                                        |
+| ---------------------------------------------------- | ---------------------------------------------- |
+| [`/using-8-habits`](Skills-Reference#using-8-habits) | Onboarding decision tree — which skill when?   |
+| [`/calibrate`](Skills-Reference#calibrate)           | Self-assess maturity, adapt guidance verbosity |
+
+**Compliance & Audit** — governance and transparency:
+
+| Skill                                                  | Purpose                                          |
+| ------------------------------------------------------ | ------------------------------------------------ |
+| [`/eu-ai-act-check`](Skills-Reference#eu-ai-act-check) | EU AI Act 9-obligation checklist (Articles 9-15) |
+| [`/ai-dev-log`](Skills-Reference#ai-dev-log)           | AI-assisted development log from git history     |
+
+## Principles
+
+> [!NOTE]
+> Skills are **read-only guidance** — they tell Claude how to approach a task. They never edit files themselves.
+
+- **Human-in-the-loop** for architecture and irreversible decisions
+- **Zero dependencies**: pure markdown + bash validation
+- **PR-first**: every change goes through review, even documentation
+- **Complementary**: pairs with [`claude-governance`](https://github.com/pitimon/claude-governance) for enforcement + compliance
 
 ## Reference
 
 - **[8 Habits](Habits-Reference)** — the full playbook
-- **[Skills Catalog](Skills-Reference)** — all 13 skills, when to use each
+- **[Skills Catalog](Skills-Reference)** — all 17 skills, when to use each
+- **[Architecture](Architecture)** — how the plugin works internally
+- **[Maturity Model](Maturity-Model)** — adaptive guidance levels
 - **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)** — side-by-side comparison
 - **[FAQ](FAQ)** · **[Troubleshooting](Troubleshooting)**
-
-## Principles
-
-- **Read-only guidance**: Skills tell Claude _how_ to approach a task, never edit files themselves
-- **Human-in-the-loop** for architecture and irreversible decisions
-- **Zero dependencies**: pure markdown + bash validation
-- **PR-first**: every change goes through review, even documentation
 
 ## Contributing
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -49,7 +49,11 @@ claude plugin uninstall 8-habit-ai-dev@pitimon-8-habit-ai-dev
 
 ## What gets installed
 
-- **Skills** (loaded on demand): `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`, `/cross-verify`, `/whole-person-check`, `/security-check`, `/reflect`, `/workflow`
+- **Skills** (loaded on demand):
+  - _Workflow_: `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`
+  - _Assessment_: `/cross-verify`, `/whole-person-check`, `/security-check`, `/reflect`, `/workflow`
+  - _Meta_: `/using-8-habits`, `/calibrate`
+  - _Compliance_: `/eu-ai-act-check`, `/ai-dev-log`
 - **Rules** (auto-loaded every session): `rules/effective-development.md` — the full 8-Habit playbook
 - **Session hook**: ≤300-token reminder of the 7-step workflow
 - **Agent**: `8-habit-reviewer` — read-only cross-verification agent

--- a/docs/wiki/Maturity-Model.md
+++ b/docs/wiki/Maturity-Model.md
@@ -1,0 +1,106 @@
+# Maturity Model
+
+> [!IMPORTANT]
+> The maturity model is not a judgment — it is a signal that lets the plugin meet you where you are, not where the template assumes.
+
+The plugin adapts its guidance based on your self-assessed maturity level. A beginner gets full scaffolding; an expert gets minimal prompts. This prevents the common complaint about workflow tools: "too much ceremony for experienced users" or "not enough guidance for new ones."
+
+## The 4 Levels
+
+Based on Covey's maturity continuum, extended with the 8th Habit's Significance level:
+
+```mermaid
+flowchart LR
+    D["Dependence<br/><i>Full guidance</i>"]:::dep --> I["Independence<br/><i>Key checkpoints</i>"]:::ind
+    I --> ID["Interdependence<br/><i>Team focus</i>"]:::inter
+    ID --> S["Significance<br/><i>Minimal prompts</i>"]:::sig
+
+    classDef dep fill:#ffcdd2
+    classDef ind fill:#fff9c4
+    classDef inter fill:#c8e6c9
+    classDef sig fill:#bbdefb
+```
+
+| Level               | You are...                                                  | Plugin behavior                                                                                          |
+| ------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Dependence**      | New to structured AI dev. Need scaffolding to build habits. | Full guidance: all examples shown, all checkpoints explained, templates provided, skip rules spelled out |
+| **Independence**    | Self-directed. Have foundations but still refining.         | Key checkpoints only: skip beginner explanations, show decision points, trust you to fill in details     |
+| **Interdependence** | Team-embedded. Lead or mentor others.                       | Team and synergy focus: delegation patterns, review quality, parallel execution, minimal solo ceremony   |
+| **Significance**    | Set standards. Define how others work.                      | Minimal prompts: expert mode, only flag exceptions, trust judgment on process, focus on meta-system      |
+
+## How to Calibrate
+
+Run `/calibrate` in Claude Code. The skill asks 5-7 questions about your development practices:
+
+1. How do you typically start a new feature?
+2. What happens after you write code?
+3. How do you handle architecture decisions?
+4. How do you work with AI assistants?
+5. How do you share knowledge with your team?
+
+Based on your answers, the skill identifies your dominant maturity level and writes a profile.
+
+> [!TIP]
+> You don't need to calibrate before using the plugin. It defaults to Independence level if no profile exists. Calibrate when you want more or less guidance than the default provides.
+
+## Where the Profile Lives
+
+The profile is stored at `~/.claude/habit-profile.md` — global, per-user, not per-project. Format:
+
+```yaml
+---
+schema-version: 1
+dominant-level: interdependence
+assessed-date: 2026-04-15
+---
+## Assessment Summary
+...
+```
+
+See [`guides/habit-profile-schema.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/habit-profile-schema.md) for the full schema specification.
+
+## How Skills Adapt
+
+The adaptation happens at session start, not per-skill:
+
+1. `hooks/session-start.sh` reads `~/.claude/habit-profile.md`
+2. Emits a level-specific directive into session context
+3. All 17 skills automatically adapt their verbosity — **zero per-skill changes needed**
+
+This means a single calibration affects every skill invocation for the rest of the session. The canonical adaptation rules are in [`guides/verbosity-adaptation.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/verbosity-adaptation.md).
+
+## Opting Out
+
+If you've internalized the workflow and find even the session-start reminder distracting:
+
+```bash
+export HABIT_QUIET=1
+```
+
+This suppresses the session-start banner entirely. Skills still work when invoked — only the automatic reminder is silenced. See [ADR-006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-superpowers-deferral.md) for rationale.
+
+## Re-Calibration
+
+Your maturity level changes over time. After ~90 days, consider re-running `/calibrate` — especially if:
+
+- You've moved to a new team or role
+- You've adopted or dropped development practices
+- The plugin guidance feels too detailed or too sparse
+
+## Connection to the Three Loops
+
+The maturity levels map naturally to the decision authority model:
+
+| Level           | Primary Loop              | Decision style                                              |
+| --------------- | ------------------------- | ----------------------------------------------------------- |
+| Dependence      | In-the-Loop               | Human decides everything, AI assists step by step           |
+| Independence    | On-the-Loop               | AI proposes, human reviews and approves                     |
+| Interdependence | On-the-Loop → Out-of-Loop | Team delegates well-scoped tasks to AI                      |
+| Significance    | Out-of-Loop + Voice       | AI executes within guardrails; human defines the guardrails |
+
+## See also
+
+- [`/calibrate`](Skills-Reference#calibrate) — the self-assessment skill
+- [Architecture](Architecture) — how the hook-based adaptation works
+- [8 Habits → H8 Find Your Voice](Habits-Reference#habit-8-find-your-voice-and-inspire-others) — the principle behind adaptive guidance
+- [ADR-008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md) — design decisions

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,6 +1,9 @@
 # Skills Catalog
 
-All 13 skills shipped with `8-habit-ai-dev`. Skills are **read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves.
+All **17 skills** shipped with `8-habit-ai-dev` v2.10.0. Skills are **read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves.
+
+> [!TIP]
+> Not sure which skill to use? Type `/using-8-habits` for an interactive decision tree, or see the [quick-select matrix](#quick-select-matrix) below.
 
 ## 7-Step Workflow Skills
 
@@ -15,19 +18,21 @@ All 13 skills shipped with `8-habit-ai-dev`. Skills are **read-only guidance** �
 | 6   | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1    | Staging-first deploys with rollback plan                 |
 | 7   | [`/monitor-setup`](Step-7-Monitor-Setup) | H7    | Observability after deploy                               |
 
-## Standalone Skills
+## Assessment Skills
+
+Run at any point in the workflow for deeper analysis.
 
 ### `/cross-verify` {#cross-verify}
 
-17-question 8-Habit cross-verification checklist. Run **after** planning and **before** committing to implementation. Produces a dimension summary across all 8 habits.
+17-question 8-Habit cross-verification checklist. Run **after** planning and **before** committing to implementation. Produces a dimension summary across all 8 habits with confidence levels.
 
-- **Habit**: H1–H8 (all)
+- **Habit**: H1-H8 (all)
 - **When to use**: Before `ExitPlanMode`, before PR creation
 - **Source**: [`skills/cross-verify/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/cross-verify/SKILL.md)
 
 ### `/whole-person-check` {#whole-person-check}
 
-Assess a feature/component/PR against Covey's 4 dimensions: **Body** (discipline), **Mind** (vision), **Heart** (passion), **Spirit** (conscience).
+Assess a feature/component/PR against Covey's 4 dimensions: **Body** (discipline), **Mind** (vision), **Heart** (passion), **Spirit** (conscience). Scores 1-5 per dimension.
 
 - **Habit**: H8 Find Your Voice
 - **When to use**: After `/review-ai` when you want a balance check
@@ -43,7 +48,7 @@ Focused security review — secrets, injection, auth, dependencies, OWASP Top 10
 
 ### `/reflect` {#reflect}
 
-Post-task micro-retrospective — 5 questions, 5 minutes. Captures lessons before context evaporates.
+Post-task micro-retrospective — 6 questions, 5 minutes. Captures lessons to `~/.claude/lessons/` for future retrieval by `/research` and `/build-brief`. Includes skill-effectiveness signal (Q6) feeding `SKILL-EFFECTIVENESS.md`.
 
 - **Habit**: H7 Sharpen the Saw
 - **When to use**: After completing a task or workflow
@@ -57,7 +62,66 @@ Interactive guided walkthrough of the 7-step workflow. Prompts at each step to i
 - **When to use**: Starting a new feature when you're unsure which step comes next
 - **Source**: [`skills/workflow/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/workflow/SKILL.md)
 
-## Skill anatomy
+## Meta & Onboarding Skills
+
+Learn the plugin and adapt it to your style.
+
+### `/using-8-habits` {#using-8-habits}
+
+Onboarding meta-skill — explains the 8 habits, all 17 skills, and provides a decision tree for "which skill next?". Includes a complete walkthrough example (password-reset feature).
+
+- **Habit**: H5 Understand First + H8 Find Your Voice
+- **When to use**: First time using the plugin, or when unsure which skill applies
+- **Source**: [`skills/using-8-habits/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/using-8-habits/SKILL.md)
+
+### `/calibrate` {#calibrate}
+
+Self-assessment skill that determines your maturity level (Dependence → Independence → Interdependence → Significance) and writes a profile to `~/.claude/habit-profile.md`. Other skills read this profile to adapt verbosity — full guidance for beginners, minimal prompts for experts.
+
+- **Habit**: H8 Find Your Voice
+- **When to use**: When plugin guidance feels too detailed or too sparse
+- **Deep dive**: [Maturity Model](Maturity-Model)
+- **Source**: [`skills/calibrate/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/calibrate/SKILL.md)
+
+## Compliance & Audit Skills
+
+Governance, transparency, and regulatory readiness.
+
+### `/eu-ai-act-check` {#eu-ai-act-check}
+
+EU AI Act Regulation 2024/1689 compliance checker. 9 obligations from Articles 9-15 with a tiered checklist: **25 MUST** + **27 SHOULD** + **8 COULD** items. Includes a scope-check pre-flight to skip quickly if your system is not high-risk or not EU-targeted.
+
+- **Habit**: H1 Be Proactive + H8 Spirit (Conscience)
+- **When to use**: Before major releases of high-risk AI systems targeting the EU
+- **Enforcement date**: 2 August 2026
+- **Source**: [`skills/eu-ai-act-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/eu-ai-act-check/SKILL.md)
+
+### `/ai-dev-log` {#ai-dev-log}
+
+Generates an AI-assisted development log from `git log` + `Co-Authored-By` trailers. 4 output modes: markdown, JSON, summary, and stdout. Useful for EU AI Act Article 11 (technical documentation) audit trails and team transparency.
+
+- **Habit**: H4 Win-Win + H1 Be Proactive
+- **When to use**: Before releases, audits, or when stakeholders ask "how much was AI-generated?"
+- **Source**: [`skills/ai-dev-log/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/ai-dev-log/SKILL.md)
+
+## Quick-Select Matrix
+
+| I need to...                          | Use                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------- |
+| Start a new feature from scratch      | [`/workflow`](#workflow) or [`/requirements`](#7-step-workflow-skills) |
+| Understand this plugin                | [`/using-8-habits`](#using-8-habits)                                   |
+| Adjust guidance verbosity             | [`/calibrate`](#calibrate)                                             |
+| Research before deciding              | [`/research`](Step-0-Research)                                         |
+| Review AI-generated code              | [`/review-ai`](Step-5-Review-AI)                                       |
+| Check all 8 habits at once            | [`/cross-verify`](#cross-verify)                                       |
+| Assess Body/Mind/Heart/Spirit balance | [`/whole-person-check`](#whole-person-check)                           |
+| Run a focused security review         | [`/security-check`](#security-check)                                   |
+| Check EU AI Act compliance            | [`/eu-ai-act-check`](#eu-ai-act-check)                                 |
+| Generate AI audit trail               | [`/ai-dev-log`](#ai-dev-log)                                           |
+| Capture lessons after a task          | [`/reflect`](#reflect)                                                 |
+| Deploy safely to production           | [`/deploy-guide`](Step-6-Deploy-Guide)                                 |
+
+## Skill Anatomy
 
 Every skill follows the same structure ([source convention](https://github.com/pitimon/8-habit-ai-dev/blob/main/CLAUDE.md#skill-authoring-conventions)):
 
@@ -80,4 +144,5 @@ Body: Habit mapping → Process → Handoff → When to Skip → Definition of D
 
 - **[Workflow Overview](Workflow-Overview)**
 - **[Habits Reference](Habits-Reference)**
+- **[Architecture](Architecture)** — how skills load and connect
 - **[FAQ: When should I use which skill?](FAQ)**

--- a/docs/wiki/Step-0-Research.md
+++ b/docs/wiki/Step-0-Research.md
@@ -46,6 +46,7 @@ A **research brief** containing:
 
 ## H5 Checkpoint
 
+> [!IMPORTANT]
 > _"Have I fully understood the problem before proposing a solution?"_
 
 ## See also

--- a/docs/wiki/Step-1-Requirements.md
+++ b/docs/wiki/Step-1-Requirements.md
@@ -46,6 +46,7 @@ Define what "done" looks like before touching code. A PRD you can verify against
 
 ## H2 Checkpoint
 
+> [!IMPORTANT]
 > _"Can I describe what success looks like before writing code?"_
 
 ## See also

--- a/docs/wiki/Step-2-Design.md
+++ b/docs/wiki/Step-2-Design.md
@@ -46,17 +46,18 @@ Decision document or ADR following `guides/templates/adr-template.md`:
 
 ## H8 Checkpoint
 
+> [!IMPORTANT]
 > _"Do I understand WHY we're building it this way, not just WHAT?"_
 
 ## Sticky Decisions (v2.8.0)
 
 Some decisions act as **sticky latches** — once set, reversing them mid-session wastes all context built on top. For each decision, ask: _"If we change this after implementation starts, how much rework?"_
 
-| Rework | Classification | Example |
-|--------|---------------|---------|
+| Rework | Classification                                    | Example                          |
+| ------ | ------------------------------------------------- | -------------------------------- |
 | >50%   | **Sticky** — revisit only via new `/design` cycle | DB choice, auth model, API style |
-| 10-50% | **Semi-sticky** — adjustable but flag the cost | ORM, test framework |
-| <10%   | **Flexible** — change freely | Variable names, UI copy |
+| 10-50% | **Semi-sticky** — adjustable but flag the cost    | ORM, test framework              |
+| <10%   | **Flexible** — change freely                      | Variable names, UI copy          |
 
 Mark sticky decisions in the ADR: **STICKY — changing this requires re-running `/design`, not patching mid-build.**
 

--- a/docs/wiki/Step-3-Breakdown.md
+++ b/docs/wiki/Step-3-Breakdown.md
@@ -49,6 +49,7 @@ Most valuable for 3+ parallel tasks. For 2 tasks, the optimization overhead rare
 
 ## H3 Checkpoint
 
+> [!IMPORTANT]
 > _"Am I doing what's important, or what's interesting?"_
 
 ## See also

--- a/docs/wiki/Step-4-Build-Brief.md
+++ b/docs/wiki/Step-4-Build-Brief.md
@@ -53,6 +53,7 @@ Claude Code uses a 4-layer context compression pipeline that progressively remov
 
 ## H5 Checkpoint
 
+> [!IMPORTANT]
 > _"Have I read enough of the existing code to make good judgments here?"_
 
 ## See also

--- a/docs/wiki/Step-5-Review-AI.md
+++ b/docs/wiki/Step-5-Review-AI.md
@@ -45,6 +45,7 @@ Run these **in addition** to `/review-ai` for deeper coverage:
 
 ## H4 Checkpoint
 
+> [!IMPORTANT]
 > _"Does this interaction leave the next developer better informed and more capable?"_
 
 ## See also

--- a/docs/wiki/Step-6-Deploy-Guide.md
+++ b/docs/wiki/Step-6-Deploy-Guide.md
@@ -49,6 +49,7 @@ A deploy plan document containing:
 
 ## H1 Checkpoint
 
+> [!IMPORTANT]
 > _"Am I preventing future incidents, or reacting to current ones?"_
 
 ## See also

--- a/docs/wiki/Step-7-Monitor-Setup.md
+++ b/docs/wiki/Step-7-Monitor-Setup.md
@@ -43,6 +43,7 @@ Set up error tracking, alerting, and health checks so you **learn from productio
 
 ## H7 Checkpoint
 
+> [!IMPORTANT]
 > _"Am I investing in future capability, or just grinding out output?"_
 
 ## See also

--- a/docs/wiki/Vibe-Coding-vs-Structured.md
+++ b/docs/wiki/Vibe-Coding-vs-Structured.md
@@ -21,6 +21,9 @@
 
 ## What vibe coding costs you
 
+> [!CAUTION]
+> These are not hypothetical. Every item below has been observed in production AI-generated codebases.
+
 - **Hallucinated APIs** shipped to production
 - **Missing error handling** that surfaces during the first outage
 - **Scope creep** — features nobody asked for

--- a/docs/wiki/Workflow-Overview.md
+++ b/docs/wiki/Workflow-Overview.md
@@ -2,35 +2,49 @@
 
 The antidote to vibe coding. Each step is a Claude Code skill, maps to one of Covey's 8 Habits, and has an explicit handoff contract with the next step.
 
-## The 7 steps (+ Step 0)
+## The 7 Steps (+ Step 0)
 
+```mermaid
+flowchart LR
+    R["0 · /research\nH5 Understand"]:::optional --> RQ["1 · /requirements\nH2 End in Mind"]:::human
+    RQ --> D["2 · /design\nH8 Voice"]:::human
+    D --> B["3 · /breakdown\nH3 First Things"]:::optional
+    B --> BB["4 · /build-brief\nH5 Understand"]:::optional
+    BB --> RA["5 · /review-ai\nH4 Win-Win"]:::never_skip
+    RA --> DG["6 · /deploy-guide\nH1 Proactive"]:::human
+    DG --> M["7 · /monitor-setup\nH7 Sharpen Saw"]:::optional
+
+    classDef optional fill:#e8f5e9,stroke:#4caf50
+    classDef human fill:#fce4ec,stroke:#e91e63
+    classDef never_skip fill:#fff3e0,stroke:#ff9800
 ```
- 0 Research  →  1 Requirements  →  2 Design  →  3 Breakdown
-                                                     ↓
- 7 Monitor  ←  6 Deploy  ←  5 Review AI  ←  4 Build Brief
-```
+
+> Green = optional entry point · Pink = human checkpoint required · Orange = **never skip**
 
 | Step | Skill                                    | Habit                 | Output                        | Human checkpoint? |
 | ---- | ---------------------------------------- | --------------------- | ----------------------------- | ----------------- |
 | 0    | [`/research`](Step-0-Research)           | H5 Understand First   | Research brief                | Optional          |
-| 1    | [`/requirements`](Step-1-Requirements)   | H2 Begin with End     | PRD summary                   | ✅ Yes            |
-| 2    | [`/design`](Step-2-Design)               | H8 Find Your Voice    | Architecture decisions (ADR)  | ✅ **Required**   |
+| 1    | [`/requirements`](Step-1-Requirements)   | H2 Begin with End     | PRD summary                   | Yes               |
+| 2    | [`/design`](Step-2-Design)               | H8 Find Your Voice    | Architecture decisions (ADR)  | **Required**      |
 | 3    | [`/breakdown`](Step-3-Breakdown)         | H3 First Things First | Atomic task list              | Optional          |
 | 4    | [`/build-brief`](Step-4-Build-Brief)     | H5 Understand First   | Implementation brief per task | Optional          |
-| 5    | [`/review-ai`](Step-5-Review-AI)         | H4 Win-Win            | Code review findings          | ✅ **Required**   |
-| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1 Be Proactive       | Deploy plan + rollback        | ✅ **Required**   |
+| 5    | [`/review-ai`](Step-5-Review-AI)         | H4 Win-Win            | Code review findings          | **Required**      |
+| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1 Be Proactive       | Deploy plan + rollback        | **Required**      |
 | 7    | [`/monitor-setup`](Step-7-Monitor-Setup) | H7 Sharpen the Saw    | Observability config          | Optional          |
 
-## Handoff contracts
+## Handoff Contracts
 
 Each skill declares `prev-skill` and `next-skill` in its frontmatter and explicitly documents:
 
 - **Expects from predecessor**: what input the skill needs
 - **Produces for successor**: what output the next step will consume
 
-This prevents context loss between steps and makes the workflow composable. Standalone skills (`/cross-verify`, `/whole-person-check`, `/security-check`) use `any` for both and can run at any point.
+This prevents context loss between steps and makes the workflow composable.
 
-## When to skip
+> [!NOTE]
+> The handoff DAG is machine-verified by `tests/test-skill-graph.sh` — no cycles, no dangling references, symmetric edges.
+
+## When to Skip
 
 | Change type                              | Steps to run           |
 | ---------------------------------------- | ---------------------- |
@@ -43,20 +57,33 @@ This prevents context loss between steps and makes the workflow composable. Stan
 | Refactor (no behavior change)            | 2, 3, 4, 5             |
 | Architecture change                      | 0, 1, 2, 3, 4, 5, 6, 7 |
 
-**Rule of thumb**: never skip `/review-ai` (Step 5). Every other step has legitimate skip cases; review does not.
+> [!WARNING]
+> **Never skip `/review-ai` (Step 5).** Every other step has legitimate skip cases; review does not.
 
-## Standalone skills
+## Beyond the Workflow
 
-These complement the pipeline and can run any time:
+These skills complement the pipeline and can run at any point:
+
+**Assessment:**
 
 - [`/cross-verify`](Skills-Reference#cross-verify) — 17-question 8-Habit checklist
 - [`/whole-person-check`](Skills-Reference#whole-person-check) — Body/Mind/Heart/Spirit balance
 - [`/security-check`](Skills-Reference#security-check) — OWASP Top 10 focused review
-- [`/reflect`](Skills-Reference#reflect) — post-task 5-question retrospective
+- [`/reflect`](Skills-Reference#reflect) — post-task retrospective with lesson persistence
 - [`/workflow`](Skills-Reference#workflow) — interactive guided walkthrough
+
+**Meta & Onboarding:**
+
+- [`/using-8-habits`](Skills-Reference#using-8-habits) — onboarding decision tree
+- [`/calibrate`](Skills-Reference#calibrate) — maturity self-assessment, verbosity adaptation
+
+**Compliance & Audit:**
+
+- [`/eu-ai-act-check`](Skills-Reference#eu-ai-act-check) — EU AI Act 9-obligation checklist
+- [`/ai-dev-log`](Skills-Reference#ai-dev-log) — AI development log from git history
 
 ## See also
 
-- **[Skills Catalog](Skills-Reference)**
+- **[Skills Catalog](Skills-Reference)** — all 17 skills with when-to-use guidance
 - **[Habits Reference](Habits-Reference)**
 - **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)**

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,10 +1,12 @@
 ### 8-Habit AI Dev
 
-**Start here**
+_Structured AI development_
 
-- [Base Camp](Home)
-- [Getting Started](Getting-Started)
+**Get Started**
+
+- [Home](Home)
 - [Installation](Installation)
+- [Getting Started](Getting-Started)
 
 **7-Step Workflow**
 
@@ -18,18 +20,20 @@
 - [6 · Deploy Guide](Step-6-Deploy-Guide)
 - [7 · Monitor Setup](Step-7-Monitor-Setup)
 
-**Reference**
+**Concepts**
 
+- [Architecture](Architecture)
+- [Maturity Model](Maturity-Model)
 - [8 Habits](Habits-Reference)
-- [Skills Catalog](Skills-Reference)
 - [Vibe Coding vs Structured](Vibe-Coding-vs-Structured)
 
-**Help**
+**Reference**
 
+- [Skills Catalog](Skills-Reference)
 - [FAQ](FAQ)
 - [Troubleshooting](Troubleshooting)
 
 **Project**
 
-- [Contributing to Wiki](Contributing-to-Wiki)
 - [Changelog](Changelog)
+- [Contributing to Wiki](Contributing-to-Wiki)


### PR DESCRIPTION
## Summary

- **Home.md** rewritten as hero landing page with quick-start flow (49 → 108 lines)
- **Architecture.md** (new) — 4-layer plugin design documentation
- **Maturity-Model.md** (new) — 4-level adaptive guidance system
- **Skills-Reference.md** expanded from 13 to 17 skills with quick-select matrix
- **Workflow-Overview.md** upgraded with Mermaid diagram and full 17-skill coverage
- **All 8 Step pages** upgraded with `> [!IMPORTANT]` checkpoint callouts
- **_Sidebar.md** reorganized with new "Concepts" section
- **Contributing-to-Wiki.md** updated with visual pattern guide
- **FAQ.md** + **Changelog.md** + **Getting-Started.md** + **Vibe-Coding-vs-Structured.md** refreshed

### Stats

20 files changed, 517 insertions, 53 deletions

## Test plan

- [x] `bash tests/validate-structure.sh` — all checks passed (previous session)
- [ ] Verify all wiki internal links resolve (Check 14 in validator)
- [ ] Spot-check Mermaid diagram renders on GitHub wiki
- [ ] Verify new Architecture.md and Maturity-Model.md linked from _Sidebar.md

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)