### PR TITLE
feat(skills): add skills/RESOLVER.md — flat trigger-to-skill dispatcher (#135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,10 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 
 `8-habit-ai-dev` and [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) are **complementary by design** (see memory obs #233270, 2026-04-07, titled "Both Recommended for Maximum Coverage"). Do not duplicate features across plugins.
 
-| Plugin                      | Domain                                                                                     | Examples                                                                                                                                                                                                                                                                          |
-| --------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`8-habit-ai-dev`** (this) | Workflow **discipline** — how to develop well                                              | 7-step workflow, 8 Habits, Whole Person Model, `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`, `/cross-verify`, `/reflect`, `/calibrate` (user maturity), `/ai-dev-log` (transparency), `/security-check` (review lens)                 |
-| **`claude-governance`**     | Compliance **enforcement** + **frameworks** — blocking bad behavior + mapping to standards | PreToolUse secret-scanner hook (25 patterns), Three Loops Decision Model (ADR-002 consequence-based auth), OWASP DSGAI mapping (11 controls), EU AI Act compliance toolkit (planned v3.1.0+), `/governance-check`, `/spec-driven-dev`, `/create-adr`, `governance-reviewer` agent |
+| Plugin                      | Domain                                                                                     | Examples                                                                                                                                                                                                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`8-habit-ai-dev`** (this) | Workflow **discipline** — how to develop well                                              | 7-step workflow, 8 Habits, Whole Person Model, `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`, `/cross-verify`, `/reflect`, `/calibrate` (user maturity), `/ai-dev-log` (transparency), `/security-check` (review lens) |
+| **`claude-governance`**     | Compliance **enforcement** + **frameworks** — blocking bad behavior + mapping to standards | PreToolUse secret-scanner hook (25 patterns), Three Loops Decision Model (ADR-002 consequence-based auth), OWASP DSGAI mapping (11 controls), EU AI Act compliance toolkit (planned v3.1.0+), `/governance-check`, `/spec-driven-dev`, `/create-adr`, `governance-reviewer` agent               |
 
 **Rule of thumb before adding a new feature here**:
 
@@ -70,26 +70,29 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 **Users who want maximum coverage**: install both plugins together. They compose cleanly — no conflicts.
 
 **Cross-plugin specs** (defined here, implemented in `claude-governance`):
+
 - [`guides/habit-nudges.md`](guides/habit-nudges.md) (v2.6.0) — specification for proactive workflow nudges; hook implementation belongs in `claude-governance`. Catalog of 6 nudges with triggers, cooldowns, and opt-out via `HABIT_QUIET=1`.
 
 ## Skills → Habits Mapping
 
-| Skill                 | Step | Habit                 | Purpose                                                                          |
-| --------------------- | ---- | --------------------- | -------------------------------------------------------------------------------- |
-| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                    |
-| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                      |
-| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                       |
-| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                     |
-| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                         |
-| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                              |
-| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready                                                    |
-| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                          |
-| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                        |
-| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                    |
-| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                           |
-| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                   |
-| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation tiered checklist (v2.3.0, migrating to claude-governance) |
-| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                    |
+> For phrase-based lookup ("given these words, which skill?"), see [`skills/RESOLVER.md`](skills/RESOLVER.md). The table below indexes by workflow step; RESOLVER indexes by user intent.
+
+| Skill                 | Step | Habit                 | Purpose                                                                                                                                                 |
+| --------------------- | ---- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                                           |
+| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                                             |
+| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                                              |
+| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                                            |
+| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                                                |
+| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                                                     |
+| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready                                                                                                                           |
+| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                                                 |
+| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                                               |
+| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                                           |
+| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                                                  |
+| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                                          |
+| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation tiered checklist (v2.3.0, migrating to claude-governance)                                                                        |
+| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                                           |
 | `/reflect`            | —    | H7 Sharpen the Saw    | 6-question post-task retrospective + persistent lesson file (`~/.claude/lessons/`) + skill-effectiveness signal (v2.6.1, Q6 → `SKILL-EFFECTIVENESS.md`) |
-| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` so other skills adapt verbosity to maturity level (v2.6.0) |
-| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                        |
+| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` so other skills adapt verbosity to maturity level (v2.6.0)                                               |
+| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                                               |

--- a/docs/adr/ADR-010-flat-skill-dispatcher.md
+++ b/docs/adr/ADR-010-flat-skill-dispatcher.md
@@ -1,0 +1,74 @@
+# ADR-010: Flat Skill Dispatcher (`skills/RESOLVER.md`)
+
+- **Status**: Accepted
+- **Date**: 2026-04-22
+- **Supersedes**: None
+- **Related**: Issue #135 (this ADR's origin), Issue #136 (consumer — llms.txt links to RESOLVER), ADR-009 (skill split convention)
+
+## Context
+
+The plugin ships 17 skills. "Which skill for this task?" knowledge is spread across four existing sources, each indexed by a different dimension:
+
+| Source                                  | Indexed by           | Shape            |
+| --------------------------------------- | -------------------- | ---------------- |
+| `CLAUDE.md` § Skills → Habits Mapping   | Workflow step        | Table            |
+| Each skill's `description:` frontmatter | Skill name           | YAML field       |
+| `/using-8-habits` decision tree         | User situation       | Narrative + tree |
+| `prev-skill` / `next-skill` frontmatter | Predecessor in chain | DAG              |
+
+None of these is a **phrase → path** lookup. A user who types raw intent — "I want to audit this PR for security" — has no direct way to learn that `/security-check` is the answer without first reading `/using-8-habits` or the full README skills table. The same gap hurts non-Claude agents (Codex, Cursor, Windsurf) that dispatch by phrase matching rather than slash-command mapping.
+
+The idea for a flat dispatcher came from [`garrytan/gbrain`](https://github.com/garrytan/gbrain/blob/master/skills/RESOLVER.md) during the 2026-04-22 `/research` session (Issue #135).
+
+## Options Considered
+
+| Option                                          | Summary                                                                                                           | Trade-offs                                                                                                                   | Verdict                                                       |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **A. New `skills/RESOLVER.md`** (chosen)        | Flat table file grouped by the existing 3-category taxonomy, ≤3 triggers per skill, bidirectional validator check | ✅ Orthogonal to existing sources; standalone URL for #136; enforceable invariant. ⚠️ One more file in the doc surface.      | **Accepted**                                                  |
+| B. `manifest.json` (machine-readable)           | Generate a JSON inventory of skills with trigger arrays                                                           | ✅ Parseable. ❌ Duplicates `test-skill-graph.sh` + frontmatter chains; drift risk without runtime consumer.                 | Rejected — no new machine need beyond what frontmatter gives. |
+| C. Extend `/using-8-habits` with a flat section | Append a `## Triggers` table to the existing meta-skill                                                           | ✅ One fewer file. ❌ Dilutes 132-line narrative; denies #136 a standalone URL; violates the ADR-009 skill-split spirit.     | Rejected — wrong shape for the job.                           |
+| D. Runtime auto-dispatch hook                   | Install a session hook that matches phrases and loads skills automatically                                        | ✅ Zero cognitive load. ❌ Enforcement gate — belongs in `claude-governance`, not `8-habit-ai-dev` (plugin boundary).        | Rejected — wrong plugin.                                      |
+| E. Adopt gbrain's 7-category taxonomy verbatim  | Use Always-on / Brain ops / Content / Thinking / Operational / Setup / Identity                                   | ✅ Pattern match with source material. ❌ Our 17 skills fit cleanly into 3 existing categories; 7 categories would fragment. | Rejected — structure must fit our scope, not the source's.    |
+
+## Decision
+
+Add a single file **`skills/RESOLVER.md`** — a flat dispatcher grouped in 3 sections that mirror `/using-8-habits`'s existing taxonomy:
+
+1. **Workflow Skills (Steps 0–7)** — 8 rows
+2. **Assessment Skills** — 6 rows
+3. **Meta / Onboarding** — 3 rows
+
+Each row carries: trigger phrases (≤3 per skill), a `skills/<name>/SKILL.md` path citation, and a one-line purpose. RESOLVER is **lookup-only**; narrative and decision-tree stay in `/using-8-habits`.
+
+A bidirectional integrity check (**Check 20** in `tests/validate-structure.sh`) enforces:
+
+- Every RESOLVER path resolves to an existing `skills/<name>/SKILL.md`
+- Every `skills/<name>/` directory appears in at least one RESOLVER row
+
+A single pointer sentence is added to `CLAUDE.md` under `## Skills → Habits Mapping`. No skill frontmatter schema changes. No runtime dispatch.
+
+## Consequences
+
+### Positive
+
+- **New users** can find a skill by typing their intent rather than learning slash-command names first.
+- **Non-Claude agents** get a standalone URL to link to from llms.txt / AGENTS.md (Issue #136 unblocked).
+- **Future skill authors** gain a mechanical onboarding step ("add a RESOLVER row") enforced by Check 20 — coverage invariant is now a test, not a hope.
+- **Skill-split tradeoffs** are honored: `/using-8-habits` stays 132-line narrative, RESOLVER stays ≤110-line table. Neither bloats to cover the other's job.
+
+### Negative / Risks
+
+- RESOLVER and `/using-8-habits` must stay **shape-differentiated** (flat table vs narrative). Drift risk caught at code review — not runtime-enforceable.
+- Trigger-phrase wording is **semi-sticky**: refinable per row post-ship, but the 3-section taxonomy and `skills/<name>/SKILL.md` path pattern are sticky (>50% rework to change — invalidates #136 llms.txt anchors).
+- Adds one file to the on-demand load surface. Mitigated by: RESOLVER is not loaded by any hook or skill — it's read by humans / agents only.
+
+## Compliance
+
+- **Plugin boundary**: ✅ RESOLVER is guidance + a reference check. No enforcement gate or runtime hook.
+- **Article 14 (EU AI Act)**: N/A — dev-tooling plugin feature, not an AI system under Annex III.
+- **Validator invariants**: ✅ Check 20 enforces bidirectional coverage; 3 failure-message strings specified for debuggability.
+- **Size limits**: ✅ `skills/RESOLVER.md` ≤ 110 body lines (file-size budget); within plugin's `<800 line` per-file rule.
+
+## Supersession
+
+If future work expands `/using-8-habits` to absorb RESOLVER's role (e.g., reorganizing around phrase lookup), a new ADR supersedes this one. Do not amend ADR-010 in place — the rejection of "extend `/using-8-habits` instead" is load-bearing history.

--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -1,0 +1,54 @@
+# Skill Resolver — Trigger-Phrase Dispatcher
+
+This is a flat lookup. **Given these words → which SKILL.md to read.** It does not replace the narrative decision tree in [`/using-8-habits`](using-8-habits/SKILL.md) — use that for _why_ and _when_. Use this for _which file_.
+
+**Constraints**:
+
+- ≤3 trigger phrases per skill (keeps the file scannable)
+- Every row cites `skills/<name>/SKILL.md` — enforced bidirectionally by Check 20 in `tests/validate-structure.sh`
+- Pattern: quoted user phrase or short action description → skill path → one-line purpose
+
+Pick the row whose trigger matches the user intent, then read the cited SKILL.md before acting. If two rows could match, read both — skills chain (e.g., `/research` → `/requirements` → `/design`).
+
+---
+
+## Workflow Skills (Steps 0–7)
+
+| Trigger                                                                              | Skill                                                     | Purpose                                                                               |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `"investigate"`, `"research before specifying"`, starting with an unclear problem    | [`skills/research/SKILL.md`](research/SKILL.md)           | Step 0 — investigate prior art, sources, constraints before writing requirements (H5) |
+| `"define done"`, `"write a PRD"`, `"plan this feature"`                              | [`skills/requirements/SKILL.md`](requirements/SKILL.md)   | Step 1 — PRD summary + EARS acceptance criteria (H2)                                  |
+| `"architecture decisions"`, `"design the system"`, choosing DB / auth / API shape    | [`skills/design/SKILL.md`](design/SKILL.md)               | Step 2 — surface decisions with trade-offs, human decides (H8)                        |
+| `"split into tasks"`, `"atomic tasks"`, decomposing a feature for parallel agents    | [`skills/breakdown/SKILL.md`](breakdown/SKILL.md)         | Step 3 — atomic tasks, 1 task per agent (H3)                                          |
+| `"context before coding"`, `"brief me on this task"`, starting an atomic task        | [`skills/build-brief/SKILL.md`](build-brief/SKILL.md)     | Step 4 — context-rich implementation brief per task (H5)                              |
+| `"audit AI code"`, `"review before commit"`, after AI writes code and before staging | [`skills/review-ai/SKILL.md`](review-ai/SKILL.md)         | Step 5 — audit AI-generated code for security, quality, completeness (H4)             |
+| `"deploy to staging"`, `"ship this safely"`, production deploy planning              | [`skills/deploy-guide/SKILL.md`](deploy-guide/SKILL.md)   | Step 6 — staging-first deploy with rollback plan (H1)                                 |
+| `"set up monitoring"`, `"error tracking"`, observability after deploy                | [`skills/monitor-setup/SKILL.md`](monitor-setup/SKILL.md) | Step 7 — error tracking, alerting, health checks (H7)                                 |
+
+## Assessment Skills
+
+| Trigger                                                                               | Skill                                                               | Purpose                                                                  |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `"cross-verify the plan"`, `"something feels off"`, 17-question checklist before ship | [`skills/cross-verify/SKILL.md`](cross-verify/SKILL.md)             | 17-question 8-habit checklist with dimension summary                     |
+| `"balance check"`, `"Body/Mind/Heart/Spirit"`, `"is this well-rounded?"`              | [`skills/whole-person-check/SKILL.md`](whole-person-check/SKILL.md) | 4-dimension assessment — discipline/vision/passion/conscience            |
+| `"security review"`, `"OWASP Top 10"`, `"check for secrets / injection"`              | [`skills/security-check/SKILL.md`](security-check/SKILL.md)         | Focused security lens — secrets, injection, auth, OWASP Top 10           |
+| `"EU AI Act compliance"`, `"high-risk AI checklist"`, Articles 9–15 obligations       | [`skills/eu-ai-act-check/SKILL.md`](eu-ai-act-check/SKILL.md)       | 9-obligation EU AI Act tiered checklist (migrating to claude-governance) |
+| `"AI dev log"`, `"Article 11 audit trail"`, generate AI disclosure from git           | [`skills/ai-dev-log/SKILL.md`](ai-dev-log/SKILL.md)                 | AI-assisted dev log from git history + Co-Authored-By trailers           |
+| `"retrospective"`, `"what did we learn"`, `"post-task reflection"`                    | [`skills/reflect/SKILL.md`](reflect/SKILL.md)                       | 6-question micro-retrospective + persistent lesson file                  |
+
+## Meta / Onboarding
+
+| Trigger                                                               | Skill                                                       | Purpose                                                                      |
+| --------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `"new to the plugin"`, `"which skill should I use?"`, `"onboard me"`  | [`skills/using-8-habits/SKILL.md`](using-8-habits/SKILL.md) | Onboarding meta-skill — 7-step workflow + 17-skill inventory + decision tree |
+| `"what's my habit maturity"`, `"assess my level"`, `"set my profile"` | [`skills/calibrate/SKILL.md`](calibrate/SKILL.md)           | 5–7 question maturity assessment → persists `~/.claude/habit-profile.md`     |
+| `"walk me through the 7 steps"`, `"guided workflow"`, starting fresh  | [`skills/workflow/SKILL.md`](workflow/SKILL.md)             | Guided 7-step walkthrough with skip prompts per step                         |
+
+---
+
+## Related
+
+- **Why** each skill exists and the decision tree for picking one: [`/using-8-habits`](using-8-habits/SKILL.md) (narrative)
+- **How** skills chain (prev/next): each skill's frontmatter `prev-skill` / `next-skill` fields, validated by `tests/test-skill-graph.sh`
+- **When** to use which step: [README § 7-Step Workflow](../README.md#the-7-step-workflow) (indexed by step)
+- **For non-Claude agents** (Codex, Cursor, Windsurf): see `llms.txt` + `AGENTS.md` at repo root (tracked in Issue #136)

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -465,6 +465,53 @@ for pair in $WIKI_SKILL_MAP; do
 done
 echo ""
 
+# --- Check 20: skills/RESOLVER.md bidirectional cross-reference (ADR-010) ---
+echo "--- Check 20: skills/RESOLVER.md ↔ skills/ bidirectional cross-reference ---"
+RESOLVER_FILE="skills/RESOLVER.md"
+RESOLVER_FAIL=0
+
+if [ ! -f "$RESOLVER_FILE" ]; then
+  fail "Check 20 FAIL: skills/RESOLVER.md is required but not found"
+  RESOLVER_FAIL=1
+else
+  # Extract skill names cited in RESOLVER via skills/<name>/SKILL.md pattern.
+  # Uses the same sed-based extraction idiom as Check 12 for consistency.
+  RESOLVER_SKILLS=""
+  while IFS= read -r line; do
+    sname=$(echo "$line" | sed -n 's|.*skills/\([a-z0-9-]\{1,\}\)/SKILL\.md.*|\1|p')
+    [ -n "$sname" ] && RESOLVER_SKILLS="$RESOLVER_SKILLS $sname"
+  done < "$RESOLVER_FILE"
+  RESOLVER_SKILLS=$(echo "$RESOLVER_SKILLS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+  # Collect actual skill directories (reuse DIR_SKILLS pattern from Check 12).
+  DIR_SKILLS_R=""
+  for skill_dir in skills/*/; do
+    [ ! -d "$skill_dir" ] && continue
+    DIR_SKILLS_R="$DIR_SKILLS_R $(basename "$skill_dir")"
+  done
+
+  # Forward: every skill directory must appear in RESOLVER.
+  for s in $DIR_SKILLS_R; do
+    if ! echo "$RESOLVER_SKILLS" | grep -qw "$s"; then
+      fail "Skill '$s' exists as directory but missing from skills/RESOLVER.md"
+      RESOLVER_FAIL=$((RESOLVER_FAIL + 1))
+    fi
+  done
+
+  # Reverse: every RESOLVER-cited path must resolve to an existing skill directory.
+  for s in $RESOLVER_SKILLS; do
+    if [ ! -f "skills/$s/SKILL.md" ]; then
+      fail "skills/RESOLVER.md cites non-existent skill path: skills/$s/SKILL.md"
+      RESOLVER_FAIL=$((RESOLVER_FAIL + 1))
+    fi
+  done
+
+  if [ "$RESOLVER_FAIL" -eq 0 ]; then
+    pass "skills/RESOLVER.md matches skills/ directories ($(echo "$DIR_SKILLS_R" | wc -w | tr -d ' ') skills)"
+  fi
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Summary ==="
 echo "PASS: $PASS"


### PR DESCRIPTION
## Summary

Adds a phrase-to-path dispatcher file covering all 17 skills, grouped in 3 sections that mirror `/using-8-habits`'s existing taxonomy. Fills a gap no existing source covers: **given user-intent phrases → which SKILL.md to read**.

- **`skills/RESOLVER.md`** — new dispatcher (≤3 triggers per skill, 17 rows total across Workflow/Assessment/Meta)
- **`docs/adr/ADR-010-flat-skill-dispatcher.md`** — decision record (5 options considered, A accepted, B–E rejected with reasons)
- **`tests/validate-structure.sh`** Check 20 — bidirectional cross-reference (mirrors Check 12's idiom)
- **`CLAUDE.md`** — 1-sentence pointer under `## Skills → Habits Mapping`

## Why

The "which skill for this task?" knowledge is currently split across:
- `CLAUDE.md` § Skills → Habits Mapping (indexed by workflow step)
- Each skill's `description:` frontmatter (indexed by skill name)
- `/using-8-habits` decision tree (narrative, indexed by situation)
- `prev-skill`/`next-skill` frontmatter (indexed by predecessor)

None of these is a **phrase → path** lookup. A user typing raw intent ("I want to audit this PR for security") has no direct way to find `/security-check`. RESOLVER fills exactly that slot without duplicating the existing four. Also **unblocks #136** (llms.txt + AGENTS.md), which needs a standalone URL to link to for non-Claude-agent onboarding.

## Out of scope (from #135 body)

- ❌ Frontmatter schema changes (no `triggers: [array]`)
- ❌ Runtime dispatch (enforcement belongs in `claude-governance`, plugin boundary)
- ❌ Duplicating `/using-8-habits` narrative — RESOLVER is flat lookup only
- ❌ `manifest.json` (machine view already in `test-skill-graph.sh` + frontmatter)
- ❌ `llms.txt` / `AGENTS.md` (tracked in #136)
- ❌ Version bump — can ride a later release

## Test plan

### Happy-path validator runs

- [x] `bash tests/validate-structure.sh` → **PASS: 244, FAIL: 0** (was 243, +1 for Check 20)
- [x] `bash tests/validate-content.sh` → **PASS: 190, FAIL: 0, WARN: 1** (was 184 PASS, +6 for ADR-010 format checks: Context, Options Considered, Decision, Consequences, Status, Date)
- [x] `bash tests/test-skill-graph.sh` → **PASS: 57, FAIL: 0** (unchanged)
- [x] `bash tests/test-verbosity-hook.sh` → **PASS: 19, FAIL: 0** (unchanged, hook still ~180 tokens)

### Negative-test evidence (bidirectional Check 20)

**Test 1 — Directory missing from RESOLVER:**
\`\`\`
$ sed -i '' '/skills\/reflect\/SKILL.md/d' skills/RESOLVER.md
$ bash tests/validate-structure.sh
--- Check 20: skills/RESOLVER.md ↔ skills/ bidirectional cross-reference ---
  FAIL: Skill 'reflect' exists as directory but missing from skills/RESOLVER.md
RESULT: FAILED (1 errors)
\`\`\`

**Test 2 — RESOLVER cites non-existent path:**
\`\`\`
$ echo '| test | skills/nonexistent-skill/SKILL.md | test |' >> skills/RESOLVER.md
$ bash tests/validate-structure.sh
  FAIL: skills/RESOLVER.md cites non-existent skill path: skills/nonexistent-skill/SKILL.md
RESULT: FAILED (1 errors)
\`\`\`

**Test 3 — RESOLVER.md missing entirely:**
\`\`\`
$ mv skills/RESOLVER.md /tmp/RESOLVER.bak.md
$ bash tests/validate-structure.sh
  FAIL: Check 20 FAIL: skills/RESOLVER.md is required but not found
RESULT: FAILED (1 errors)
\`\`\`

All 3 failure messages match the strings specified in ADR-010 § Check 20. After restore → all validators green.

### Post-merge

- [ ] `/reflect` to capture any sed portability subtleties hit during Check 20 authoring, lessons for future validator work.

Closes #135.