### PR TITLE
chore(skills): add agent attribution to SKILL_OUTPUT handoff blocks (#151)

### DIFF
--- a/guides/structured-output-protocol.md
+++ b/guides/structured-output-protocol.md
@@ -7,7 +7,8 @@ Enable cross-skill data handoff via machine-readable blocks embedded in markdown
 ## Format
 
 ```
-<!-- SKILL_OUTPUT:<skill-name>
+[/<skill-name>] <STATUS-MARKER> SKILL_OUTPUT:<type>
+<!-- SKILL_OUTPUT:<type>
 key: value
 list_key:
   - "item 1"
@@ -17,17 +18,27 @@ END_SKILL_OUTPUT -->
 
 ### Rules
 
-1. **Block delimiters**: `<!-- SKILL_OUTPUT:<name>` opens, `END_SKILL_OUTPUT -->` closes
-2. **Content format**: YAML-like key-value pairs (human-readable, not strict YAML)
-3. **Placement**: At the END of skill output, after all human-readable content
-4. **Optional**: Skills SHOULD emit blocks but output remains valid without them
-5. **Invisible**: HTML comments don't render in markdown viewers — zero visual impact
+1. **Attribution line** (visible, REQUIRED): `[/<skill-name>] <STATUS-MARKER> SKILL_OUTPUT:<type>` directly above the HTML comment opener.
+   - Status markers: `COMPLETE` (default emit), `PARTIAL` (degraded run, missing optional fields), `FAILED` (skill could not produce required fields)
+   - Skill-name in brackets is the slash-command name without the leading slash escaped — e.g. `[/requirements]`, `[/review-ai]`
+   - Text-only markers (no emoji) per `~/.claude/CLAUDE.md` no-emoji rule
+   - No plugin version in attribution — keeps version-bump checklist at 4 files instead of 4+N
+2. **Block delimiters**: `<!-- SKILL_OUTPUT:<type>` opens, `END_SKILL_OUTPUT -->` closes
+3. **Content format**: YAML-like key-value pairs (human-readable, not strict YAML)
+4. **Placement**: At the END of skill output, after all human-readable content
+5. **Optional payload, REQUIRED attribution**: Skills SHOULD emit blocks but output remains valid without payload; if a block is emitted, attribution is required.
+6. **Invisible payload, visible attribution**: HTML comment payload doesn't render in markdown viewers — zero visual impact. Attribution line is plain text above the comment, scannable in transcripts.
+
+### Parser-impact statement
+
+The `/cross-verify` parser at `skills/cross-verify/SKILL.md:34` scans for `<!-- SKILL_OUTPUT:` (HTML-comment opener) — the attribution line ABOVE the comment is unaffected. Attribution adds visibility for human readers and downstream skills without breaking existing payload parsers.
 
 ## Producer Skills
 
 ### `/requirements` → `SKILL_OUTPUT:requirements`
 
 ```
+[/requirements] COMPLETE SKILL_OUTPUT:requirements
 <!-- SKILL_OUTPUT:requirements
 ears_count: 5
 ears_criteria:
@@ -46,6 +57,7 @@ END_SKILL_OUTPUT -->
 ### `/breakdown` → `SKILL_OUTPUT:breakdown`
 
 ```
+[/breakdown] COMPLETE SKILL_OUTPUT:breakdown
 <!-- SKILL_OUTPUT:breakdown
 task_count: 5
 tasks:
@@ -63,6 +75,7 @@ END_SKILL_OUTPUT -->
 ### `/review-ai` → `SKILL_OUTPUT:review`
 
 ```
+[/review-ai] COMPLETE SKILL_OUTPUT:review
 <!-- SKILL_OUTPUT:review
 files_reviewed: 4
 findings_critical: 0

--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -54,16 +54,15 @@ next-skill: build-brief
 5. **Token-efficient parallel design** (for `parallel-safe` and `parallel-worktree` tasks):
 
    Claude Code's fork agents share a byte-identical prompt prefix with their parent, achieving ~90% input token savings. Apply this principle when designing parallel tasks:
-
    - **Maximize shared context**: Group tasks that read the same files and share the same architectural understanding. Their `/build-brief` context sections will overlap, and the shared prefix stays cached.
    - **Minimize divergence point**: Put the task-specific instruction LAST in the agent prompt. Everything before it is the shared prefix that gets cached.
    - **Avoid redundant reads**: If 3 agents all need to read `schema.prisma`, include it in the shared brief rather than having each agent read it independently (3x the token cost).
 
-   | Pattern | When | Token Efficiency |
-   |---------|------|-----------------|
-   | Sequential (no sharing) | Tasks depend on each other | 1x (baseline) |
-   | Parallel, independent briefs | Tasks touch different areas | ~1.3x (overhead from duplicate system prompts) |
-   | Parallel, shared prefix brief | Tasks share context | ~0.3x (90% cache hit on shared prefix) |
+   | Pattern                       | When                        | Token Efficiency                               |
+   | ----------------------------- | --------------------------- | ---------------------------------------------- |
+   | Sequential (no sharing)       | Tasks depend on each other  | 1x (baseline)                                  |
+   | Parallel, independent briefs  | Tasks touch different areas | ~1.3x (overhead from duplicate system prompts) |
+   | Parallel, shared prefix brief | Tasks share context         | ~0.3x (90% cache hit on shared prefix)         |
 
    This step is most valuable for 3+ parallel tasks. For 2 tasks, the overhead of optimizing the prefix rarely pays off.
 
@@ -109,6 +108,7 @@ next-skill: build-brief
 After writing the task list, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check scope alignment:
 
 ```
+[/breakdown] COMPLETE SKILL_OUTPUT:breakdown
 <!-- SKILL_OUTPUT:breakdown
 task_count: [N]
 tasks:

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -117,6 +117,7 @@ next-skill: breakdown
 After documenting design decisions, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check design coverage:
 
 ```
+[/design] COMPLETE SKILL_OUTPUT:design
 <!-- SKILL_OUTPUT:design
 decision_count: [N]
 decisions:

--- a/skills/requirements/SKILL.md
+++ b/skills/requirements/SKILL.md
@@ -100,6 +100,7 @@ next-skill: design
 After writing the PRD, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check coverage:
 
 ```
+[/requirements] COMPLETE SKILL_OUTPUT:requirements
 <!-- SKILL_OUTPUT:requirements
 ears_count: [N]
 ears_criteria:

--- a/skills/review-ai/SKILL.md
+++ b/skills/review-ai/SKILL.md
@@ -18,7 +18,7 @@ next-skill: deploy-guide
 
 1. **Get the diff**: `git diff --name-only HEAD` to see what changed.
 
-2. **Read the tests first** — before judging the implementation, open the new or changed test files. Tests declare the *intended* behavior; reading them first gives you the specification to review the code against. If new logic has no corresponding test, record that as a Completeness finding in step 6.
+2. **Read the tests first** — before judging the implementation, open the new or changed test files. Tests declare the _intended_ behavior; reading them first gives you the specification to review the code against. If new logic has no corresponding test, record that as a Completeness finding in step 6.
 
 3. **Security check** (CRITICAL — block if found):
    - Hardcoded secrets (API keys, passwords, tokens)
@@ -149,6 +149,7 @@ If Heart or Spirit scores lag Body/Mind by ≥2 categories, add:
 After rendering the review verdict, append a structured output block for cross-skill handoff. This HTML comment is invisible when rendered but enables `/cross-verify` to auto-check review coverage:
 
 ```
+[/review-ai] COMPLETE SKILL_OUTPUT:review
 <!-- SKILL_OUTPUT:review
 files_reviewed: [N]
 findings_critical: [N]

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -549,6 +549,44 @@ if [ -f AGENTS.md ] && [ -f llms.txt ]; then
 fi
 echo ""
 
+# --- Check 22: SKILL_OUTPUT attribution lines (Issue #151) ---
+# Each emitter must have an attribution line directly above its `<!-- SKILL_OUTPUT:` opener
+# Format: [/<skill-name>] (COMPLETE|PARTIAL|FAILED) SKILL_OUTPUT:<type>
+# Uses grep -B1 only (BSD-safe; no sed/awk per ADR-011 portability constraint)
+echo "--- Check 22: SKILL_OUTPUT attribution lines ---"
+ATTR_FAIL=0
+
+for entry in "skills/design/SKILL.md:design" \
+             "skills/breakdown/SKILL.md:breakdown" \
+             "skills/requirements/SKILL.md:requirements" \
+             "skills/review-ai/SKILL.md:review"; do
+  file="${entry%:*}"
+  type="${entry##*:}"
+  if [ ! -f "$file" ]; then
+    fail "Check 22: emitter file $file not found"
+    ATTR_FAIL=$((ATTR_FAIL + 1))
+    continue
+  fi
+  # Get the line directly above the opener via grep -B1; head -1 yields the preceding line
+  attr_text=$(grep -B1 "^<!-- SKILL_OUTPUT:${type}\$" "$file" | head -1)
+  # If grep returned nothing (empty) or returned the opener itself (no preceding line in file), fail
+  if [ -z "$attr_text" ] || [ "$attr_text" = "<!-- SKILL_OUTPUT:${type}" ]; then
+    fail "Check 22: $file missing '<!-- SKILL_OUTPUT:${type}' opener or has no preceding line"
+    ATTR_FAIL=$((ATTR_FAIL + 1))
+    continue
+  fi
+  # Validate attribution format
+  if ! echo "$attr_text" | grep -qE '^\[/[a-z-]+\] (COMPLETE|PARTIAL|FAILED) SKILL_OUTPUT:[a-z-]+$'; then
+    fail "Check 22: $file attribution line malformed (got: '$attr_text')"
+    ATTR_FAIL=$((ATTR_FAIL + 1))
+  fi
+done
+
+if [ "$ATTR_FAIL" -eq 0 ]; then
+  pass "SKILL_OUTPUT attribution lines present and well-formed (4 emitters)"
+fi
+echo ""
+
 # --- Summary ---
 echo "=== Summary ==="
 echo "PASS: $PASS"


### PR DESCRIPTION
## Summary

- Add visible attribution line `[/<skill>] COMPLETE SKILL_OUTPUT:<type>` directly above each SKILL_OUTPUT HTML comment in 4 emitter skills (design, breakdown, requirements, review-ai)
- Update `guides/structured-output-protocol.md` with format spec, status markers (COMPLETE/PARTIAL/FAILED), no-version-in-attribution rationale, and parser-impact statement
- Add `tests/validate-structure.sh` Check 22 (BSD-safe via `grep -B1`, no sed/awk per ADR-011)

Inspiration: Toh Framework Agent Announcement format (`github.com/Nathanphop/Toh-Framework`) — adapted to text-only markers per project no-emoji rule.

## Plugin boundary

Pure SKILL.md template content + read-only validator + documentation. **No hooks added. No enforcement.** Stays within `8-habit-ai-dev` workflow-discipline scope.

## Test plan

- [x] `bash tests/validate-structure.sh` → 246 PASS / 0 FAIL (was 245; +1 Check 22)
- [x] `bash tests/validate-content.sh` → 198 PASS / 0 FAIL / 1 WARN (pre-existing, unchanged)
- [x] `bash tests/test-skill-graph.sh` → 57 PASS / 0 FAIL
- [x] `grep -B1 "<!-- SKILL_OUTPUT:" skills/*/SKILL.md` → 4 attribution lines present
- [x] `cross-verify` parser unaffected (still scans `<!-- SKILL_OUTPUT:` HTML-comment opener)
- [x] Pre-commit cross-verify by `8-habit-reviewer` agent: 17/17 pass, decision CONCERNS-non-blocking (one follow-up gap noted: `/design` producer absent from guide catalog — pre-existing, out-of-scope for #151, will file separately)

## Out of scope (deliberate)

- Adding `/design` producer example to the guide (pre-existing gap, follow-up issue)
- Version bump (release PR aggregates Wave 1 + Wave 2)
- CHANGELOG entry (release PR aggregates)
- Issue #150 implementation (Wave 2)

Refs #151