### PR TITLE
chore(release): v2.14.0 — TOH Framework Inspirations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.14.0 — TOH Framework Inspirations (2026-05-02)
+
+Minor release closing milestone [#15](https://github.com/pitimon/8-habit-ai-dev/milestone/15) — three workflow-discipline imports from [Toh Framework](https://github.com/Nathanphop/Toh-Framework) (an "AI-Orchestration Driven Development" framework for solo SaaS builders). Cross-pollination filtered through the plugin-boundary rule: workflow discipline lands here; enforcement and project-state persistence routed to `claude-governance` ([pitimon/claude-governance#24](https://github.com/pitimon/claude-governance/issues/24) for 7-file memory system).
+
+### Added
+
+- **`SKILL_OUTPUT` attribution lines** ([#151](https://github.com/pitimon/8-habit-ai-dev/issues/151), [PR #152](https://github.com/pitimon/8-habit-ai-dev/pull/152)) — visible attribution `[/<skill-name>] COMPLETE SKILL_OUTPUT:<type>` directly above each `<!-- SKILL_OUTPUT:` HTML comment in the 4 emitter skills (design, breakdown, requirements, review-ai). Status markers: `COMPLETE` / `PARTIAL` / `FAILED` (text-only per no-emoji rule). No plugin version in attribution — keeps version-bump checklist at 4 files. **Check 22** added to `tests/validate-structure.sh` (BSD-safe via `grep -B1`, no sed/awk per ADR-011). `cross-verify` parser at `skills/cross-verify/SKILL.md:34` unaffected (still scans HTML-comment opener). Inspired by Toh's Agent Announcement format.
+- **Argument-driven smart-routing for `/using-8-habits`** ([#149](https://github.com/pitimon/8-habit-ai-dev/issues/149), [PR #154](https://github.com/pitimon/8-habit-ai-dev/pull/154)) — when invoked with intent (`/using-8-habits "I need to verify what we built last week"`), switches from narrative-tree mode to ranked-recommendation mode: ≤3 ranked skills + reasoning + alternatives + a single direct question. Reads `~/.claude/habit-profile.md` for verbosity and `~/.claude/lessons/*.md` for context. **Activates** the existing `argument-hint` frontmatter at `skills/using-8-habits/SKILL.md:8` — no new skill file, no `/8h` shortcut. Reshape decision (extend existing skill rather than wrapper) made during planning per cross-verify + advisor feedback to avoid skill-catalogue bloat. Inspired by Toh's `/toh` Smart Command.
+- **`/review-ai` Verification Phase** ([#150](https://github.com/pitimon/8-habit-ai-dev/issues/150), [PR #155](https://github.com/pitimon/8-habit-ai-dev/pull/155)) — new section between Sequence Rule and When to Skip. 5-step Find→Fix→Re-Verify loop: list CRITICAL/HIGH findings → apply fix → re-run review on same scope → cite evidence-of-fix per finding (file:line or deferred issue ref) → **refuse to emit `pass: true` SKILL_OUTPUT unless all CRITICAL closed**. Output ends with Verification Table (Finding | Severity | Fix Evidence | Status). **Plugin-boundary guardrails** with three independent anchors in the implementation: (a) section header reads "guidance only — NOT a hook", (b) blockquote redirects hook-based proposals to `claude-governance` per #58/#60 correction pattern, (c) step 5 closes "guidance to Claude, not a runtime gate". `tests/validate-content.sh` Check 20 enforces all three. Inspired by Toh's Test → Fix → Loop adapted as discipline guidance, not automated enforcement.
+
+### Pattern
+
+External-framework cross-pollination kept tight by the boundary rule. Of 10 candidate ideas surfaced from Toh, 3 imported cleanly, 7 rejected with reason (multi-agent builders, "vibe" full-pipeline command, slash shortcuts, design profiles, component registry, multi-IDE syntax adapters, 7-file project memory system — all out of scope or routed elsewhere). Decision rationale captured in research brief at `~/.claude/plans/toh-framework-idea-inspiration-sunny-forest.md`. Companion proposal in `claude-governance` ([#24](https://github.com/pitimon/claude-governance/issues/24)) for the persistence layer.
+
+### Fitness
+
+- `validate-structure.sh` **246/0** (was 245; +1 Check 22), `validate-content.sh` **201/0/1 WARN** (was 198; +3 Check 20), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+### Follow-ups (open)
+
+- [#153](https://github.com/pitimon/8-habit-ai-dev/issues/153) — `/design` producer example missing from `guides/structured-output-protocol.md` (pre-existing gap, surfaced during #151 cross-verify, separate scope).
+- Reviewer suggestion (non-blocking): harden Check 20 to pin the 5-step loop name and step count — currently passes on 3 weak string matches.
+
+Closes #149, #150, #151.
+
+---
+
 ## v2.13.1 — SELF-CHECK.md Body Freshness (2026-04-25)
 
 Patch release closing a three-PR arc for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141). `SELF-CHECK.md` had drifted within a single file — header read v2.13.0 while footer said `Previous: 2.7.1` and the per-release score list ended at v2.8.0, silently skipping 6 releases (v2.9.0 through v2.13.0). The plugin opens with _"H8 Modeling: Follow the process always, no shortcuts when unwatched"_ — the 6-release gap contradicted the stated principle. Same bug class as [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) on a surface not covered by Check 19.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.13.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.13.1)
+[![Version](https://img.shields.io/badge/Version-2.14.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.14.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -317,7 +317,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.13.1)
+│   ├── plugin.json                 # Plugin metadata (v2.14.0)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -613,4 +613,4 @@ MIT
 
 ---
 
-_Version: 2.13.1 | Last updated: 2026-04-25_
+_Version: 2.14.0 | Last updated: 2026-05-02_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.13.1 | **Date**: 2026-04-25 | **Previous**: 2.13.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.14.0 | **Date**: 2026-05-02 | **Previous**: 2.13.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -168,7 +168,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.12.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Code-Symbol Grep Evidence: #133 /research gains grep obligation for remove/dead/unused verdicts, research-verifier scope clarified with Limit of Verification + SEMANTIC-EVIDENCE-MISSING flag)
 - v2.13.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Cross-Agent Discoverability: #135 skills/RESOLVER.md flat dispatcher, #136 llms.txt + AGENTS.md at repo root, #137 README "Thin Harness, Fat Skills" citation, ADR-010 + ADR-011, Check 20 + 21 added)
 - v2.13.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (SELF-CHECK.md Body Freshness: #141 three-PR arc — #142 catch-up 6 missing per-release rows v2.9.0→v2.13.0 + footer, #143 CONTRIBUTING.md 3→4 files correction, #144 Check 19 sub-checks E + F — CI invariant via git tag source of truth)
+- v2.14.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (TOH Framework Inspirations — milestone #15: #151 SKILL_OUTPUT attribution lines + Check 22, #149 argument-driven smart-routing in /using-8-habits, #150 Verification Phase in /review-ai with explicit "guidance only, NOT a hook" boundary qualifier — three workflow-discipline imports from external framework, all stayed within plugin boundary)
 
 ---
 
-_Updated with each release. Previous: 2.13.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.13.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,26 @@
-![Version](https://img.shields.io/badge/latest-v2.13.1-blue)
+![Version](https://img.shields.io/badge/latest-v2.14.0-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.14.0 — TOH Framework Inspirations (May 2026)
+
+Minor release closing milestone [#15](https://github.com/pitimon/8-habit-ai-dev/milestone/15) — three workflow-discipline imports from [Toh Framework](https://github.com/Nathanphop/Toh-Framework) (an "AI-Orchestration Driven Development" framework for solo SaaS builders). Cross-pollination filtered through plugin-boundary: workflow discipline here, project-state persistence routed to `claude-governance`.
+
+- **SKILL_OUTPUT attribution lines** ([#151](https://github.com/pitimon/8-habit-ai-dev/issues/151), [PR #152](https://github.com/pitimon/8-habit-ai-dev/pull/152)) — `[/<skill>] COMPLETE SKILL_OUTPUT:<type>` directly above each HTML comment in the 4 emitter skills. Status markers `COMPLETE` / `PARTIAL` / `FAILED` (text-only). New **Check 22** in `validate-structure.sh`; `cross-verify` parser unaffected. Inspired by Toh's Agent Announcement format.
+- **Argument-driven smart-routing for `/using-8-habits`** ([#149](https://github.com/pitimon/8-habit-ai-dev/issues/149), [PR #154](https://github.com/pitimon/8-habit-ai-dev/pull/154)) — `/using-8-habits "<intent>"` returns ≤3 ranked skills + reasoning + alternatives + one direct question, instead of the full narrative tree. Reads `~/.claude/habit-profile.md` for verbosity and recent `~/.claude/lessons/` for context. Activates existing `argument-hint` frontmatter — no new skill file. Inspired by Toh's `/toh` Smart Command (reshape: extend rather than wrap).
+- **`/review-ai` Verification Phase** ([#150](https://github.com/pitimon/8-habit-ai-dev/issues/150), [PR #155](https://github.com/pitimon/8-habit-ai-dev/pull/155)) — Find → Fix → Re-Verify loop: list CRITICAL/HIGH, apply fix, re-run review, cite evidence per finding, refuse to emit `pass: true` unless all CRITICAL closed. Output ends with a Verification Table. **Plugin boundary**: section header reads "guidance only — NOT a hook"; new **Check 20** in `validate-content.sh` enforces three-anchor boundary qualifier. Inspired by Toh's Test → Fix → Loop adapted as discipline guidance, not automated enforcement.
+
+Pattern: external-framework cross-pollination kept tight by the boundary rule — 3 of 10 Toh ideas imported, 7 rejected with reason (multi-agent builders, "vibe" command, design profiles, component registry, multi-IDE adapters, 7-file project memory). Companion proposal in `claude-governance` ([#24](https://github.com/pitimon/claude-governance/issues/24)) for the persistence layer.
+
+Fitness receipts: `validate-structure.sh` **246/0** (+1), `validate-content.sh` **201/0/1 WARN** (+3), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+Closes #149, #150, #151.
+
+---
 
 ## v2.13.1 — SELF-CHECK.md Body Freshness (April 2026)
 


### PR DESCRIPTION
## Summary

Release PR closing milestone [#15 — v2.14.0 — TOH Framework Inspirations](https://github.com/pitimon/8-habit-ai-dev/milestone/15). Three workflow-discipline imports from [Toh Framework](https://github.com/Nathanphop/Toh-Framework) (an "AI-Orchestration Driven Development" framework for solo SaaS builders), all stayed within plugin boundary.

**Pattern**: cross-pollination filtered through the boundary rule. Of 10 candidate ideas surfaced, 3 imported cleanly, 7 rejected with reason (multi-agent builders, "vibe" full-pipeline command, slash shortcuts, design profiles, component registry, multi-IDE syntax adapters, 7-file project memory system — last item routed to [pitimon/claude-governance#24](https://github.com/pitimon/claude-governance/issues/24)).

## Issues closed (3)

- **[#151](https://github.com/pitimon/8-habit-ai-dev/issues/151)** SKILL_OUTPUT attribution lines + new `validate-structure.sh` Check 22 — [PR #152](https://github.com/pitimon/8-habit-ai-dev/pull/152) merged
- **[#149](https://github.com/pitimon/8-habit-ai-dev/issues/149)** Argument-driven smart-routing for `/using-8-habits` — [PR #154](https://github.com/pitimon/8-habit-ai-dev/pull/154) merged
- **[#150](https://github.com/pitimon/8-habit-ai-dev/issues/150)** `/review-ai` Verification Phase with three-anchor "guidance only, NOT a hook" boundary qualifier + new `validate-content.sh` Check 20 — [PR #155](https://github.com/pitimon/8-habit-ai-dev/pull/155) merged

## Version bump (4 files)

- `.claude-plugin/plugin.json`: 2.13.1 → 2.14.0
- `.claude-plugin/marketplace.json`: 2.13.1 → 2.14.0
- `README.md`: badge + architecture diagram comment + footer date
- `SELF-CHECK.md`: header (line 3) + new v2.14.0 row in per-release list + footer (line 174)

## Docs

- `CHANGELOG.md` — full v2.14.0 entry (Added / Pattern / Fitness / Follow-ups / Closes)
- `docs/wiki/Changelog.md` — summarized v2.14.0 entry + version badge bump (latest-v2.13.1 → latest-v2.14.0)

## Test plan

- [x] `bash tests/validate-structure.sh` → 246 PASS / 0 FAIL (was 245; Check 22 added in #152)
- [x] `bash tests/validate-content.sh` → 203 PASS / 0 FAIL / 1 WARN (was 198 on v2.13.1; +3 Check 20 from #155, +2 from #154 content assertions)
- [x] `bash tests/test-skill-graph.sh` → 57 PASS / 0 FAIL
- [x] `bash tests/test-verbosity-hook.sh` → 19 PASS / 0 FAIL
- [x] Check 19 sub-checks E + F (SELF-CHECK.md body freshness vs git tag history) — Pass on release commit per pre-release-state handling (see v2.13.1 [PR #144](https://github.com/pitimon/8-habit-ai-dev/pull/144))
- [ ] After merge: tag `v2.14.0` + GitHub release notes (will run from main)

## Follow-ups (open, not blocking release)

- [#153](https://github.com/pitimon/8-habit-ai-dev/issues/153) — `/design` producer example missing from `guides/structured-output-protocol.md` (pre-existing gap, surfaced during #151 cross-verify)
- Reviewer suggestion (non-blocking): harden Check 20 to pin the 5-step loop name and step count
- [pitimon/claude-governance#24](https://github.com/pitimon/claude-governance/issues/24) — 7-file project memory system proposal (out-of-boundary, deferred)

## Research brief

Full filter analysis + plan + reviewer + advisor trail at `~/.claude/plans/toh-framework-idea-inspiration-sunny-forest.md` (local artifact).

Closes #149, #150, #151