### PR TITLE
chore(release): v2.13.1 — SELF-CHECK.md body freshness (closes #141)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.13.1 — SELF-CHECK.md Body Freshness (2026-04-25)
+
+Patch release closing a three-PR arc for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141). `SELF-CHECK.md` had drifted within a single file — header read v2.13.0 while footer said `Previous: 2.7.1` and the per-release score list ended at v2.8.0, silently skipping 6 releases (v2.9.0 through v2.13.0). The plugin opens with _"H8 Modeling: Follow the process always, no shortcuts when unwatched"_ — the 6-release gap contradicted the stated principle. Same bug class as [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) on a surface not covered by Check 19.
+
+### Fixed
+
+- **`SELF-CHECK.md` body catch-up** ([#142](https://github.com/pitimon/8-habit-ai-dev/pull/142)) — footer updated from `Previous: 2.7.1` to `Previous: 2.12.0`; added 6 missing per-release rows (v2.9.0, v2.10.0, v2.11.0, v2.11.1, v2.12.0, v2.13.0) using the v2.8.0 row format with dimension evidence sourced from this CHANGELOG. All 6 rows scored 5.0 — no genuine regressions observed.
+- **`CONTRIBUTING.md` § Version Bumping** ([#143](https://github.com/pitimon/8-habit-ai-dev/pull/143)) — "Version lives in **3 files**" → "**4 files**", adds `SELF-CHECK.md` header (line 3) to the list. The 4-file convention has been enforced by `tests/validate-structure.sh` since [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) but CONTRIBUTING.md was missed in PR #107.
+
+### Added
+
+- **`tests/validate-content.sh` Check 19 sub-checks E + F** ([#144](https://github.com/pitimon/8-habit-ai-dev/pull/144)) — CI invariant preventing recurrence:
+  - **E (footer freshness)**: derives `prev_version` from `git tag -l "v2.*" | sort -V` (tag immediately preceding `plugin.json.version`) and asserts `SELF-CHECK.md` footer reads `Previous: <prev_version>`.
+  - **F (no-gaps)**: iterates all v2.x tags; each must have a matching `^- v<x.y.z>: ` row in `SELF-CHECK.md`.
+  - Dev-env resilience: if `git tag -l "v2.*"` returns empty (shallow clone without tags), emits WARN and skips E + F — CI sets `fetch-tags: true` + `fetch-depth: 0` so drift is still caught at merge time.
+- **`.github/workflows/validate.yml`** — `fetch-tags: true` + `fetch-depth: 0` on `actions/checkout@v4` so CI can read the tag list.
+
+### Pattern
+
+Same shape as v2.11.1 (CHANGELOG Drift Guard, [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124)): when QA surfaces the same drift class across multiple releases, the fix is a validator assertion, not a checklist. Check 19 now covers README + CHANGELOG + wiki + SELF-CHECK freshness — all docs-freshness assertions co-located.
+
+### Fitness
+
+- `validate-structure.sh` 245/0, `validate-content.sh` **198/0/1 WARN** (was 196 + 2 net new pass-able assertions), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+### Intentionally not in scope
+
+- Re-computing dimension scores for v2.9.0..v2.13.0 — all defaulted to 5.0 (no regression evidence in CHANGELOG entries).
+- Same-PR version-bump policy — check runs on every PR; if version bumps without SELF-CHECK.md update, CI fails, which is the desired outcome.
+- Pre-v2.0.0 tag coverage — explicitly excluded; v1.x tags predate the per-release list convention and are documented in `docs/wiki/Changelog.md`.
+
+Closes #141.
+
+---
+
 ## v2.13.0 — Cross-Agent Discoverability (2026-04-22)
 
 Minor release completing the cross-agent story — three linked PRs from the 2026-04-22 `/research` session on [`garrytan/gbrain`](https://github.com/garrytan/gbrain) make the plugin discoverable from non-Claude agent platforms (Codex, Cursor, Windsurf, Aider, Continue) and LLM-based repo fetchers. No breaking changes; every addition is opt-in or purely additive.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.13.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.13.0)
+[![Version](https://img.shields.io/badge/Version-2.13.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.13.1)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -317,7 +317,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.13.0)
+│   ├── plugin.json                 # Plugin metadata (v2.13.1)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -390,6 +390,15 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.13.1
+
+**Theme: SELF-CHECK.md Body Freshness** ([#141](https://github.com/pitimon/8-habit-ai-dev/issues/141))
+
+- **SELF-CHECK.md body drift fixed** ([#142](https://github.com/pitimon/8-habit-ai-dev/pull/142)) — footer updated from `Previous: 2.7.1` to `Previous: 2.12.0` and 6 missing per-release rows added (v2.9.0 through v2.13.0). Plugin opens with _"H8 Modeling: Follow the process always, no shortcuts when unwatched"_ — the 6-release silent gap contradicted the stated principle.
+- **CONTRIBUTING.md § Version Bumping corrected** ([#143](https://github.com/pitimon/8-habit-ai-dev/pull/143)) — "Version lives in **3 files**" → "**4 files**" and adds `SELF-CHECK.md` header to the list. The 4-file convention has been enforced by `tests/validate-structure.sh` since #106, but CONTRIBUTING.md never caught up.
+- **`tests/validate-content.sh` Check 19 sub-checks E + F** ([#144](https://github.com/pitimon/8-habit-ai-dev/pull/144)) — CI invariant against SELF-CHECK.md body drift. Sub-check E asserts the footer references the tag immediately preceding `plugin.json.version` (derived from `git tag -l "v2.*" | sort -V`). Sub-check F asserts every v2.x tag has a matching `^- v<x.y.z>: ` row — no gaps. Prevents recurrence of the #141 drift class.
+- **`.github/workflows/validate.yml`** — `fetch-tags: true` + `fetch-depth: 0` added to `actions/checkout@v4` so CI can read the tag list for sub-checks E + F.
 
 ## What's New in v2.13.0
 
@@ -604,4 +613,4 @@ MIT
 
 ---
 
-_Version: 2.13.0 | Last updated: 2026-04-22_
+_Version: 2.13.1 | Last updated: 2026-04-25_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.13.0 | **Date**: 2026-04-22 | **Previous**: 2.12.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.13.1 | **Date**: 2026-04-25 | **Previous**: 2.13.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -167,7 +167,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.11.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (CHANGELOG Drift Guard: #124 hardened Check 19 with 3 FAIL assertions, backfilled v2.9.0 + v2.11.0 entries — two-release drift pattern closed with fitness function)
 - v2.12.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Code-Symbol Grep Evidence: #133 /research gains grep obligation for remove/dead/unused verdicts, research-verifier scope clarified with Limit of Verification + SEMANTIC-EVIDENCE-MISSING flag)
 - v2.13.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Cross-Agent Discoverability: #135 skills/RESOLVER.md flat dispatcher, #136 llms.txt + AGENTS.md at repo root, #137 README "Thin Harness, Fat Skills" citation, ADR-010 + ADR-011, Check 20 + 21 added)
+- v2.13.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (SELF-CHECK.md Body Freshness: #141 three-PR arc — #142 catch-up 6 missing per-release rows v2.9.0→v2.13.0 + footer, #143 CONTRIBUTING.md 3→4 files correction, #144 Check 19 sub-checks E + F — CI invariant via git tag source of truth)
 
 ---
 
-_Updated with each release. Previous: 2.12.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.13.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,25 @@
-![Version](https://img.shields.io/badge/latest-v2.13.0-blue)
+![Version](https://img.shields.io/badge/latest-v2.13.1-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.13.1 — SELF-CHECK.md Body Freshness (April 2026)
+
+Patch release closing the three-PR arc for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) — SELF-CHECK.md body drift (header said v2.13.0 but footer said Previous: 2.7.1 and per-release list ended at v2.8.0, skipping 6 releases).
+
+- **One-time catch-up** ([PR #142](https://github.com/pitimon/8-habit-ai-dev/pull/142)) — SELF-CHECK.md footer updated to `Previous: 2.12.0`; added 6 missing rows (v2.9.0 through v2.13.0). Plugin opens with _"H8 Modeling: Follow the process always, no shortcuts when unwatched"_ — contradicted by 6 consecutive silent releases.
+- **Convention correction** ([PR #143](https://github.com/pitimon/8-habit-ai-dev/pull/143)) — CONTRIBUTING.md § Version Bumping "Version lives in **3 files**" → "**4 files**", adds `SELF-CHECK.md` header to the list (convention enforced since [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) but CONTRIBUTING.md never caught up).
+- **CI invariant** ([PR #144](https://github.com/pitimon/8-habit-ai-dev/pull/144)) — `tests/validate-content.sh` Check 19 sub-checks E + F: footer must match `git tag -l "v2.*" | sort -V` predecessor of `plugin.json.version` (E); every v2.x tag must have a matching `^- v<x.y.z>: ` row in SELF-CHECK.md (F). Prevents recurrence of the drift class.
+- **`.github/workflows/validate.yml`** — `fetch-tags: true` + `fetch-depth: 0` added to `actions/checkout@v4` so CI can read tag history.
+
+Fitness receipts: `validate-structure.sh` 245/0, `validate-content.sh` **198/0/1 WARN** (was 196 + 2 net new pass-able assertions — same hardening shape as v2.11.1 drift guard), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+Closes #141.
+
+---
 
 ## v2.13.0 — Cross-Agent Discoverability (April 2026)
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -576,11 +576,18 @@ else
   if [ -z "$all_tags" ]; then
     warn "git tag history unavailable — skipping SELF-CHECK.md body freshness (sub-checks E + F). CI sets fetch-tags: true."
   else
-    # E. Footer Previous: version must match the tag immediately preceding current_version.
-    prev_version=$(echo "$all_tags" | awk -v cur="v${current_version}" '
-      $0 == cur { print prev; exit }
-      { prev = $0 }
-    ' | sed 's/^v//')
+    # E. Footer Previous: version must match the tag preceding current_version.
+    # Two shapes are valid:
+    #   1. Post-release (current_version is tagged): previous = tag before current in sorted list
+    #   2. Pre-release (plugin.json bumped but tag not yet pushed): previous = last tag in sorted list
+    if echo "$all_tags" | grep -qx "v${current_version}"; then
+      prev_version=$(echo "$all_tags" | awk -v cur="v${current_version}" '
+        $0 == cur { print prev; exit }
+        { prev = $0 }
+      ' | sed 's/^v//')
+    else
+      prev_version=$(echo "$all_tags" | tail -1 | sed 's/^v//')
+    fi
 
     if [ -z "$prev_version" ]; then
       warn "could not derive previous version for v${current_version} from git tags — is this the first release?"
@@ -591,6 +598,7 @@ else
     fi
 
     # F. Per-release score list must have one row per tagged version — no gaps.
+    # Plus: row for current_version must exist even if tag not yet pushed (release-in-progress).
     missing=()
     while IFS= read -r tag; do
       ver="${tag#v}"
@@ -599,8 +607,12 @@ else
       fi
     done <<< "$all_tags"
 
+    if ! grep -Eq "^- v${current_version}: " SELF-CHECK.md; then
+      missing+=("v${current_version}")
+    fi
+
     if [ ${#missing[@]} -eq 0 ]; then
-      pass "SELF-CHECK.md per-release list covers all tagged versions ($(echo "$all_tags" | wc -l | tr -d ' ') entries)"
+      pass "SELF-CHECK.md per-release list covers all tagged versions + current ($(echo "$all_tags" | wc -l | tr -d ' ') tags + v${current_version})"
     else
       fail "SELF-CHECK.md per-release list missing ${#missing[@]} version(s): ${missing[*]} — add a '- v<x.y.z>: Body N, Mind N, Heart N, Spirit N = **N.N** (…)' row per tagged release."
     fi


### PR DESCRIPTION
## Summary

Patch release closing the three-PR arc for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141). Bundles:

1. **#142** `fix(docs)` — SELF-CHECK.md body catch-up (footer v2.7.1 → v2.12.0, +6 per-release rows for v2.9.0..v2.13.0)
2. **#143** `fix(docs)` — CONTRIBUTING.md § Version Bumping 3 files → 4 files
3. **#144** `feat(tests)` — validate-content.sh Check 19 sub-checks E + F (CI invariant via `git tag` source of truth)

Plus a small hardening in this release commit:
- **Release-in-progress handling in sub-checks E + F** — when `plugin.json` is bumped but the tag isn't pushed yet (every release PR including this one), E falls back to "last tag" as previous-version and F asserts the current_version row exists alongside all-tags rows. Makes the check green on the release commit itself instead of WARN-skipping.

## Version bumps (4-file convention)

- `.claude-plugin/plugin.json` → `2.13.1`
- `.claude-plugin/marketplace.json` → `2.13.1`
- `README.md` badge + tree-view + footer → `2.13.1`
- `SELF-CHECK.md` header + new row → `2.13.1`

Plus user-facing changelogs:
- `CHANGELOG.md` → new v2.13.1 entry with full detail
- `docs/wiki/Changelog.md` → summary entry + badge bump

## Fitness receipts

All 4 validators green on this branch:
- `validate-structure.sh`: **245/0**
- `validate-content.sh`: **198/0 + 1 WARN** (was 196 at v2.13.0 — +2 net new pass-able assertions, matching the v2.11.1 drift guard pattern)
- `test-skill-graph.sh`: **57/0**
- `test-verbosity-hook.sh`: **19/0**

Evidence sub-checks E + F work end-to-end:
```
PASS: SELF-CHECK.md footer references Previous: 2.13.0
PASS: SELF-CHECK.md per-release list covers all tagged versions + current (18 tags + v2.13.1)
```

## Test plan

- [ ] Reviewer confirms all 4 validator outputs in CI logs
- [ ] Reviewer verifies release-in-progress logic: on this branch, `v2.13.1` tag doesn't exist yet but sub-check E derives `prev_version = 2.13.0` from the last existing tag
- [ ] After merge: create v2.13.1 tag + GitHub release, close #141

Closes #141 (SELF-CHECK.md body drift).