### PR TITLE
docs(readme): cite "Thin Harness, Fat Skills" as external validation (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 **The Framework**
 
+- [Design Principle](#design-principle) — Thin harness, fat skills
 - [7-Step Workflow](#the-7-step-workflow) — Visual pipeline from research to monitoring
 - [Skills Reference](#skills-reference) — All 17 skills with habit mappings
 - [Use Cases](#use-cases-which-skill-when) — Common scenarios and recommended paths
@@ -64,6 +65,14 @@ The 7 most common mistakes:
 7. **No monitoring** — "it works on my machine" mindset
 
 This plugin provides a **skill for each step** — not as a gate, but as a habit.
+
+---
+
+## Design Principle
+
+We follow the **"Thin Harness, Fat Skills"** pattern — the session hook is bounded (≤300 tokens, enforced in [`hooks/session-start.sh`](hooks/session-start.sh) and documented in `CLAUDE.md`), and the intelligence lives in on-demand markdown skills loaded when you invoke them. The harness gets out of the way; the skills do the work.
+
+The same principle is documented independently by Garry Tan (President & CEO, Y Combinator) in his 2026 essay [_"Thin Harness, Fat Skills"_](https://github.com/garrytan/gbrain/blob/master/docs/ethos/THIN_HARNESS_FAT_SKILLS.md) and shipped in [gbrain](https://github.com/garrytan/gbrain). We arrived at it from workflow discipline; he arrived at it from building a brain — same conclusion.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a short **## Design Principle** section to `README.md` between "The Problem" and "Quick Start"
- Cites Garry Tan's 2026 essay [_"Thin Harness, Fat Skills"_](https://github.com/garrytan/gbrain/blob/master/docs/ethos/THIN_HARNESS_FAT_SKILLS.md) (garrytan/gbrain, MIT) as external validation of our bounded-session-hook + on-demand-skills architecture
- Adds matching ToC entry under "The Framework"

## Why

The ≤300-token hook budget is already enforced in `hooks/session-start.sh:2` and documented in `CLAUDE.md:16,50`, but reads as a local implementation detail. Naming the pattern and crediting an independent YC-CEO source promotes it to a first-class design principle — useful for both new adopters (credibility signal) and future contributors tempted to grow the session hook (principled choice, not arbitrary).

Pure docs delta — 9 line insertion across 2 hunks, no code paths touched.

## Out of scope (from #137 body)

- ❌ Other gbrain mechanisms (`RESOLVER.md` → #135; `llms.txt` / `AGENTS.md` → #136)
- ❌ Verbatim content copy — we link, we don't replicate
- ❌ New `docs/ethos/` directory (our `habits/` + `rules/effective-development.md` already carry the philosophy role)
- ❌ Version bump — docs-only change; rides the next release

## Test plan

- [x] External link verified live via `gh api /repos/garrytan/gbrain/contents/docs/ethos/THIN_HARNESS_FAT_SKILLS.md` — returns HTTP 200, file SHA `f17a773`, size 13.6KB
- [x] `bash tests/validate-structure.sh` → **PASS: 243, FAIL: 0**
- [x] `bash tests/validate-content.sh` → **PASS: 184, FAIL: 0, WARN: 1** (unchanged baseline)
- [x] `bash tests/test-skill-graph.sh` → **PASS: 57, FAIL: 0**
- [x] `bash tests/test-verbosity-hook.sh` → **PASS: 19, FAIL: 0** (including "hook output fits ≤300 token budget (~180 tokens)" — nicely reinforces the new section's claim)
- [x] `CLAUDE.md` untouched — no duplicate enforcement language
- [x] No version bump, no other files changed

Closes #137.