### PR TITLE
docs(changelog): backfill v2.9.0 + v2.11.0, harden Check 19, close #124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.11.0 — Design Pipeline Completion + Wiki Redesign (2026-04-16)
+
+Close the only remaining structured-output-block gap in the `/requirements` → `/design` → `/breakdown` → `/review-ai` handoff chain ([#128](https://github.com/pitimon/8-habit-ai-dev/issues/128), [PR #129](https://github.com/pitimon/8-habit-ai-dev/pull/129)) and upgrade 20 wiki pages to a professional template ([#127](https://github.com/pitimon/8-habit-ai-dev/issues/127), [PR #130](https://github.com/pitimon/8-habit-ai-dev/pull/130)). Both PRs merged within 3 minutes of each other (14:13 and 14:16 UTC).
+
+### Added
+
+- **`SKILL_OUTPUT:design` structured block** ([#128](https://github.com/pitimon/8-habit-ai-dev/issues/128)) — closes the last cross-skill handoff gap. `/cross-verify` Q4, Q14, Q16 now auto-populate (`✓A`) from the design block instead of requiring manual re-reading.
+- **Tech-stack decisions as formal concerns** — `/design` Step 2 + `/research` Step 1 now surface language/framework choices as explicit design outputs, not implicit assumptions.
+- **Scope validation via `SKILL_OUTPUT:requirements`** — `/design` now consumes the requirements block so the skill can flag scope drift between decisions and success criteria.
+- **Decision granularity heuristic** — H3-based guidance for splitting vs grouping design decisions.
+- **H8 Whole Person dimensions in `/design` checkpoint** — Body/Mind/Heart/Spirit prompts added alongside the existing pass/fail gate.
+- **`docs/wiki/Architecture.md`** (new) — 4-layer plugin design documentation.
+- **`docs/wiki/Maturity-Model.md`** (new) — 4-level adaptive guidance system.
+
+### Changed
+
+- **`docs/wiki/Home.md`** — rewritten as a hero landing page (49 → 108 lines).
+- **`docs/wiki/Skills-Reference.md`** — expanded from 13 → 17 skills with quick-select matrix.
+- **`docs/wiki/Workflow-Overview.md`** — upgraded with a Mermaid diagram and full 17-skill coverage.
+- **All 8 Step wiki pages** — upgraded with `> [!IMPORTANT]` checkpoint callouts.
+- **`docs/wiki/_Sidebar.md`** — reorganized with a new "Concepts" section.
+- **`docs/wiki/FAQ.md`** — 2 new FAQ entries; **`docs/wiki/Getting-Started.md`** + **`docs/wiki/Vibe-Coding-vs-Structured.md`** updated with GitHub Alert boxes.
+- **`docs/wiki/Installation.md`** — skills list updated to 17 skills across 4 categories.
+- **Wiki redesign totals**: 18 files changed, 291 insertions, 53 deletions.
+
+### Fitness
+
+- `validate-structure.sh` 243/243 PASS, `validate-content.sh` 183/183 PASS, `test-skill-graph.sh` PASS, `test-verbosity-hook.sh` PASS — all green at release.
+
+---
+
 ## v2.10.0 — Progressive-Disclosure SKILL.md Split (2026-04-16)
 
 Refactor the 3 largest skills into `SKILL.md + reference.md + examples.md` triads to create headroom below the 2000-word F3 fitness-function ceiling. Pattern sourced from external research (`shanraisshan/claude-code-best-practice`), filtered through plugin-boundary audit — see [ADR-009](docs/adr/ADR-009-skill-split-convention.md).
@@ -38,6 +69,26 @@ Refactor the 3 largest skills into `SKILL.md + reference.md + examples.md` triad
 ### Fitness
 
 - All 3 validators pass: `validate-structure.sh` 243/0, `test-skill-graph.sh` PASS, `validate-content.sh` 183/0 with 0 fitness breaches.
+
+---
+
+## v2.9.0 — Deep-Project Inspired Improvements (2026-04-13)
+
+Three features inspired by comparison research against [`piercelamb/deep-project`](https://github.com/piercelamb/deep-project). Cross-verified (14/17), advisor-reviewed, 8-habit QA passed (13/17 → 15/17 after fixes). Released via PRs [#121](https://github.com/pitimon/8-habit-ai-dev/pull/121), [#122](https://github.com/pitimon/8-habit-ai-dev/pull/122), [#123](https://github.com/pitimon/8-habit-ai-dev/pull/123).
+
+### Added
+
+- **Interview protocol for `/requirements`** ([#118](https://github.com/pitimon/8-habit-ai-dev/issues/118), [PR #121](https://github.com/pitimon/8-habit-ai-dev/pull/121)) — new `guides/templates/interview-protocol.md` gives structured conversation scaffolding (Quick / Standard / Deep depth) for discovering requirements before EARS criteria. Replaces the "ask the user 5 questions" default with a better-shaped discovery flow.
+- **Workflow step awareness in session-start hook** ([#119](https://github.com/pitimon/8-habit-ai-dev/issues/119), [PR #122](https://github.com/pitimon/8-habit-ai-dev/pull/122)) — `hooks/session-start.sh` now surfaces a workflow step cue so partial chains can resume across sessions without per-skill rework. Respects existing `HABIT_QUIET=1` opt-out.
+- **Machine-readable structured output blocks** ([#120](https://github.com/pitimon/8-habit-ai-dev/issues/120), [PR #123](https://github.com/pitimon/8-habit-ai-dev/pull/123)) — new `guides/structured-output-protocol.md` defines `<!-- SKILL_OUTPUT:... END_SKILL_OUTPUT -->` HTML comment blocks at the end of `/requirements`, `/breakdown`, and `/review-ai`. Enables `/cross-verify` to auto-populate (`✓A`) answers from producer skills instead of requiring manual re-reading of prior-step artifacts.
+
+### Fixed
+
+- **Scope-alignment threshold in `/cross-verify` Q8** — QA raised the `task_count` vs `ears_count` ratio guard from hardcoded `3×` to a documented `≤ 3×` threshold so the heuristic is auditable and adjustable.
+
+### Fitness
+
+- `validate-structure.sh` 238/238 PASS, `validate-content.sh` 177/177 PASS, `test-skill-graph.sh` 57/57 PASS, `test-verbosity-hook.sh` 19/19 PASS — 491/491 total at release commit `8123b25`.
 
 ---
 

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,24 @@
-![Version](https://img.shields.io/badge/latest-v2.10.0-blue)
+![Version](https://img.shields.io/badge/latest-v2.11.0-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.11.0 — Design Pipeline Completion + Wiki Redesign (April 2026)
+
+Close the final gap in the `/requirements` → `/design` → `/breakdown` → `/review-ai` structured-output-block handoff chain, and upgrade 20 wiki pages to a professional template. Both PRs merged within 3 minutes of each other.
+
+- **`SKILL_OUTPUT:design` structured block** ([#128](https://github.com/pitimon/8-habit-ai-dev/issues/128) / [PR #129](https://github.com/pitimon/8-habit-ai-dev/pull/129)) — closes the last cross-skill handoff gap; `/cross-verify` Q4/Q14/Q16 now auto-populate from the design block.
+- **Tech-stack decisions as formal concerns** — `/design` Step 2 + `/research` Step 1 surface language/framework as explicit outputs.
+- **Scope validation via `SKILL_OUTPUT:requirements`** — `/design` consumes the requirements block so scope drift between decisions and success criteria is flaggable.
+- **H8 Whole Person in `/design` checkpoint** — Body/Mind/Heart/Spirit prompts.
+- **Wiki redesign** ([#127](https://github.com/pitimon/8-habit-ai-dev/issues/127) / [PR #130](https://github.com/pitimon/8-habit-ai-dev/pull/130)) — new `Architecture.md` (4-layer plugin design), new `Maturity-Model.md` (4-level adaptive guidance), `Home.md` rewritten as hero landing page, `Skills-Reference.md` expanded 13 → 17 with quick-select matrix, `Workflow-Overview.md` Mermaid diagram, all 8 Step pages with `> [!IMPORTANT]` checkpoints, `_Sidebar.md` reorganized with Concepts section. 18 files, 291 insertions, 53 deletions.
+
+Fitness receipts: `validate-structure.sh` 243/0, `validate-content.sh` 183/0, `test-skill-graph.sh` PASS, `test-verbosity-hook.sh` PASS.
+
+---
 
 ## v2.10.0 — Progressive-Disclosure SKILL.md Split (April 2026)
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -516,8 +516,11 @@ fi
 echo ""
 
 # --- Check 19: Docs freshness vs plugin.json version ---
-# Enforces downstream propagation from CHANGELOG.md to README.md and docs/wiki/Changelog.md.
+# Enforces downstream propagation from plugin.json across all changelog surfaces.
 # Prevents the "stuck at v2.N-5" drift scenario (see issue #106, fix in PR #107).
+# Tightened 2026-04-17 per issue #124 F1+F2 after v2.9.0 + v2.11.0 recurrence:
+# pointer-to-CHANGELOG.md fallback removed (the wiki was passing just by containing
+# the string "CHANGELOG.md" even when the actual entry was missing).
 # See CONTRIBUTING.md § Testing Conventions for rationale.
 echo "--- Check 19: Docs freshness vs plugin.json version ---"
 
@@ -527,19 +530,37 @@ current_version=$(awk -F'"' '/"version"/{print $4; exit}' .claude-plugin/plugin.
 if [ -z "$current_version" ]; then
   fail "could not extract version from .claude-plugin/plugin.json"
 else
-  # README.md must mention the current version somewhere (typically in "What's New")
+  # A. README.md must mention the current version somewhere (typically in "What's New")
   if grep -q "v${current_version}" README.md; then
     pass "README.md mentions current version v${current_version}"
   else
     fail "README.md does not mention v${current_version} — CHANGELOG.md likely updated but downstream propagation was skipped. See CONTRIBUTING.md § Testing Conventions."
   fi
 
-  # docs/wiki/Changelog.md must either mention the version OR point to CHANGELOG.md
-  # (pointer-based design is valid per ADR-004 — wiki references root as source of truth)
-  if grep -Eq "v${current_version}|CHANGELOG\.md" docs/wiki/Changelog.md; then
-    pass "docs/wiki/Changelog.md references v${current_version} or points to CHANGELOG.md"
+  # B. CHANGELOG.md must contain a version section header (^## v<version>)
+  # Added 2026-04-17: v2.9.0 (issue #124 F1) and v2.11.0 both shipped without this
+  # entry because nothing asserted it. Root CHANGELOG is authoritative per ADR-004.
+  if grep -q "^## v${current_version}" CHANGELOG.md; then
+    pass "CHANGELOG.md contains v${current_version} entry"
   else
-    fail "docs/wiki/Changelog.md missing v${current_version} mention AND no CHANGELOG.md pointer — wiki drift. See CONTRIBUTING.md § Testing Conventions."
+    fail "CHANGELOG.md missing '## v${current_version}' section header — backfill before release. See issue #124 F1."
+  fi
+
+  # C. docs/wiki/Changelog.md must contain a version section header — pointer-to-CHANGELOG.md
+  # is no longer sufficient (the pointer existed in both v2.9.0 and v2.11.0 misses,
+  # and the old assertion passed purely on the literal string "CHANGELOG.md").
+  if grep -q "^## v${current_version}" docs/wiki/Changelog.md; then
+    pass "docs/wiki/Changelog.md contains v${current_version} entry"
+  else
+    fail "docs/wiki/Changelog.md missing '## v${current_version}' section — pointer-to-CHANGELOG.md no longer sufficient. See issue #124 F2."
+  fi
+
+  # D. docs/wiki/Changelog.md badge must match the current version
+  # Added 2026-04-17: v2.11.0 shipped with a stale latest-v2.10.0 badge.
+  if grep -q "badge/latest-v${current_version}-blue" docs/wiki/Changelog.md; then
+    pass "docs/wiki/Changelog.md badge matches v${current_version}"
+  else
+    fail "docs/wiki/Changelog.md badge stale — bump 'latest-v…' to v${current_version}."
   fi
 fi
 


### PR DESCRIPTION
## Summary

Post-release `/cross-verify` on v2.11.0 surfaced recurring CHANGELOG drift across v2.9.0 and v2.11.0 — same class issue [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124) F1+F2 predicted on 2026-04-15. Two releases in a row = capability-level pattern, not discrete miss. This PR ships the structural fix (validator guard) on the same commit as the data fix (CHANGELOG backfill) so H7 investment is immediate, not deferred.

- Backfill root `CHANGELOG.md` — missing v2.9.0 AND v2.11.0 entries (file jumped v2.10.0 → v2.8.0).
- Backfill wiki `docs/wiki/Changelog.md` — missing v2.11.0 entry; badge bumped `latest-v2.10.0` → `latest-v2.11.0`.
- Strengthen `tests/validate-content.sh` Check 19 — 3 new FAIL-severity assertions close the pointer-fallback loophole.

Closes #124.

## Changes

| File | Change | Deliverable |
| --- | --- | --- |
| `CHANGELOG.md` | +v2.11.0, +v2.9.0 sections above v2.10.0 | D1 |
| `docs/wiki/Changelog.md` | +v2.11.0 section + badge bump | D2 + D3 |
| `tests/validate-content.sh` | Rewrite Check 19 with 3 new assertions, remove pointer fallback | D4 |
| `~/.claude/lessons/2026-04-17-v2.11.0-changelog-drift-recurrence.md` | Persist H7 capability-pattern lesson (local, not committed) | D5 |

**Check 19 before:** 2 assertions, wiki-check used `grep -Eq "v${version}|CHANGELOG\.md"` — the OR fallback passed on the literal string "CHANGELOG.md" even when the actual entry was missing. That stealth loophole is why 491/491 assertions passed at both v2.9.0 and v2.11.0 release time.

**Check 19 after:** 4 assertions, all FAIL-severity, all with specific remediation text:
- A. README.md mentions `v<version>` (unchanged)
- B. `CHANGELOG.md` contains `^## v<version>` section header (NEW)
- C. `docs/wiki/Changelog.md` contains `^## v<version>` section — **no pointer fallback** (TIGHTENED)
- D. `docs/wiki/Changelog.md` badge `latest-v<version>-blue` match (NEW)

## Test Plan

- [x] Pre-fix regression: new assertions fail on current tree (CHANGELOG entry missing, wiki entry missing, badge stale) — confirmed all 3 FAILs with correct remediation messages before any doc edits.
- [x] `bash tests/validate-structure.sh` → **243/0 PASS** (no structural change).
- [x] `bash tests/validate-content.sh` → **185/0 PASS** (was 183, +2 net new pass-able assertions — C tightens existing rather than adding).
- [x] `bash tests/test-skill-graph.sh` → **57/0 PASS**.
- [x] `bash tests/test-verbosity-hook.sh` → **19/0 PASS**.
- [x] `grep -n "^## v" CHANGELOG.md` → v2.11.0 / v2.10.0 / v2.9.0 / v2.8.0 / v2.7.1 / v2.7.0 (no gaps).
- [x] `grep -n "^## v" docs/wiki/Changelog.md` → same sequence (no gaps).
- [x] `head -1 docs/wiki/Changelog.md` → badge reads `latest-v2.11.0-blue`.

## Out of scope (remain on #124)

- F3 — test-script cwd sensitivity (separate PR)
- F4 — `gen-habits-reference.sh --check` mode (INFO priority)
- F5 — Port `release-checklist.sh` pattern from devsecops-ai-team (Q2 future investment)

## Why single commit

Docs fix + validator guard travel together. Splitting them would leave a bisect point on `main` where the validator passes but the docs are stale (misleading). Single commit = single pattern fix = single bisect point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)