### PR TITLE
feat(using-8-habits): add argument-driven smart-routing mode (#149)

### DIFF
--- a/docs/wiki/Workflow-Overview.md
+++ b/docs/wiki/Workflow-Overview.md
@@ -84,7 +84,7 @@ These skills complement the pipeline and can run at any point:
 
 **Meta & Onboarding:**
 
-- [`/using-8-habits`](Skills-Reference#using-8-habits) — onboarding decision tree
+- [`/using-8-habits`](Skills-Reference#using-8-habits) — onboarding decision tree (no-arg) **or** smart-routing mode when invoked with intent (e.g. `/using-8-habits "I need to verify what we built last week"` returns ≤3 ranked skills with reasoning)
 - [`/calibrate`](Skills-Reference#calibrate) — maturity self-assessment, verbosity adaptation
 
 **Compliance & Audit:**

--- a/skills/using-8-habits/SKILL.md
+++ b/skills/using-8-habits/SKILL.md
@@ -15,7 +15,7 @@ next-skill: any
 
 **Habit**: H5 (Seek First to Understand — read before acting) + H8 (Find Your Voice — empower the next person)
 
-**Purpose**: First skill to invoke when you're new to 8-habit-ai-dev, or when you're unsure which skill fits your current task. Explains the 7-step workflow, all 17 skills, and provides a decision tree for "which skill next?".
+**Purpose**: First skill to invoke when you're new to 8-habit-ai-dev, or when you're unsure which skill fits your current task. Explains the 7-step workflow, all 17 skills, and provides a decision tree for "which skill next?". When invoked with an argument (a free-text intent like `/using-8-habits "I need to verify what we built last week"`), switches to ranked-recommendation mode — see [Smart-routing mode](#smart-routing-mode-when-invoked-with-argument) below.
 
 ## When to Use This Skill
 
@@ -117,6 +117,33 @@ What are you doing?
 For a worked end-to-end example (password reset feature, all 11 steps), see the examples file below.
 
 Load `${CLAUDE_PLUGIN_ROOT}/skills/using-8-habits/examples.md` for the full onboarding walkthrough.
+
+## Smart-routing mode (when invoked with argument)
+
+If `$ARGUMENTS` is non-empty, switch from narrative-tree mode to ranked-recommendation mode. The decision tree above is for the no-arg case (onboarding); smart-routing handles "I have an intent in mind, which skill?".
+
+**Process**:
+
+1. Read `skills/RESOLVER.md` — flat trigger-phrase → skill index (already structured for matching)
+2. Read `~/.claude/habit-profile.md` if it exists — governs verbosity per the v2.7.0 contract (Dependence → Independence → Interdependence → Significance shapes how much narrative wraps each recommendation)
+3. Glob `~/.claude/lessons/*.md` and check the 5 most recent by mtime — past task context can disambiguate borderline intents
+4. Match the argument intent against RESOLVER triggers; rank up to 3 skills by fit
+5. For each recommended skill, output:
+   - Skill name (slash-command form)
+   - 1-line "why this fits your intent"
+   - 1-line "alternatives are X / Y because they Z" (helps user understand the choice)
+6. End with a single direct question — "which one?" or "should I dispatch /<top-pick> now?"
+
+**Output bound**: ≤3 ranked skills, NEVER the full narrative tree. If no skill scores above a sensible threshold (e.g. argument is "help" or pure noise), surface that explicitly and recommend either `/workflow` (guided 7-step walkthrough) or no-arg `/using-8-habits` (full tree). Don't invent a fit that isn't there.
+
+**Verbosity by maturity** (read from `habit-profile.md` `level:`):
+
+- `dependence` → include 3-line rationale per skill + step number reminder
+- `independence` → 2 lines per skill, expected default
+- `interdependence` → 1 line per skill, terse
+- `significance` → minimum viable: name + one-clause why + question
+
+For 5 worked examples covering all 4 quadrants (workflow / assessment / meta / unclear), see the reference file linked at the end of this skill.
 
 ## Handoff
 

--- a/skills/using-8-habits/reference.md
+++ b/skills/using-8-habits/reference.md
@@ -83,3 +83,65 @@ If a peer plugin isn't installed, its skill simply isn't available — nothing b
 - **addyosmani/agent-skills** (8.3K⭐): ships `using-agent-skills` meta-skill; this is the 8-habit-ai-dev equivalent
 - **Plugin Boundary**: `8-habit-ai-dev` owns workflow discipline; `pitimon/claude-governance` owns enforcement and compliance frameworks (see `CLAUDE.md` → Plugin Boundary section)
 - **Cross-plugin composition**: suggested security flow above contributed by mgmt-pve QA tester in feedback issue #77
+
+## Smart-routing examples
+
+Five worked examples for the argument-driven mode introduced in #149. Each shows what `/using-8-habits "<intent>"` should return — ranked skills + reasoning, NOT the full decision tree.
+
+### Example 1 — Workflow quadrant
+
+**Intent**: `"I'm starting a new feature from scratch"`
+
+**Recommendation** (ranked):
+
+1. `/research` — your intent says "from scratch", so problem-space investigation comes first (H5 Seek First to Understand). Returns a research brief with depth (Quick/Standard/Deep) and verified sources.
+2. `/requirements` — alternative if the problem space is already clear; jump straight to PRD + EARS criteria.
+3. `superpowers:brainstorming` — alternative if the intent is still fuzzy and you can't articulate the problem yet (cross-plugin, optional).
+
+**Question**: Is the problem clear, or still fuzzy? If clear → `/research`; if fuzzy → `superpowers:brainstorming`.
+
+### Example 2 — Assessment quadrant
+
+**Intent**: `"something feels off about this plan"`
+
+**Recommendation**:
+
+1. `/cross-verify` — the 17-question 8-habit checklist surfaces what specifically feels off; band-based verdict (PASS/CONCERNS/REWORK/FAIL) anchors the gut feeling in evidence.
+2. `/whole-person-check` — alternative if the unease is dimensional (Body/Mind/Heart/Spirit imbalance) rather than habit-by-habit; runs a 4-dimension assessment.
+3. `/security-check` — alternative if the unease is specifically about secrets / injection / auth (focused OWASP lens).
+
+**Question**: Is it a general gut check (`/cross-verify`), a balance issue (`/whole-person-check`), or a security concern (`/security-check`)?
+
+### Example 3 — Meta quadrant
+
+**Intent**: `"how do I configure my habit profile?"`
+
+**Recommendation**:
+
+1. `/calibrate` — 5-7 question maturity self-assessment writes `~/.claude/habit-profile.md`; other skills read this for verbosity (v2.7.0 contract).
+2. No close alternative — if the user wants narrative onboarding instead, recommend no-arg `/using-8-habits`.
+
+**Question**: Run `/calibrate` now?
+
+### Example 4 — Unclear / multi-skill quadrant
+
+**Intent**: `"the deploy went sideways"`
+
+**Recommendation**:
+
+1. `/cross-verify` — first, anchor what specifically went sideways (deployment-related habits: H1 staging-first, H3 rollback ready). Output gives evidence to pick the next move.
+2. `/security-check` — alternative if the deploy issue may be a secret leak or injection regression introduced in the release.
+3. `/reflect` — alternative for after-the-fact retrospective once the immediate fire is out (5-question retro persisted to `~/.claude/lessons/`).
+
+**Question**: Is the deploy still failing right now (`/cross-verify` + `/security-check`), or is the dust settled and we want lessons captured (`/reflect`)?
+
+### Example 5 — Edge case (insufficient signal)
+
+**Intent**: `"help"`
+
+**Recommendation**: argument is too short / generic to route confidently. Two fallback paths:
+
+1. **No-arg mode** — invoke `/using-8-habits` without argument for the full narrative decision tree (best for new users).
+2. **Guided mode** — invoke `/workflow` for the step-by-step 7-step walkthrough with skip prompts (best when user knows they want structure but not which step).
+
+**Question**: New here, or just need a structured restart?

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -509,6 +509,17 @@ if [ -f "$META_SKILL" ]; then
   else
     fail "CLAUDE.md missing /using-8-habits cross-link"
   fi
+  # Issue #149: Smart-routing mode (argument-driven) — section header + reference examples
+  if grep -q "^## Smart-routing mode" "$META_SKILL"; then
+    pass "$META_SKILL has '## Smart-routing mode' section (Issue #149)"
+  else
+    fail "$META_SKILL missing '## Smart-routing mode' section (Issue #149)"
+  fi
+  if grep -q "^## Smart-routing examples" skills/using-8-habits/reference.md 2>/dev/null; then
+    pass "using-8-habits/reference.md has '## Smart-routing examples' section (Issue #149)"
+  else
+    fail "using-8-habits/reference.md missing '## Smart-routing examples' section (Issue #149)"
+  fi
 else
   fail "$META_SKILL not found"
 fi


### PR DESCRIPTION
## Summary

- When invoked with intent (`/using-8-habits "I need to verify what we built last week"`), switch from narrative-tree mode to ranked-recommendation mode — returns ≤3 ranked skills with reasoning + alternatives + a single direct question
- Reads `skills/RESOLVER.md` triggers, `~/.claude/habit-profile.md` (governs verbosity per v2.7.0 contract), and recent `~/.claude/lessons/*.md` for context
- Verbosity adapts by maturity: dependence (3-line rationale) → independence (default 2 lines) → interdependence (1 line) → significance (minimum viable)
- **No new skill file** — activates existing `argument-hint` frontmatter at `skills/using-8-habits/SKILL.md:8`. No `/8h` shortcut.

Inspiration: Toh Framework `/toh` Smart Command — adapted via reshape (extend existing skill) rather than wrapper, per cross-verify + advisor feedback during planning (avoids skill catalogue bloat).

## Differentiation honored (per issue body)

| Surface                            | Input style                  | Output style                              | When invoked                            |
| ---------------------------------- | ---------------------------- | ----------------------------------------- | --------------------------------------- |
| `/using-8-habits` (no-arg, today)  | none                         | full narrative tree + 17-skill catalog    | first-time onboarding, refresher        |
| `/using-8-habits "<intent>"` (NEW) | free-text intent             | ≤3 ranked skills + why + alternatives     | unknown entry-point, mid-task ambiguity |
| `/workflow`                        | none                         | guided 7-step walkthrough w/ skip prompts | structured fresh start                  |
| `RESOLVER.md`                      | trigger phrase (AI-internal) | flat lookup row                           | AI dispatch, not user-facing            |

## Plugin boundary

Pure SKILL.md template content + read-only validator + documentation. **No hooks. No new skill file.** Stays within `8-habit-ai-dev` workflow-discipline scope.

## Test plan

- [x] `bash tests/validate-structure.sh` → 245 PASS / 0 FAIL (unchanged)
- [x] `bash tests/validate-content.sh` → 200 PASS / 0 FAIL / 1 WARN (was 198; +2 assertions inside Check 18)
- [x] `bash tests/test-skill-graph.sh` → 57 PASS / 0 FAIL
- [x] DoD self-check via grep:
  - `\$ARGUMENTS` present in SKILL.md (1 match) — argument-hint at line 8 now consumed
  - "≤3 ranked skills" output bound present
  - `skills/8h/` directory does NOT exist (no new skill, per DoD)
  - `habit-profile.md` referenced (2 mentions)
  - 4-tier maturity vocabulary present (dependence/independence/interdependence/significance)
- [x] 5 worked examples in reference.md cover 4 quadrants + 1 edge case
- [ ] Manual run on 5 sample intents — left as runtime sanity check post-merge

## Out of scope (deliberate)

- Version bump (release PR aggregates Wave 1 + Wave 2)
- CHANGELOG entry (release PR aggregates)
- Issue #150 implementation (Wave 2; shares `review-ai/SKILL.md` with #151)

Refs #149