### PR TITLE
chore(release): v2.11.1 — CHANGELOG drift guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.11.1 — CHANGELOG Drift Guard (2026-04-17)
+
+Patch release hardening `validate-content.sh` Check 19 against a recurring documentation-drift pattern ([#124](https://github.com/pitimon/8-habit-ai-dev/issues/124), [PR #131](https://github.com/pitimon/8-habit-ai-dev/pull/131)). Post-v2.11.0 `/cross-verify` exposed that the same drift class slipped through CI twice — at v2.9.0 and v2.11.0 — because Check 19's pointer-fallback logic (`grep -Eq "v${ver}|CHANGELOG\.md"`) passed purely on the literal string "CHANGELOG.md" in the wiki file, not on any actual version entry. Two releases in a row = capability-level pattern; the fix is a fitness-function assertion, not a checklist.
+
+### Added
+
+- **Check 19 hardening** — 3 new **FAIL**-severity assertions (`tests/validate-content.sh` lines 518–567):
+  - B. `CHANGELOG.md` contains `^## v<version>` section header
+  - C. `docs/wiki/Changelog.md` contains `^## v<version>` section (pointer-to-CHANGELOG.md fallback removed — the stealth loophole)
+  - D. `docs/wiki/Changelog.md` badge `latest-v<version>-blue` matches
+
+### Fixed
+
+- **`CHANGELOG.md`** — backfill missing v2.9.0 + v2.11.0 entries (file previously jumped v2.10.0 → v2.8.0).
+- **`docs/wiki/Changelog.md`** — backfill missing v2.11.0 entry + bump stale badge `latest-v2.10.0` → `latest-v2.11.0`.
+
+### Fitness
+
+- `validate-structure.sh` 243/0, `validate-content.sh` **185/0** (was 183 + 2 net new pass-able assertions), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+Closes [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124). Lesson persisted as H7 capability pattern.
+
+---
+
 ## v2.11.0 — Design Pipeline Completion + Wiki Redesign (2026-04-16)
 
 Close the only remaining structured-output-block gap in the `/requirements` → `/design` → `/breakdown` → `/review-ai` handoff chain ([#128](https://github.com/pitimon/8-habit-ai-dev/issues/128), [PR #129](https://github.com/pitimon/8-habit-ai-dev/pull/129)) and upgrade 20 wiki pages to a professional template ([#127](https://github.com/pitimon/8-habit-ai-dev/issues/127), [PR #130](https://github.com/pitimon/8-habit-ai-dev/pull/130)). Both PRs merged within 3 minutes of each other (14:13 and 14:16 UTC).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.11.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.11.0)
+[![Version](https://img.shields.io/badge/Version-2.11.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.11.1)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.11.0)
+│   ├── plugin.json                 # Plugin metadata (v2.11.1)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -380,6 +380,14 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.11.1
+
+**Theme: CHANGELOG Drift Guard** ([#124](https://github.com/pitimon/8-habit-ai-dev/issues/124), [#131](https://github.com/pitimon/8-habit-ai-dev/pull/131))
+
+- **`tests/validate-content.sh` Check 19 strengthened** — 3 new FAIL-severity assertions close the pointer-fallback loophole that let v2.9.0 and v2.11.0 ship with stale changelogs despite 491/491 validators passing. Now asserts: root `CHANGELOG.md` contains `^## v<version>` entry, wiki `Changelog.md` contains `^## v<version>` entry (no pointer-to-CHANGELOG.md fallback), wiki badge `latest-v<version>-blue` match.
+- **Backfill v2.9.0 + v2.11.0** in root `CHANGELOG.md` (was jumping v2.10.0 → v2.8.0) and v2.11.0 in wiki `Changelog.md` + badge bump.
+- **Lesson persisted** (`~/.claude/lessons/2026-04-17-v2.11.0-changelog-drift-recurrence.md`) as H7 capability pattern: when a QA surfaces the same drift class across 2+ releases, the fix is a validator assertion, not a checklist.
 
 ## What's New in v2.11.0
 
@@ -568,4 +576,4 @@ MIT
 
 ---
 
-_Version: 2.11.0 | Last updated: 2026-04-16_
+_Version: 2.11.1 | Last updated: 2026-04-17_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.11.0 | **Date**: 2026-04-16 | **Previous**: 2.10.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.11.1 | **Date**: 2026-04-17 | **Previous**: 2.11.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,23 @@
-![Version](https://img.shields.io/badge/latest-v2.11.0-blue)
+![Version](https://img.shields.io/badge/latest-v2.11.1-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.11.1 — CHANGELOG Drift Guard (April 2026)
+
+Patch release hardening `validate-content.sh` Check 19 against recurring CHANGELOG drift ([#124](https://github.com/pitimon/8-habit-ai-dev/issues/124), [PR #131](https://github.com/pitimon/8-habit-ai-dev/pull/131)). Post-v2.11.0 `/cross-verify` exposed the same drift class slipping CI twice (v2.9.0 + v2.11.0) through a pointer-fallback loophole.
+
+- **3 new FAIL-severity assertions** in Check 19: `CHANGELOG.md ^## v<ver>` present, wiki `^## v<ver>` present (no pointer fallback), wiki badge `latest-v<ver>-blue` match.
+- **Backfilled** missing v2.9.0 + v2.11.0 entries in root `CHANGELOG.md` and v2.11.0 in wiki `Changelog.md`.
+
+Fitness receipts: `validate-structure.sh` 243/0, `validate-content.sh` 185/0, `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+Closes #124.
+
+---
 
 ## v2.11.0 — Design Pipeline Completion + Wiki Redesign (April 2026)
 


### PR DESCRIPTION
## Summary

Patch release bumping the plugin from **v2.11.0 → v2.11.1**. Ships the structural fix for recurring CHANGELOG drift first documented in #124 and landed in #131.

The #131 change is a CI-visible behavior change (stricter Check 19 + pointer-fallback removal + new badge assertion), which warrants a patch bump per semver.

## Version Bumps

All 4 authoritative files bumped together per plugin convention (enforced by `validate-structure.sh` Check 4):

| File | Before | After |
| --- | --- | --- |
| `.claude-plugin/plugin.json` | `"version": "2.11.0"` | `"version": "2.11.1"` |
| `.claude-plugin/marketplace.json` | `"version": "2.11.0"` | `"version": "2.11.1"` |
| `README.md` (badge + struct diagram + footer + What's New) | v2.11.0 | v2.11.1 |
| `SELF-CHECK.md` header | 2.11.0 / Previous 2.10.0 | 2.11.1 / Previous 2.11.0 |

## Changelog Entries

- `CHANGELOG.md` — new `## v2.11.1 — CHANGELOG Drift Guard (2026-04-17)` section above v2.11.0 entry.
- `docs/wiki/Changelog.md` — new `## v2.11.1` summary + badge bump `latest-v2.11.0` → `latest-v2.11.1`.

Both CHANGELOG surfaces are now self-consistent — the newly strengthened Check 19 passes on its own release's files.

## Validator Receipts at v2.11.1

- `validate-structure.sh` → **243/0 PASS** (version consistency across all 4 files green)
- `validate-content.sh` → **185/0 PASS** (Check 19 now enforces CHANGELOG + wiki entry + wiki badge match at FAIL severity)
- `test-skill-graph.sh` → **57/0 PASS**
- `test-verbosity-hook.sh` → **19/0 PASS**

## Test Plan

- [x] All 4 validators pass locally.
- [ ] CI `validate` job green.
- [ ] CI `linkcheck` job green.
- [ ] After merge: tag `v2.11.1`, push tag, cut GitHub release.

## Why Patch, Not Minor

No user-facing skill changes, no new skills, no workflow additions — only a test-suite tightening + backfill of past changelogs. Strict semver: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)