### PR TITLE
feat(research): grep evidence for code-symbol verdicts (#133)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.12.0 — Code-Symbol Grep Evidence (2026-04-17)
+
+Minor release adding a new Evidence Standard obligation to the `/research` skill and clarifying the scope of the `research-verifier` agent ([#133](https://github.com/pitimon/8-habit-ai-dev/issues/133)). Guidance-only — no automation, no hook, no change to verifier execution behavior.
+
+**Motivation**: A real-world Deep-mode `/research` tech-stack audit (memforge v1.10.0, 2026-04-17) produced a findings row verdicting `neo4j-driver` as "dead/transitional". The `research-verifier` agent passed the brief: every file path and line number cited was accurate. A downstream PRD and Design doc were produced recommending removal. A simple grep at the next workflow step revealed 5+ files with active imports — `neo4j-driver` is the canonical Bolt-protocol client for Memgraph (both engines share the same TS/Node client library). Removing it would have broken production graph on first image rebuild. The verdict passed Deep-mode verification on pristine citations while carrying a load-bearing false semantic claim.
+
+### Added
+
+- **`skills/research/SKILL.md` — Evidence Standard bullet**: when an Audit-mode or Findings-table row's verdict matches `/remove|dead|unused|transitional|safe to (drop|remove)/i` on a code symbol (dep, module, function, exported type, file), the row must cite a grep-check across the repo's source directories showing whether consumers exist. Declaration-site citations (e.g. `package.json:6`, import statements) do not establish liveness. Two concrete examples included (dead-verdict and keep-verdict shapes).
+- **`skills/research/SKILL.md` — Step 4 scope callout**: one-line note after the Deep-mode dispatch makes explicit that the verifier gates citation integrity, not semantic correctness, and that code-symbol verdicts need separate grep evidence even when Deep-mode passes.
+- **`skills/research/SKILL.md` — Definition-of-Done line**: new checklist item so code-symbol verdicts are visible at handoff time.
+- **`agents/research-verifier.md` — `description:` frontmatter**: rewritten to "citation-integrity verification agent" with an explicit out-of-scope clause callers see before dispatching.
+- **`agents/research-verifier.md` — `## Limit of Verification` section**: defines in-scope (file paths exist, line numbers contain the claimed text, URLs resolve, documents are findable) vs. out-of-scope (semantic correctness of conclusions) and introduces a `SEMANTIC-EVIDENCE-MISSING` flag the verifier emits when a code-symbol verdict row lacks liveness evidence. The verifier does **not** attempt the grep itself — that remains the author's obligation.
+
+### Intentionally not in scope
+
+- Expanding the `research-verifier` agent to semantically check conclusions. Per CONTRIBUTING.md philosophy ("Skills provide guidance, not automation"), this is a documentation change that gives Claude an explicit obligation for a specific verdict shape.
+- `"revisit"` is intentionally **excluded** from the obligation trigger. It is a weaker, follow-up-style verdict that would over-trigger the grep requirement on rows that are merely flagged for attention. The hard-removal verdicts (`remove`, `dead`, `unused`, `transitional`, `safe to drop/remove`) are the load-bearing class.
+
+### Cost/benefit
+
+~2 seconds of grep per dead-verdict row. Benefit in the incident above: ~1 hour of downstream workflow (PRD + Design + archive + correction log) saved, plus averted production-graph breakage.
+
+---
+
 ## v2.11.1 — CHANGELOG Drift Guard (2026-04-17)
 
 Patch release hardening `validate-content.sh` Check 19 against a recurring documentation-drift pattern ([#124](https://github.com/pitimon/8-habit-ai-dev/issues/124), [PR #131](https://github.com/pitimon/8-habit-ai-dev/pull/131)). Post-v2.11.0 `/cross-verify` exposed that the same drift class slipped through CI twice — at v2.9.0 and v2.11.0 — because Check 19's pointer-fallback logic (`grep -Eq "v${ver}|CHANGELOG\.md"`) passed purely on the literal string "CHANGELOG.md" in the wiki file, not on any actual version entry. Two releases in a row = capability-level pattern; the fix is a fitness-function assertion, not a checklist.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.11.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.11.1)
+[![Version](https://img.shields.io/badge/Version-2.12.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.12.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -307,7 +307,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.11.1)
+│   ├── plugin.json                 # Plugin metadata (v2.12.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -380,6 +380,14 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.12.0
+
+**Theme: Code-Symbol Grep Evidence** ([#133](https://github.com/pitimon/8-habit-ai-dev/issues/133))
+
+- **`/research` Evidence Standard — code-symbol verdicts require grep evidence** — when an Audit-mode or Findings-table row's verdict matches `/remove|dead|unused|transitional|safe to (drop|remove)/i` on a code symbol (dep, module, function, exported type, file), the row must cite a grep-check showing consumers across the repo's source directories. Declaration-site citations (e.g. `package.json:6`) do not establish liveness. Closes a false-positive class where plausible-sounding "brand names differ, must be unrelated" reasoning passed Deep-mode verification with pristine citations (real-world: memforge `neo4j-driver` audit — `neo4j-driver` is the canonical Bolt client for Memgraph; would have broken production graph on first rebuild).
+- **`/research` Step 4 clarification** — one-line callout after the Deep-mode dispatch makes the verifier's scope explicit inline: citation integrity, not semantic correctness.
+- **`research-verifier` agent scope clarified** — `description:` frontmatter rewritten to say "citation-integrity verification agent" and to spell out what is out of scope. New `## Limit of Verification` section inside the agent body defines in-scope vs. out-of-scope, and introduces a `SEMANTIC-EVIDENCE-MISSING` flag the verifier emits (without performing the grep itself) when a code-symbol verdict row lacks liveness evidence. The agent's execution behavior is unchanged — this is a documentation change preventing authors from over-trusting a passing Deep-mode gate.
 
 ## What's New in v2.11.1
 
@@ -576,4 +584,4 @@ MIT
 
 ---
 
-_Version: 2.11.1 | Last updated: 2026-04-17_
+_Version: 2.12.0 | Last updated: 2026-04-17_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.11.1 | **Date**: 2026-04-17 | **Previous**: 2.11.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.12.0 | **Date**: 2026-04-17 | **Previous**: 2.11.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 

--- a/agents/research-verifier.md
+++ b/agents/research-verifier.md
@@ -1,9 +1,11 @@
 ---
 name: research-verifier
 description: >
-  Source verification agent — validates cited URLs, checks file path existence,
-  flags dead links in research briefs. Use during /research Deep mode or when
-  evidence verification is needed. Read-only analysis.
+  Citation-integrity verification agent — validates cited URLs, checks file path
+  existence, flags dead links in research briefs. Use during /research Deep mode
+  or when evidence verification is needed. Read-only analysis. Does NOT verify
+  semantic correctness of conclusions (e.g. "this dep is unused") — those require
+  separate grep or call-graph evidence provided by the author.
 model: sonnet
 tools: ["Read", "Glob", "Grep", "WebFetch"]
 ---
@@ -15,6 +17,17 @@ You are a source verification agent who validates every citation in a research b
 ## Scope
 
 Verify all cited sources in a research brief. Confirm that file paths exist, URLs resolve, and document references are findable.
+
+## Limit of Verification (important)
+
+This agent gates **citation integrity**, not **semantic correctness**. Specifically:
+
+- **In scope**: cited file paths exist, cited line numbers contain the claimed text, cited URLs resolve, cited documents are findable.
+- **Out of scope**: whether the conclusion drawn from those citations is true. Verdicts such as "this dep is unused", "this function is dead", "this module is transitional/safe-to-drop" require independent evidence (typically a grep across the repo's source directories, or a call-graph pass) that the brief author must provide in the row itself.
+
+A passing verdict from this agent means "every citation is real and accurate." It does **not** mean "every conclusion is correct." The `/research` skill's Evidence Standard (code-symbol verdicts require grep evidence) is the author's responsibility; this agent does not backstop it.
+
+If a brief row's verdict matches `/remove|dead|unused|transitional|safe to (drop|remove)/i` on a code symbol and the row does not cite grep-check liveness evidence, flag it under "Issues Found" as `SEMANTIC-EVIDENCE-MISSING` — but do not attempt the grep yourself (that is the author's obligation, not the verifier's).
 
 ## Process
 

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,24 @@
-![Version](https://img.shields.io/badge/latest-v2.11.1-blue)
+![Version](https://img.shields.io/badge/latest-v2.12.0-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.12.0 — Code-Symbol Grep Evidence (April 2026)
+
+Minor release adding a new Evidence Standard obligation to `/research` and clarifying `research-verifier` scope ([#133](https://github.com/pitimon/8-habit-ai-dev/issues/133)). Guidance-only — no automation, no hook.
+
+- **`/research` Evidence Standard** — code-symbol verdicts matching `/remove|dead|unused|transitional|safe to (drop|remove)/i` must cite a grep-check showing consumer usage across source directories; declaration-site citations (e.g. `package.json:6`) do not establish liveness. Closes a false-positive class surfaced by memforge `neo4j-driver` audit (the canonical Bolt client for Memgraph — brand-name mismatch passed Deep-mode with pristine citations).
+- **`research-verifier` scope** — `description:` rewritten to "citation-integrity verification agent"; new `## Limit of Verification` section defines in-scope (citation accuracy) vs. out-of-scope (semantic correctness of conclusions). Verifier emits `SEMANTIC-EVIDENCE-MISSING` flag on code-symbol verdict rows lacking liveness evidence but does not perform the grep itself.
+- **Trigger regex scope** — `"revisit"` intentionally excluded; over-triggers on follow-up-style verdicts. Hard-removal verdicts are the load-bearing class.
+
+Fitness receipts: `validate-structure.sh`, `validate-content.sh`, `test-skill-graph.sh`, `test-verbosity-hook.sh` all green.
+
+Closes #133.
+
+---
 
 ## v2.11.1 — CHANGELOG Drift Guard (April 2026)
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -117,6 +117,8 @@ Before documenting findings, verify all cited sources:
 
 **Deep**: Dispatch the `research-verifier` agent for comprehensive verification. Use the Agent tool with `subagent_type: "8-habit-ai-dev:research-verifier"` passing the draft brief. The agent checks every citation and produces a verification report.
 
+> **Scope of Deep-mode verification**: the agent gates **citation integrity** (cited files/URLs exist and contain the claimed text), not **semantic correctness** of conclusions drawn from those citations. A verdict like "this dep is unused" needs separate evidence (see _Evidence Standard_ below) even when Deep-mode passes.
+
 ### 5. Document constraints and findings
 
 Produce a research brief using the template. Load the template for the full structure:
@@ -154,6 +156,13 @@ Every finding MUST cite its source (Feynman principle: "evidence or it didn't ha
 
 No unsourced claims. If you can't cite it, mark it as "unverified assumption."
 
+**Code-symbol verdicts require grep evidence.** When an Audit-mode or Findings-table row's verdict concerns the existence or live usage of a code symbol (dependency, module, function, exported type, file) — specifically any verdict matching `/remove|dead|unused|transitional|safe to (drop|remove)/i` — the row must cite a grep-check across the repo's source directories showing whether consumers exist. Citing the declaration site alone (e.g. `package.json:6`, an import statement) does not establish liveness. Examples:
+
+- Dead verdict: `` `grep -rE "neo4j[-_]driver" --exclude-dir=node_modules --exclude=*.lock .` → 0 consumer matches `` (liveness evidence)
+- Keep verdict: list of 5 consumer files from the grep (liveness evidence)
+
+Rationale: a dep or symbol can be imported by a different-sounding name (e.g. `neo4j-driver` is the canonical Bolt client for Memgraph). Plausible-sounding "brand names differ, must be unrelated" reasoning has produced false-positive removal verdicts that passed Deep-mode verification with pristine citations. ~2 seconds of grep closes this class of error.
+
 ## When to Skip
 
 - Requirements already clear from user or stakeholder — nothing to investigate
@@ -171,6 +180,7 @@ No unsourced claims. If you can't cite it, mark it as "unverified assumption."
 - [ ] Constraints documented with source
 - [ ] Comparison matrix included (if Compare mode) with evidence per cell
 - [ ] Audit results included (if Audit mode) with file:line per row
+- [ ] Code-symbol verdicts (remove/dead/unused/transitional/safe-to-drop) cite grep-check liveness evidence, not just declaration sites
 - [ ] Research brief ready for handoff to /requirements
 
 ## Further Reading


### PR DESCRIPTION
## Summary

- **`/research` Evidence Standard** gains a code-symbol verdict obligation: rows whose verdict matches `/remove|dead|unused|transitional|safe to (drop|remove)/i` on a code symbol (dep, module, function, exported type, file) must cite a grep-check showing consumer liveness. Declaration-site citations (e.g. `package.json:6`, import statements) do not establish liveness.
- **`research-verifier` agent scope clarified** — `description:` rewritten to "citation-integrity verification agent" and a new `## Limit of Verification` section makes the in/out-of-scope boundary explicit. Introduces `SEMANTIC-EVIDENCE-MISSING` flag the verifier emits on code-symbol verdict rows lacking liveness evidence (without performing the grep itself — that stays the author's obligation).
- **Guidance-only change** — no automation, no hook, no change to verifier execution behavior. Per CONTRIBUTING.md philosophy ("Skills provide guidance, not automation").

## Motivation

A real-world Deep-mode `/research` tech-stack audit (memforge v1.10.0, 2026-04-17) verdicted `neo4j-driver` as **"dead/transitional"** on pristine citations that the `research-verifier` passed. A simple `grep -rE "neo4j[-_]driver"` at the next workflow step revealed **5+ files with active imports** — `neo4j-driver` is the canonical Bolt-protocol client for Memgraph (both engines share the same Node client library). Removing it per the audit verdict would have broken production graph on first image rebuild.

The verdict passed Deep-mode verification on accurate citations while carrying a load-bearing false **semantic** claim. Root cause: Step 2 of `/research` said "Glob/Grep the codebase for related patterns" but did not tie this to a specific obligation when the verdict concerns the existence or live usage of a code symbol.

## Trigger regex scope decision

`"revisit"` is intentionally **excluded** from the obligation trigger — weaker follow-up verdict, would over-trigger on rows merely flagged for attention. The hard-removal verdicts (`remove`, `dead`, `unused`, `transitional`, `safe to drop/remove`) are the load-bearing class. Authors can still add grep evidence to `"revisit"` rows voluntarily.

## Intentionally not in scope

- Expanding the `research-verifier` to semantically check conclusions. This is a documentation change; the issue was explicit that scope expansion is out-of-bounds.

## Files touched

| File | Change |
|------|--------|
| `skills/research/SKILL.md` | Evidence Standard bullet, Step 4 scope callout, Definition-of-Done item |
| `agents/research-verifier.md` | `description:` rewrite, new `## Limit of Verification` section |
| `.claude-plugin/plugin.json` | version 2.11.1 → 2.12.0 |
| `.claude-plugin/marketplace.json` | version 2.11.1 → 2.12.0 |
| `README.md` | badge, plugin.json comment, What's New heading, footer |
| `SELF-CHECK.md` | header version |
| `CHANGELOG.md` | v2.12.0 entry |
| `docs/wiki/Changelog.md` | v2.12.0 entry + badge |

## Cross-verification

Pre-implementation `/cross-verify` score: **15/17 (94%)**, band **Well-prepared**. Single Fail was Q2 (wording undecided on trigger regex); resolved by narrowing the trigger to exclude `"revisit"` before implementation.

## Test plan

- [x] `bash tests/validate-structure.sh` → 243/0 PASS
- [x] `bash tests/validate-content.sh` → 184/0 PASS, 1 soft WARN (research DoD at 10 items — accepted; the added item is load-bearing)
- [x] `bash tests/test-skill-graph.sh` → 57/0 PASS
- [x] `bash tests/test-verbosity-hook.sh` → 19/0 PASS
- [x] Check 19 confirms v2.12.0 present in `CHANGELOG.md`, `docs/wiki/Changelog.md`, and wiki badge
- [ ] Manual invocation of `/research` in a sandbox to confirm the new guidance renders and reads cleanly (reviewer)
- [ ] Spot-check: the `SEMANTIC-EVIDENCE-MISSING` flag wording in the verifier agent is actionable for a future Deep-mode brief review (reviewer)

## Cost/benefit

~2 seconds of grep per hard-removal verdict row. Benefit observed in the incident: ~1 hour of downstream workflow (PRD + Design + archive + correction log) saved, plus averted production-graph breakage.

Closes #133.