### PR TITLE
fix(docs): CONTRIBUTING.md § Version Bumping — 3 files → 4 files (#141 PR-B)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,11 +144,14 @@ See [issue #108](https://github.com/pitimon/8-habit-ai-dev/issues/108) and [issu
 
 ## Version Bumping
 
-Version lives in **3 files** — all must be bumped together:
+Version lives in **4 files** — all must be bumped together:
 
 - `.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
 - `README.md` footer
+- `SELF-CHECK.md` header (line 3: `**Version**: ... | **Previous**: ...`)
+
+`tests/validate-structure.sh` enforces consistency across all four — CI fails if any drifts. See [issue #106](https://github.com/pitimon/8-habit-ai-dev/issues/106) for the drift incident that motivated the SELF-CHECK.md addition.
 
 ## Quality Checklist
 


### PR DESCRIPTION
## Summary

Part 2 of 3 for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) — corrects a stale convention note in `CONTRIBUTING.md`.

- `CONTRIBUTING.md § Version Bumping` still read "Version lives in **3 files**"
- The 4-file convention has been in place since [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) (README/wiki drift incident) and is enforced by `tests/validate-structure.sh`
- `PR #107` corrected `docs/wiki/Changelog.md` only; `CONTRIBUTING.md` was missed
- This PR updates the count, adds `SELF-CHECK.md` header (line 3) to the list, and references #106 for context

Sibling PRs (independent, land in any order):
- **PR-A** [#142](https://github.com/pitimon/8-habit-ai-dev/pull/142) — `fix(docs)` SELF-CHECK.md body catch-up (footer + 6 missing rows)
- **PR-C** `feat(tests)` — `validate-content.sh` Check 22 (CI invariant; lands after PR-A + PR-B merge)

## Fitness receipts

All 4 validators green on this branch:
- `validate-structure.sh`: **245/0**
- `validate-content.sh`: **196/0 + 1 WARN**
- `test-skill-graph.sh`: **57/0**
- `test-verbosity-hook.sh`: **19/0**

## Test plan

- [ ] Reviewer confirms CONTRIBUTING.md now lists 4 files (plugin.json, marketplace.json, README.md footer, SELF-CHECK.md header)
- [ ] Reviewer spot-checks that CLAUDE.md § "Version lives in 4 files" (already correct per #106) stays consistent with this update
- [ ] `bash tests/validate-structure.sh` — green

## Not in scope

- CI invariant (PR-C)
- SELF-CHECK.md body catch-up (PR-A)
- CLAUDE.md text (already correct)

Refs: #141