### PR TITLE
docs(wiki): replace Architecture + Maturity-Model mermaid with ASCII flow

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -9,16 +9,17 @@ The plugin is a **pure-markdown Claude Code plugin** with zero runtime dependenc
 
 The plugin loads content in 4 layers, each with different timing and scope:
 
-```mermaid
-flowchart TD
-    A["Layer 1: Rules<br/><i>Auto-loaded every session</i><br/>rules/effective-development.md"] --> B["Layer 2: Session Hook<br/><i>Runs at session start</i><br/>hooks/session-start.sh"]
-    B --> C["Layer 3: Skills<br/><i>On-demand, user-invoked</i><br/>skills/*/SKILL.md"]
-    C --> D["Layer 4: Agents<br/><i>Cross-verification</i><br/>8-habit-reviewer"]
-
-    style A fill:#e3f2fd
-    style B fill:#f3e5f5
-    style C fill:#e8f5e9
-    style D fill:#fff8e1
+```
+   Layer 1 · Rules           auto-loaded every session    rules/effective-development.md
+        │
+        ▼
+   Layer 2 · Session Hook    runs at session start        hooks/session-start.sh
+        │
+        ▼
+   Layer 3 · Skills          on-demand, user-invoked      skills/*/SKILL.md
+        │
+        ▼
+   Layer 4 · Agents          cross-verification           8-habit-reviewer
 ```
 
 ### Layer 1: Rules (always active)

--- a/docs/wiki/Maturity-Model.md
+++ b/docs/wiki/Maturity-Model.md
@@ -9,16 +9,17 @@ The plugin adapts its guidance based on your self-assessed maturity level. A beg
 
 Based on Covey's maturity continuum, extended with the 8th Habit's Significance level:
 
-```mermaid
-flowchart LR
-    D["Dependence<br/><i>Full guidance</i>"]:::dep --> I["Independence<br/><i>Key checkpoints</i>"]:::ind
-    I --> ID["Interdependence<br/><i>Team focus</i>"]:::inter
-    ID --> S["Significance<br/><i>Minimal prompts</i>"]:::sig
-
-    classDef dep fill:#ffcdd2
-    classDef ind fill:#fff9c4
-    classDef inter fill:#c8e6c9
-    classDef sig fill:#bbdefb
+```
+   Dependence       full guidance — all examples, checkpoints, templates
+        │
+        ▼
+   Independence     key checkpoints — skip beginner detail, trust user
+        │
+        ▼
+   Interdependence  team focus — delegation, parallel execution, synergy
+        │
+        ▼
+   Significance     minimal prompts — expert mode, flag exceptions only
 ```
 
 | Level               | You are...                                                  | Plugin behavior                                                                                          |


### PR DESCRIPTION
## Summary

Follow-up to #147. Convert remaining two wiki pages with mermaid blocks to monospace ASCII for consistent rendering across surfaces.

- **`Architecture.md`** — 4-layer loading model (Rules → Session Hook → Skills → Agents)
- **`Maturity-Model.md`** — 4-stage progression (Dependence → Independence → Interdependence → Significance)

After this PR, no `docs/wiki/*.md` page uses mermaid.

## Diagrams (preview)

### Architecture (4 layers)

```
   Layer 1 · Rules           auto-loaded every session    rules/effective-development.md
        │
        ▼
   Layer 2 · Session Hook    runs at session start        hooks/session-start.sh
        │
        ▼
   Layer 3 · Skills          on-demand, user-invoked      skills/*/SKILL.md
        │
        ▼
   Layer 4 · Agents          cross-verification           8-habit-reviewer
```

### Maturity Model (4 stages)

```
   Dependence       full guidance — all examples, checkpoints, templates
        │
        ▼
   Independence     key checkpoints — skip beginner detail, trust user
        │
        ▼
   Interdependence  team focus — delegation, parallel execution, synergy
        │
        ▼
   Significance     minimal prompts — expert mode, flag exceptions only
```

## Test plan

- [x] `tests/validate-structure.sh` — PASS 245/245
- [x] `tests/validate-content.sh` — PASS 198/198 (1 pre-existing WARN, unrelated)
- [ ] Visual check on rendered wiki after merge — confirm fixed-width font preserves alignment

## Merge order

Independent of #147 (different files). Either PR can merge first.