### PR TITLE
feat(docs): add llms.txt + AGENTS.md — non-Claude agent entry points (#136)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agents working on 8-habit-ai-dev
+
+This is your install + operating protocol. Claude Code reads `./CLAUDE.md` automatically. Everyone else (Codex, Cursor, Windsurf, Aider, Continue, or any LLM fetching this repo via URL) starts here.
+
+## What this is
+
+A Claude Code plugin that adds **workflow discipline** to AI-assisted development — 17 on-demand markdown skills across a 7-step workflow grounded in Covey's 8 Habits. The plugin is markdown only: no build system, no runtime code, no dependencies. Skills are **read-only guidance** — they tell an agent _how_ to approach a task; they never edit files on their own.
+
+## Install
+
+- **Claude Code**: `claude plugin marketplace add pitimon/8-habit-ai-dev && claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev`
+- **Other agent platforms**: `git clone https://github.com/pitimon/8-habit-ai-dev` then load `skills/<name>/SKILL.md` via your platform's skill-loading mechanism (Codex `skill` tool, Cursor Rules, Windsurf memories, Aider `--read`, etc.). The skill _content_ is identical across platforms — only the invocation differs. Consult your tool's documentation for the exact command.
+
+## Read this order
+
+1. **`./AGENTS.md`** (this file) — install + operating protocol.
+2. [`./CLAUDE.md`](./CLAUDE.md) — architecture reference, skill authoring conventions, plugin boundary with `claude-governance`.
+3. [`./skills/RESOLVER.md`](./skills/RESOLVER.md) — phrase-to-path skill dispatcher. Read first for any task; pick the row matching user intent, then read the cited `SKILL.md`.
+4. If new to the workflow: invoke `/workflow` for a guided 7-step walkthrough, or `/using-8-habits` for the decision tree.
+
+## Trust boundary
+
+Skills are **read-only guidance**. A skill tells you _how_ to approach a task (what questions to ask, what checklist to run, what artifact to produce). It does not modify files by itself — any edits are made by the agent loading the skill, under the user's approval. This matches the plugin's core philosophy: **discipline, not enforcement**. Compliance enforcement (gates, hooks, irreversible-action auth) lives in the sibling plugin [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) — install both for full coverage.
+
+## Common tasks
+
+- **"I want to research a library before choosing it"** → [`skills/research/SKILL.md`](./skills/research/SKILL.md) (Step 0 of the 7-step workflow)
+- **"I need to plan what this feature does"** → [`skills/requirements/SKILL.md`](./skills/requirements/SKILL.md) (PRD + EARS criteria)
+- **"I just got some AI-generated code, audit it before I commit"** → [`skills/review-ai/SKILL.md`](./skills/review-ai/SKILL.md)
+- **"Something feels off in my plan, run a checklist"** → [`skills/cross-verify/SKILL.md`](./skills/cross-verify/SKILL.md) (17-question 8-habit review)
+- **"I just finished a task, what did we learn?"** → [`skills/reflect/SKILL.md`](./skills/reflect/SKILL.md) (6-question micro-retrospective)
+
+For the full phrase-to-path index, see [`./skills/RESOLVER.md`](./skills/RESOLVER.md).
+
+## Full map
+
+[`./llms.txt`](./llms.txt) is the flat documentation map used by LLM-based agents to fetch and index the plugin remotely. It lists every entry point, philosophy doc, and compliance reference with absolute URLs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+> **Non-Claude agents** (Codex, Cursor, Windsurf, Aider, Continue): start at [`AGENTS.md`](AGENTS.md). [`llms.txt`](llms.txt) is the full doc map. Claude Code users: this file is auto-loaded — keep reading.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What This Is

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - [The Problem](#the-problem) — Why this exists
 - [Quick Start](#quick-start) — Install in 3 steps, verify in 1
+- [Not using Claude Code?](AGENTS.md) — Entry point for Codex, Cursor, Windsurf, Aider, etc.
 
 **The Framework**
 

--- a/docs/adr/ADR-011-cross-agent-discoverability.md
+++ b/docs/adr/ADR-011-cross-agent-discoverability.md
@@ -1,0 +1,60 @@
+# ADR-011: Cross-Agent Discoverability (`llms.txt` + `AGENTS.md`)
+
+- **Status**: Accepted
+- **Date**: 2026-04-22
+- **Supersedes**: None
+- **Related**: Issue #136 (origin), Issue #135 / ADR-010 (enabling predecessor — `skills/RESOLVER.md` as shared link target)
+
+## Context
+
+The plugin is cross-agent by philosophy — workflow discipline is agent-agnostic. Today only `CLAUDE.md` exists as a file-named entry point, and Claude Code auto-loads it. Other agent platforms (Codex, Cursor, Windsurf, Aider, Continue) and LLM-based repo-fetchers have no canonical door into the plugin. `skills/RESOLVER.md` (added in #135) is the phrase-to-path lookup but requires a reader who already knows to look in `skills/`.
+
+Two emerging cross-tool conventions address this gap:
+
+- **`llms.txt`** — flat doc-map at repo root, fetched by LLM-based tools to index a project. Convention from [llmstxt.org](https://llmstxt.org).
+- **`AGENTS.md`** — non-Claude operating protocol at repo root. Used by [garrytan/gbrain](https://github.com/garrytan/gbrain) and similar projects to guide Codex/Cursor/Aider users.
+
+Both are real adoption signals, not speculative. Adding them closes the cross-agent gap with minimal surface area and reuses `skills/RESOLVER.md` as a shared link target.
+
+## Options Considered
+
+| Option                                   | Summary                                                                                                                                                          | Trade-offs                                                                                                                                                                                            | Verdict      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| **A. `llms.txt` + `AGENTS.md`** (chosen) | Two root files: `llms.txt` (llmstxt.org convention, flat doc map) + `AGENTS.md` (non-Claude operating protocol). `skills/RESOLVER.md` is the shared link target. | ✅ Matches real emerging conventions. ✅ Remote fetchers and non-Claude agents get distinct shapes (machine-flat vs. human-operating). ✅ Works with #135's RESOLVER as-is. ⚠️ Two new files at root. | **Accepted** |
+| B. `AGENTS.md` only (skip `llms.txt`)    | One file covers both audiences                                                                                                                                   | ✅ One fewer file. ❌ Denies `llmstxt.org` discovery pattern — crawlers look for the literal filename `llms.txt`.                                                                                     | Rejected     |
+| C. `llms.txt` only (skip `AGENTS.md`)    | Rely on README for human-facing non-Claude guidance                                                                                                              | ✅ Machine-readable. ❌ Humans on non-Claude platforms get no install / trust-boundary / common-tasks page — README is too broad.                                                                     | Rejected     |
+| D. Combined `agent-setup.md`             | Merge both files                                                                                                                                                 | ✅ One file. ❌ Breaks `llmstxt.org` convention (wrong filename). ❌ Mixes audiences (machine-flat list vs. human operating protocol) in one shape.                                                   | Rejected     |
+| E. Rename `CLAUDE.md` → `AGENTS.md`      | Single source of truth for all agents                                                                                                                            | ❌ Claude Code auto-loads `CLAUDE.md` by literal name; rename breaks the auto-load behavior.                                                                                                          | Rejected     |
+| F. Do nothing                            | Accept single-`CLAUDE.md` status quo                                                                                                                             | ❌ Counter to cross-agent philosophy; privileges Claude Code users.                                                                                                                                   | Rejected     |
+
+## Decision
+
+Add `llms.txt` + `AGENTS.md` at repo root following Option A. Extend `tests/validate-structure.sh` with **Check 21** enforcing both files exist and contain correct pointers to `skills/RESOLVER.md` + `CLAUDE.md`. Add one pointer line to `CLAUDE.md` (blockquote at line 3, before the first paragraph) and one ToC bullet to `README.md` under `Get Started`.
+
+Cite upstream per-platform skill-loading references (Codex, Cursor, Windsurf, etc.) **by name only** — the `obra/superpowers-skills/using-superpowers/references/` path cited in Issue #136 body was confirmed HTTP 404 via `gh api` at design time (2026-04-22). Individual tool docs resolve the invocation details.
+
+## Consequences
+
+### Positive
+
+- **Non-Claude agents** and `llmstxt.org`-aware tools have canonical entry points for the plugin.
+- **`skills/RESOLVER.md`** (from #135) gains a discoverable URL pattern from outside Claude Code — the cross-agent story is now end-to-end (`llms.txt` → `AGENTS.md` → `RESOLVER.md` → individual `SKILL.md`).
+- **Future skill authors** have a named cross-agent contract (`AGENTS.md` enforces that skills remain read-only guidance, not runtime behavior).
+- **Check 21** makes cross-agent pointer integrity a test, not a hope — future file renames caught automatically.
+
+### Negative / Risks
+
+- **`AGENTS.md` drift risk** from `CLAUDE.md` over time (skill list, plugin boundary, conventions). Mitigated by tight discipline: `AGENTS.md` contains **how-to-use only** — no architecture content is duplicated from `CLAUDE.md`. 80-line cap + PR review enforce.
+- **URL rot in `llms.txt`** on file moves — raw URLs hardcode `main/<path>`. Mitigated by treating `llms.txt` as a rename-PR touchpoint (low-priority follow-up: add to `CONTRIBUTING.md` reviewer checklist).
+- **Dead upstream link exposure** — `obra/superpowers-skills/.../references/` was 404 at design time. Mitigation baked into the chosen design: cite by name, no hyperlink.
+
+## Compliance
+
+- **Plugin boundary**: ✅ Pure docs + validator — no hooks, no runtime enforcement gates. Matches 8-habit-ai-dev's role per `CLAUDE.md § Plugin Boundary`.
+- **Article 14 (EU AI Act)**: N/A — dev-tooling plugin feature. Not an AI system under Annex III, not EU-targeted.
+- **`llmstxt.org` convention**: ✅ H1 + blockquote summary + sectioned markdown-link lists with absolute URLs.
+- **ADR-010 precedent**: ✅ Same ADR shape (Context / Options Considered / Decision / Consequences / Compliance); validate-content Check 13 enforces section integrity.
+
+## Supersession
+
+If a future cross-agent convention emerges that obsoletes either `llms.txt` or `AGENTS.md`, a new ADR supersedes this one. Do not amend ADR-011 in place — the HTTP-404-at-design-time observation and the dual-file rationale are load-bearing history.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,36 @@
+# 8-habit-ai-dev
+
+> A Claude Code plugin that adds workflow discipline to AI-assisted development. 17 on-demand skills across a 7-step workflow, grounded in Covey's 8 Habits. Cross-agent: written for Claude Code first, usable by any agent platform that can load markdown skills.
+
+Repo: https://github.com/pitimon/8-habit-ai-dev
+
+## Core entry points
+
+- [AGENTS.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/AGENTS.md): Start here if you are not Claude Code. Install order, trust boundary, skill resolver pointer, common-tasks examples.
+- [CLAUDE.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/CLAUDE.md): Architecture reference for Claude Code. Plugin layout, skill authoring conventions, plugin boundary, skills-to-habits mapping.
+- [README.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/README.md): Human-facing overview, quick start, decision tree, full skill reference.
+- [SELF-CHECK.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/SELF-CHECK.md): Release checklist and integrity checks.
+- [CONTRIBUTING.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/CONTRIBUTING.md): How to author new skills and run local validators.
+- [skills/RESOLVER.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/skills/RESOLVER.md): Flat phrase-to-path dispatcher. Given user intent → which SKILL.md to read.
+
+## Skills
+
+- [skills/](https://github.com/pitimon/8-habit-ai-dev/tree/main/skills): 17 skill directories, each with `SKILL.md`. Read `skills/RESOLVER.md` first to pick the right one.
+- [CLAUDE.md § Skills → Habits Mapping](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/CLAUDE.md): Step-indexed skill table mapping each skill to a Covey habit.
+
+## Philosophy
+
+- [rules/effective-development.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/rules/effective-development.md): Covey's 8 Habits translated into Claude + human collaboration standards.
+- [habits/](https://github.com/pitimon/8-habit-ai-dev/tree/main/habits): Per-habit deep dives loaded on demand by skills.
+- [guides/integrity-principles.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/integrity-principles.md): Evidence standards for reviews, cross-verification, and reflection.
+
+## Compliance
+
+- [guides/eu-ai-act-mapping.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/eu-ai-act-mapping.md): EU AI Act Articles 9-15 mapping to plugin skills.
+- [guides/cross-verification.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/cross-verification.md): 17-question 8-habit checklist with dimension summary.
+- [guides/ears-notation.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/ears-notation.md): EARS requirements syntax reference for `/requirements`.
+- [SKILL-EFFECTIVENESS.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/SKILL-EFFECTIVENESS.md): Per-skill effectiveness signal ledger from `/reflect`.
+
+## Cross-plugin boundary
+
+- [CLAUDE.md § Plugin Boundary](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/CLAUDE.md): Rule of thumb for what belongs here (workflow discipline) vs. [pitimon/claude-governance](https://github.com/pitimon/claude-governance) (compliance enforcement + frameworks). Install both together for maximum coverage.

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -512,6 +512,43 @@ else
 fi
 echo ""
 
+# --- Check 21: Cross-agent discoverability (ADR-011) ---
+echo "--- Check 21: llms.txt + AGENTS.md cross-agent discoverability ---"
+CROSS_AGENT_FAIL=0
+
+# Existence — both files are required at repo root (EARS #4).
+for f in llms.txt AGENTS.md; do
+  if [ ! -f "$f" ]; then
+    fail "Check 21 FAIL: $f is required at repo root but not found"
+    CROSS_AGENT_FAIL=$((CROSS_AGENT_FAIL + 1))
+  fi
+done
+
+# Pointer integrity — only run if both files exist (avoids cascade noise).
+# Uses grep -q (BSD-safe; no sed/awk per ADR-011 portability constraint).
+if [ -f AGENTS.md ] && [ -f llms.txt ]; then
+  if ! grep -q 'skills/RESOLVER.md' AGENTS.md; then
+    fail "AGENTS.md missing pointer to skills/RESOLVER.md"
+    CROSS_AGENT_FAIL=$((CROSS_AGENT_FAIL + 1))
+  fi
+  if ! grep -q 'CLAUDE.md' AGENTS.md; then
+    fail "AGENTS.md missing pointer to CLAUDE.md"
+    CROSS_AGENT_FAIL=$((CROSS_AGENT_FAIL + 1))
+  fi
+  if ! grep -q 'AGENTS.md' llms.txt; then
+    fail "llms.txt missing pointer to AGENTS.md"
+    CROSS_AGENT_FAIL=$((CROSS_AGENT_FAIL + 1))
+  fi
+  if ! grep -q 'skills/RESOLVER.md' llms.txt; then
+    fail "llms.txt missing pointer to skills/RESOLVER.md"
+    CROSS_AGENT_FAIL=$((CROSS_AGENT_FAIL + 1))
+  fi
+  if [ "$CROSS_AGENT_FAIL" -eq 0 ]; then
+    pass "llms.txt + AGENTS.md exist with all required pointers intact"
+  fi
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Summary ==="
 echo "PASS: $PASS"


### PR DESCRIPTION
## Summary

Completes the cross-agent discoverability story opened by #135. Adds 2 root-level files (`llms.txt` + `AGENTS.md`) that give Codex, Cursor, Windsurf, Aider, Continue, and LLM-based repo fetchers a canonical door into the plugin — without changing anything for Claude Code users.

- **`llms.txt`** — [llmstxt.org](https://llmstxt.org) convention; flat doc map with 5 custom sections and `raw.githubusercontent.com` URLs throughout
- **`AGENTS.md`** — non-Claude operating protocol; install order, trust boundary, 5 Common-tasks examples matching `/using-8-habits` Core 5
- **`docs/adr/ADR-011-cross-agent-discoverability.md`** — 6 options considered (A accepted; B–F rejected with reasons)
- **`tests/validate-structure.sh`** Check 21 — file existence + 4× pointer integrity (`test -f` + `grep -q`; no `sed`/`awk` for BSD portability)
- **`CLAUDE.md`** — 1 blockquote line at line 3 pointing non-Claude agents to AGENTS.md + llms.txt
- **`README.md`** — 1 ToC bullet under *Get Started*

## Why

The 8-habit philosophy is **cross-agent by design** — workflow discipline is agent-agnostic. But today only `CLAUDE.md` exists as a file-named entry point, and only Claude Code auto-loads it. Non-Claude agents have had to fumble the README. This PR closes that gap with minimal surface area and composes cleanly with #135's `skills/RESOLVER.md` as the shared link target, making the full chain `llms.txt → AGENTS.md → RESOLVER.md → individual SKILL.md` discoverable from any agent platform.

## Out of scope (honored from #136 body)

- ❌ Adding any new skill
- ❌ Rewriting `CLAUDE.md` — it stays Claude-specific; AGENTS.md duplicates ONLY the non-Claude operating subset
- ❌ `llms-full.txt` variant (gbrain has one; at 17 skills we don't need it yet)
- ❌ Per-tool install walkthrough — single sentence "consult your tool's documentation"
- ❌ Hyperlinking the upstream `obra/superpowers-skills/.../references/` path cited in issue body — **confirmed HTTP 404 via `gh api` at design time** (2026-04-22). Cite by name only, no broken link shipped.
- ❌ Version bump — docs-only change, can ride next release

## Test plan

### Happy-path validator runs

- [x] `bash tests/validate-structure.sh` → **PASS: 245, FAIL: 0** (was 244 post-#135, +1 for Check 21)
- [x] `bash tests/validate-content.sh` → **PASS: 196, FAIL: 0, WARN: 1** (was 190, +6 for ADR-011 format checks via Check 13)
- [x] `bash tests/test-skill-graph.sh` → **PASS: 57** (unchanged)
- [x] `bash tests/test-verbosity-hook.sh` → **PASS: 19** (unchanged)

### Negative-test evidence (3 scenarios, all match ADR-011 spec)

**Test 1 — `llms.txt` missing:**
\`\`\`
$ mv llms.txt /tmp/llms.bak && bash tests/validate-structure.sh
--- Check 21: llms.txt + AGENTS.md cross-agent discoverability ---
  FAIL: Check 21 FAIL: llms.txt is required at repo root but not found
RESULT: FAILED (1 errors)
\`\`\`

**Test 2 — `AGENTS.md` missing:**
\`\`\`
$ mv AGENTS.md /tmp/AGENTS.bak && bash tests/validate-structure.sh
  FAIL: Check 21 FAIL: AGENTS.md is required at repo root but not found
RESULT: FAILED (1 errors)
\`\`\`

**Test 3 — `llms.txt` missing `AGENTS.md` pointer:**
\`\`\`
$ sed -i '' '/AGENTS.md/d' llms.txt && bash tests/validate-structure.sh
  FAIL: llms.txt missing pointer to AGENTS.md
RESULT: FAILED (1 errors)
\`\`\`

After restore → 245 PASS, 0 FAIL.

### Post-merge

- [ ] `/reflect` to capture any upstream-link verification subtleties, llmstxt.org-convention gotchas, or cross-agent testing learnings for future AGENTS.md/llms.txt work.

Closes #136. Completes the 2026-04-22 `/research` batch (#137 done, #135 done, #136 this PR).