### PR TITLE
feat(tests): Check 19 sub-checks E + F — SELF-CHECK.md body freshness invariant (#141 PR-C)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Required by tests/validate-content.sh Check 19 sub-checks E + F
+          # (SELF-CHECK.md body freshness vs git tag history). See issue #141.
+          fetch-tags: true
+          fetch-depth: 0
       - name: Validate structure and conventions
         run: bash tests/validate-structure.sh
       - name: Validate skill graph DAG

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -562,6 +562,49 @@ else
   else
     fail "docs/wiki/Changelog.md badge stale — bump 'latest-v…' to v${current_version}."
   fi
+
+  # E + F. SELF-CHECK.md body freshness vs git tag history
+  # Added 2026-04-25 per issue #141: header was v2.13.0 but footer said Previous: 2.7.1
+  # and per-release score list ended at v2.8.0 — 6 releases shipped silently.
+  # Source of truth: git tag -l "v2.*" (v2.x release line; v2.0.0 onwards per #141 decision).
+  # Older v1.x tags predate the SELF-CHECK.md per-release list convention and are
+  # documented elsewhere (see CHANGELOG.md note "For v2.2.0 and earlier, see docs/wiki/Changelog.md").
+  # Dev-env resilience: if no tags available (shallow clone without fetch-tags),
+  # emit WARN and skip — CI has tags (.github/workflows/validate.yml sets fetch-tags: true)
+  # so drift is still caught at merge time.
+  all_tags=$(git tag -l "v2.*" 2>/dev/null | sort -V)
+  if [ -z "$all_tags" ]; then
+    warn "git tag history unavailable — skipping SELF-CHECK.md body freshness (sub-checks E + F). CI sets fetch-tags: true."
+  else
+    # E. Footer Previous: version must match the tag immediately preceding current_version.
+    prev_version=$(echo "$all_tags" | awk -v cur="v${current_version}" '
+      $0 == cur { print prev; exit }
+      { prev = $0 }
+    ' | sed 's/^v//')
+
+    if [ -z "$prev_version" ]; then
+      warn "could not derive previous version for v${current_version} from git tags — is this the first release?"
+    elif grep -Eq "Previous: ${prev_version}\b" SELF-CHECK.md; then
+      pass "SELF-CHECK.md footer references Previous: ${prev_version}"
+    else
+      fail "SELF-CHECK.md footer stale — expected 'Previous: ${prev_version}' (derived from git tags); update the last line of the file."
+    fi
+
+    # F. Per-release score list must have one row per tagged version — no gaps.
+    missing=()
+    while IFS= read -r tag; do
+      ver="${tag#v}"
+      if ! grep -Eq "^- v${ver}: " SELF-CHECK.md; then
+        missing+=("v${ver}")
+      fi
+    done <<< "$all_tags"
+
+    if [ ${#missing[@]} -eq 0 ]; then
+      pass "SELF-CHECK.md per-release list covers all tagged versions ($(echo "$all_tags" | wc -l | tr -d ' ') entries)"
+    else
+      fail "SELF-CHECK.md per-release list missing ${#missing[@]} version(s): ${missing[*]} — add a '- v<x.y.z>: Body N, Mind N, Heart N, Spirit N = **N.N** (…)' row per tagged release."
+    fi
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Part 3 of 3 for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) — CI invariant that prevents SELF-CHECK.md body drift from recurring. Ships the fitness-function half after PR-A (#142) did the one-time catch-up and PR-B (#143) corrected the 3→4 files convention.

### What's added

**`tests/validate-content.sh` Check 19 sub-check E** — footer freshness:
- Derives `prev_version` from `git tag -l "v2.*" | sort -V` (tag immediately preceding `plugin.json.version`)
- Asserts `SELF-CHECK.md` footer reads `Previous: <prev_version>`
- Catches stale footers like the one that shipped across 6 releases pre-#141 catch-up

**`tests/validate-content.sh` Check 19 sub-check F** — no-gaps enforcement:
- Iterates all `v2.x` tags
- Asserts each has a matching `^- v<x.y.z>: ` row in `SELF-CHECK.md`
- Catches silent-drift-across-releases (the v2.9.0 → v2.13.0 gap that motivated #141)

**`.github/workflows/validate.yml`** — `fetch-tags: true` + `fetch-depth: 0` on `actions/checkout@v4` so CI can read the tag list. Without this, sub-checks E + F would WARN-skip on CI runners.

### Design decisions (per issue #141 review)

| # | Decision | Rationale |
|---|---|---|
| 1 | Extend Check 19 (same block) | Docs-freshness assertions co-located — easier to reason about when changelog-family checks cluster |
| 2 | `git tag` source of truth | Authoritative; zero drift vs CHANGELOG.md parsing; all 18 v2.x tags present |
| 3 | No-gaps from v2.0.0 | Strictest option; v1.x filtered via `git tag -l "v2.*"` per `CHANGELOG.md` note _"For v2.2.0 and earlier, see docs/wiki/Changelog.md"_ |

### Dev-env resilience

If `git tag -l "v2.*"` returns empty (shallow clone without tags), the check emits **WARN** and skips sub-checks E + F. CI sets `fetch-tags: true` + `fetch-depth: 0` so drift is caught at merge time; local dev without tags doesn't get spurious failures.

## Fitness receipts

All 4 validators green on this branch:
- `validate-structure.sh`: **245/0**
- `validate-content.sh`: **198/0 + 1 WARN** (was 196 + 2 net new pass-able assertions, matches the v2.11.1 hardening pattern)
- `test-skill-graph.sh`: **57/0**
- `test-verbosity-hook.sh`: **19/0**

## Negative tests performed (evidence chain)

Tested on branch before commit — check failed as expected; clean tree restored and passes:

**Test 1 — stale footer**:
```
Modified SELF-CHECK.md footer: "Previous: 2.12.0" → "Previous: 2.7.1"
Result: FAIL: SELF-CHECK.md footer stale — expected 'Previous: 2.12.0' (derived from git tags); update the last line of the file.
```

**Test 2 — missing row in per-release list**:
```
Removed the "- v2.11.0: ..." row
Result: FAIL: SELF-CHECK.md per-release list missing 1 version(s): v2.11.0 — add a '- v<x.y.z>: Body N, Mind N, Heart N, Spirit N = **N.N** (…)' row per tagged release.
```

**Test 3 — clean tree**:
```
Both PASS. Summary: 198/0/1-WARN (clean restore).
```

## Test plan

- [ ] Reviewer confirms Check 19 output in CI logs shows sub-checks E + F both PASS
- [ ] Reviewer triggers a dry-run of drift (edit SELF-CHECK.md footer locally, re-run `bash tests/validate-content.sh`, confirm FAIL message clear and actionable)
- [ ] Reviewer confirms `.github/workflows/validate.yml` checkout action pulls tags (check "Set up job" step in CI run)
- [ ] Issue #141 ready to close after merge

## Not in scope

- Running check on same-PR version bumps (maintainer's policy call from the issue) — current behavior: check runs on every PR; if you bump version without updating SELF-CHECK.md, CI fails, which is the desired outcome
- Backfill dimension scores with anything other than "5.0" — handled in PR-A per the issue
- Pre-v2.0.0 tag coverage — explicitly excluded per decision #3

Refs: #141. Closes the third of three fixes for this issue.