### PR TITLE
chore(release): v2.14.1 — README "What's New" Drift Guard (#157)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.14.1 — README "What's New" Drift Guard (2026-05-02)
+
+Patch release closing [#157](https://github.com/pitimon/8-habit-ai-dev/issues/157) — external QA via the plugin's own `8-habit-reviewer` agent found 13/17 score with Spirit (33%) and Body (50%) failures concentrated in one root cause: `validate-content.sh` Check 19A passes on the README badge URL `releases/tag/v2.14.0`, never asserting that `## What's New in v2.14.0` exists as a section header. So the validator was green while the README "What's New" section ended at v2.13.1. Same bug class as [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124) (CHANGELOG pointer-fallback loophole, hardened in v2.11.1) and [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) (SELF-CHECK.md body drift, hardened in v2.13.1). Capability-level pattern recurrence on a sibling surface — the v2.13.1 sub-checks E + F lesson did not generalize to README.md.
+
+### Fixed
+
+- **`README.md` "What's New" backfill** — `## What's New in v2.14.0` block restored (3-bullet TOH theme summary). The section had stayed at v2.13.1 through the entire v2.14.0 release because the validator was matching the bare version string from the badge URL.
+- **`README.md` TOC anchor** — `[What's New](#whats-new-in-v220)` → `[What's New](#whats-new-in-v2141)`. The v2.2.0 anchor has not existed since v2.3.0; the broken link has shipped through 11 releases.
+- **`README.md` architecture file tree** — declared "17 skills (8 workflow + 9 standalone)" but enumerated only 13 SKILL.md paths. Backfilled the 4 missing skills (`calibrate`, `using-8-habits`, `eu-ai-act-check`, `ai-dev-log`) so the tree matches the count.
+
+### Added
+
+- **`tests/validate-content.sh` Check 19 sub-check G** — anchored grep `^## What's New in v${current_version}` against `README.md`. Mirrors the sub-checks E + F mechanism from [PR #144](https://github.com/pitimon/8-habit-ai-dev/pull/144) (SELF-CHECK.md body freshness). Closes the badge-URL false-positive class permanently — sub-check A keeps the existing "version mentioned anywhere" check, sub-check G adds the strict header anchor.
+- **Check 20 hardening** — pin literal `Find → Fix → Re-Verify` loop name + assert exactly 5 numbered steps in the Verification Phase section of `skills/review-ai/SKILL.md`. Closes the v2.14.0 self-disclosed follow-up (CHANGELOG noted "passes on 3 weak string matches; 5-step loop name + step count not pinned"). Two new assertions; reviewer concern documented and addressed in the same release.
+
+### Pattern
+
+Same shape as v2.11.1 (CHANGELOG drift guard) and v2.13.1 (SELF-CHECK body freshness): when QA surfaces the same drift class on a third surface, the fix is a fitness-function tightening, not a checklist. Check 19 now covers README + CHANGELOG + wiki + SELF-CHECK + README-section-header — five anchored assertions, all co-located.
+
+### Fitness
+
+- `validate-structure.sh` 246/0, `validate-content.sh` **206/0/1 WARN** (was 203 + 3 new pass-able assertions: sub-check G + Check 20 loop name + Check 20 step count), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+### Reviewer
+
+External QA report by [@itarunp-apple](https://github.com/itarunp-apple) — ran `8-habit-reviewer` agent against the v2.14.0 install at `~/.claude/plugins/cache/.../8-habit-ai-dev/2.14.0/` per the framework's intended self-discipline workflow. The boundary discipline citation in the issue body ("the H8 framing 'modeling = follow the process always' landing the structural-fix-not-checklist case is exactly the right pressure") frames the patch correctly: this is a deposit, not a withdrawal — the reporter brought rigorous file:line evidence and a sound patch plan.
+
+Closes #157.
+
+---
+
 ## v2.14.0 — TOH Framework Inspirations (2026-05-02)
 
 Minor release closing milestone [#15](https://github.com/pitimon/8-habit-ai-dev/milestone/15) — three workflow-discipline imports from [Toh Framework](https://github.com/Nathanphop/Toh-Framework) (an "AI-Orchestration Driven Development" framework for solo SaaS builders). Cross-pollination filtered through the plugin-boundary rule: workflow discipline lands here; enforcement and project-state persistence routed to `claude-governance` ([pitimon/claude-governance#24](https://github.com/pitimon/claude-governance/issues/24) for 7-file memory system).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.14.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.14.0)
+[![Version](https://img.shields.io/badge/Version-2.14.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.14.1)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -42,7 +42,7 @@
 
 **Reference**
 
-- [What's New](#whats-new-in-v220) — Version history
+- [What's New](#whats-new-in-v2141) — Version history
 - [Not a Checklist](#not-a-checklist) — Principles, not gates
 - [Origin](#origin) — Where these habits come from
 - [FAQ](#faq) — Common questions answered
@@ -317,7 +317,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.14.0)
+│   ├── plugin.json                 # Plugin metadata (v2.14.1)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -331,7 +331,11 @@ Both agents use the `sonnet` model for fast, focused analysis.
 │   ├── cross-verify/SKILL.md       #   All habits (17Q + dimension summary)
 │   ├── whole-person-check/SKILL.md #   H8: Body/Mind/Heart/Spirit
 │   ├── security-check/SKILL.md     #   H1: OWASP security lens
-│   ├── reflect/SKILL.md            #   H7: micro-retrospective
+│   ├── reflect/SKILL.md            #   H7: micro-retrospective + lesson persistence
+│   ├── calibrate/SKILL.md          #   H8: maturity self-assessment → habit-profile.md
+│   ├── using-8-habits/SKILL.md     #   H5+H8: onboarding + smart-routing mode (v2.14.0)
+│   ├── eu-ai-act-check/SKILL.md    #   H1+H8: EU AI Act 9-obligation checklist
+│   ├── ai-dev-log/SKILL.md         #   H4+H1: AI dev log from git history (Art. 11)
 │   └── workflow/SKILL.md           #   Guided 7-step walkthrough
 ├── agents/
 │   ├── 8-habit-reviewer.md         # Deep cross-verification agent
@@ -390,6 +394,30 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
 
 ---
+
+## What's New in v2.14.1
+
+**Theme: README "What's New" Drift Guard** ([#157](https://github.com/pitimon/8-habit-ai-dev/issues/157))
+
+Patch release closing an external QA finding — same bug class as #124 (CHANGELOG pointer-fallback) and #141 (SELF-CHECK.md body drift) recurring on a sibling surface (README.md "What's New" section).
+
+- **README.md backfill** — `## What's New in v2.14.0` block restored (was missing — Check 19A passed silently because `grep -q "v${current_version}"` matched the badge URL `releases/tag/v2.14.0` instead of asserting the section header). Architecture file tree backfilled with 4 missing skills (calibrate, using-8-habits, eu-ai-act-check, ai-dev-log) so it matches the declared 17-skill count. TOC anchor fixed (`#whats-new-in-v220` → `#whats-new-in-v2141`) — broken since at least v2.3.0.
+- **`tests/validate-content.sh` Check 19 sub-check G** — anchored grep `^## What's New in v${current_version}` in README.md. Mirrors sub-checks E + F mechanism from #144 (SELF-CHECK.md body freshness). Prevents the badge-URL false-positive class permanently.
+- **Check 20 hardening** — `Find → Fix → Re-Verify` literal name pinned + assert exactly 5 numbered steps (1-5) in `skills/review-ai/SKILL.md` Verification Phase. Closes the v2.14.0 self-disclosed follow-up.
+
+Pattern: validator assertion, not checklist — when QA surfaces the same drift class across multiple releases, the fix is a fitness function. Same shape as v2.11.1 (CHANGELOG drift guard) and v2.13.1 (SELF-CHECK body freshness).
+
+## What's New in v2.14.0
+
+**Theme: TOH Framework Inspirations** ([milestone #15](https://github.com/pitimon/8-habit-ai-dev/milestone/15))
+
+Three workflow-discipline imports from [Toh Framework](https://github.com/Nathanphop/Toh-Framework) (an "AI-Orchestration Driven Development" framework for solo SaaS builders), filtered through plugin-boundary rule (3/10 candidates imported, 7 rejected with route-elsewhere reasoning).
+
+- **`SKILL_OUTPUT` attribution lines** ([#151](https://github.com/pitimon/8-habit-ai-dev/issues/151), [PR #152](https://github.com/pitimon/8-habit-ai-dev/pull/152)) — visible `[/<skill>] COMPLETE SKILL_OUTPUT:<type>` directly above each HTML comment in 4 emitter skills (design, breakdown, requirements, review-ai). Status markers `COMPLETE` / `PARTIAL` / `FAILED` (text-only, no emoji). New `validate-structure.sh` Check 22 enforces format (BSD-safe via `grep -B1`). `cross-verify` parser unaffected. Inspired by Toh's Agent Announcement format.
+- **Argument-driven smart-routing for `/using-8-habits`** ([#149](https://github.com/pitimon/8-habit-ai-dev/issues/149), [PR #154](https://github.com/pitimon/8-habit-ai-dev/pull/154)) — `/using-8-habits "<intent>"` returns ≤3 ranked skills + reasoning + alternatives + a single direct question instead of the full narrative tree. Reads `~/.claude/habit-profile.md` for verbosity tier (dependence → independence → interdependence → significance) and recent `~/.claude/lessons/` for context. **Activates** existing `argument-hint` frontmatter — no new skill file. Inspired by Toh's `/toh` Smart Command (reshape: extend rather than wrap).
+- **`/review-ai` Verification Phase** ([#150](https://github.com/pitimon/8-habit-ai-dev/issues/150), [PR #155](https://github.com/pitimon/8-habit-ai-dev/pull/155)) — Find → Fix → Re-Verify loop ending in a Verification Table (Finding | Severity | Fix Evidence | Status). **Plugin boundary**: section header reads "guidance only — NOT a hook"; three independent anchors (header + blockquote + step-5 prose) prevent future enforcement creep. New `validate-content.sh` Check 20 enforces all three anchors. Inspired by Toh's Test → Fix → Loop adapted as discipline guidance, not automated enforcement.
+
+Companion proposal: [pitimon/claude-governance#24](https://github.com/pitimon/claude-governance/issues/24) for the 7-file project memory persistence layer (out-of-boundary for this plugin).
 
 ## What's New in v2.13.1
 
@@ -613,4 +641,4 @@ MIT
 
 ---
 
-_Version: 2.14.0 | Last updated: 2026-05-02_
+_Version: 2.14.1 | Last updated: 2026-05-02_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.14.0 | **Date**: 2026-05-02 | **Previous**: 2.13.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.14.1 | **Date**: 2026-05-02 | **Previous**: 2.14.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -169,7 +169,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.13.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (Cross-Agent Discoverability: #135 skills/RESOLVER.md flat dispatcher, #136 llms.txt + AGENTS.md at repo root, #137 README "Thin Harness, Fat Skills" citation, ADR-010 + ADR-011, Check 20 + 21 added)
 - v2.13.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (SELF-CHECK.md Body Freshness: #141 three-PR arc — #142 catch-up 6 missing per-release rows v2.9.0→v2.13.0 + footer, #143 CONTRIBUTING.md 3→4 files correction, #144 Check 19 sub-checks E + F — CI invariant via git tag source of truth)
 - v2.14.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (TOH Framework Inspirations — milestone #15: #151 SKILL_OUTPUT attribution lines + Check 22, #149 argument-driven smart-routing in /using-8-habits, #150 Verification Phase in /review-ai with explicit "guidance only, NOT a hook" boundary qualifier — three workflow-discipline imports from external framework, all stayed within plugin boundary)
+- v2.14.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#157 README "What's New" Drift Guard — external QA found Check 19A passes on badge URL not section header, README "What's New" missing v2.14.0 entry, TOC anchor broken since v2.3.0, architecture tree under-enumerated 4 skills; same bug class as #124/#141 recurring on sibling surface; fix is doc backfill + Check 19 sub-check G anchored grep + Check 20 hardening pinning Find→Fix→Re-Verify loop name and step count — capability-level pattern closed with fitness function not checklist)
 
 ---
 
-_Updated with each release. Previous: 2.13.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.14.0 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,28 @@
-![Version](https://img.shields.io/badge/latest-v2.14.0-blue)
+![Version](https://img.shields.io/badge/latest-v2.14.1-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.14.1 — README "What's New" Drift Guard (May 2026)
+
+Patch release closing [#157](https://github.com/pitimon/8-habit-ai-dev/issues/157) — external QA found `validate-content.sh` Check 19A was passing on the README badge URL `releases/tag/v2.14.0` instead of asserting the section header `## What's New in v2.14.0`. Same bug class as [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124) (CHANGELOG pointer-fallback) and [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) (SELF-CHECK.md body drift) — capability-level recurrence on a sibling surface.
+
+- **README.md backfill** — restored missing `## What's New in v2.14.0` block, fixed broken TOC anchor (`#whats-new-in-v220` → `#whats-new-in-v2141`, broken since v2.3.0), backfilled 4 missing skills in the architecture file tree (calibrate, using-8-habits, eu-ai-act-check, ai-dev-log) so the tree matches the declared 17-skill count.
+- **`tests/validate-content.sh` Check 19 sub-check G** — anchored grep `^## What's New in v${current_version}` in README.md. Closes the badge-URL false-positive class permanently. Mirrors the sub-checks E + F mechanism from PR #144.
+- **Check 20 hardening** — pin literal `Find → Fix → Re-Verify` loop name + assert exactly 5 numbered steps in `skills/review-ai/SKILL.md` Verification Phase. Closes the v2.14.0 self-disclosed follow-up (passes-on-3-string-matches risk).
+
+Pattern: same shape as v2.11.1 and v2.13.1 — QA surfaces drift class on a sibling surface → fix is fitness function, not checklist. Check 19 now covers README + CHANGELOG + wiki + SELF-CHECK + README-section-header — five anchored assertions, all co-located.
+
+Fitness receipts: `validate-structure.sh` 246/0, `validate-content.sh` **206/0/1 WARN** (was 203; +3 new assertions), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
+
+External QA report by [@itarunp-apple](https://github.com/itarunp-apple) — ran the plugin's own `8-habit-reviewer` agent against v2.14.0 install per the framework's intended self-discipline workflow.
+
+Closes #157.
+
+---
 
 ## v2.14.0 — TOH Framework Inspirations (May 2026)
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -553,6 +553,24 @@ if [ -f "$REVIEW_AI" ]; then
     fail "$REVIEW_AI Verification Phase missing Verification Table example (need 'Fix Evidence' + 'RESOLVED')"
     VERIFY_FAIL=$((VERIFY_FAIL + 1))
   fi
+  # Find → Fix → Re-Verify literal loop name pinned (Issue #157 hardening — was
+  # self-disclosed weak in v2.14.0 CHANGELOG follow-up; passes-on-3-string-matches risk)
+  if grep -q "Find → Fix → Re-Verify" "$REVIEW_AI"; then
+    pass "$REVIEW_AI Verification Phase pins 'Find → Fix → Re-Verify' loop name"
+  else
+    fail "$REVIEW_AI Verification Phase missing 'Find → Fix → Re-Verify' literal loop name (Issue #157 hardening)"
+    VERIFY_FAIL=$((VERIFY_FAIL + 1))
+  fi
+  # Exactly 5 numbered steps (1.-5.) in the Verification Phase section
+  # awk extracts the section content between '## Verification Phase' and the next '## ',
+  # then grep counts numbered-step lines like "1. **List**" / "2. **Apply fix**" / etc.
+  verify_steps=$(awk '/^## Verification Phase/{found=1; next} /^## /{if(found) exit} found' "$REVIEW_AI" | grep -cE '^[1-5]\. \*\*')
+  if [ "$verify_steps" = "5" ]; then
+    pass "$REVIEW_AI Verification Phase has exactly 5 numbered steps"
+  else
+    fail "$REVIEW_AI Verification Phase has $verify_steps numbered steps (expected exactly 5 — Issue #157 hardening pins the loop count)"
+    VERIFY_FAIL=$((VERIFY_FAIL + 1))
+  fi
 else
   fail "$REVIEW_AI not found"
   VERIFY_FAIL=$((VERIFY_FAIL + 1))
@@ -660,6 +678,18 @@ else
     else
       fail "SELF-CHECK.md per-release list missing ${#missing[@]} version(s): ${missing[*]} — add a '- v<x.y.z>: Body N, Mind N, Heart N, Spirit N = **N.N** (…)' row per tagged release."
     fi
+  fi
+
+  # G. README.md "What's New in v<current_version>" section header anchored.
+  # Added 2026-05-02 per issue #157: sub-check A (line 578) only checks bare
+  # version mention, which the badge URL "releases/tag/v<x.y.z>" satisfies even
+  # when the section header is missing. Same bug class as #124 pointer-fallback
+  # loophole — tighter assertion required so README "What's New" cannot drift
+  # like SELF-CHECK.md did before sub-checks E + F (#141/#144).
+  if grep -q "^## What's New in v${current_version}" README.md; then
+    pass "README.md contains '## What's New in v${current_version}' section header"
+  else
+    fail "README.md missing '## What's New in v${current_version}' section header — sub-check A passed on badge URL but the user-facing upgrade-discovery surface is stale. Add the section between the existing 'Zero dependencies' block and the previous '## What's New in v...' entry. See issue #157."
   fi
 fi
 


### PR DESCRIPTION
## Summary

Patch release closing [#157](https://github.com/pitimon/8-habit-ai-dev/issues/157) — external QA via 8-habit-reviewer agent against v2.14.0 install found `validate-content.sh` Check 19A was passing on README badge URL `releases/tag/v2.14.0` instead of asserting the section header. Same bug class as [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124) (CHANGELOG pointer-fallback) and [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) (SELF-CHECK.md body drift) recurring on a sibling surface.

External reporter: [@itarunp-apple](https://github.com/itarunp-apple) — brought file:line evidence + a sound patch plan; this PR implements the plan exactly.

## Findings closed (5)

| # | Finding | Fix |
|---|---|---|
| F1 | `README.md:394` "What's New" ended at v2.13.1 — no v2.14.0 entry | Backfilled `## What's New in v2.14.0` (3-bullet TOH theme) + new `## What's New in v2.14.1` block |
| F2 | `README.md:45` TOC anchor `#whats-new-in-v220` broken since v2.3.0 | Updated to `#whats-new-in-v2141` |
| F3 | Architecture tree declared "17 skills" but enumerated 13 | Backfilled 4 missing: calibrate, using-8-habits, eu-ai-act-check, ai-dev-log |
| F4 | Check 20 self-disclosed weak — passes on 3 string matches | Added 2 assertions: pin `Find → Fix → Re-Verify` loop name + assert exactly 5 numbered steps |
| F5 (root) | Check 19A grep matches badge URL not section header | Added Check 19 sub-check **G**: anchored `^## What's New in v${current_version}` (mirrors E + F mechanism from PR #144) |

## Plugin boundary

Pure README + CHANGELOG + validator changes. No new hooks. Stays within `8-habit-ai-dev` workflow-discipline scope. Pattern is fitness-function tightening (per the v2.11.1 / v2.13.1 lesson), not new enforcement surface.

## Test plan

- [x] `bash tests/validate-structure.sh` → 246 PASS / 0 FAIL (unchanged)
- [x] `bash tests/validate-content.sh` → 206 PASS / 0 FAIL / 1 WARN (was 203; +3 new: sub-check G + Check 20 loop name + Check 20 step count)
- [x] `bash tests/test-skill-graph.sh` → 57 PASS / 0 FAIL
- [x] `bash tests/test-verbosity-hook.sh` → 19 PASS / 0 FAIL
- [x] Spot-checks: 2 `## What's New in v2.14.x` headers in README, TOC anchor `#whats-new-in-v2141`, 17 SKILL.md paths in arch tree, 5 numbered steps in Verification Phase, plugin.json 2.14.1
- [x] Negative test (logical): if README "What's New in v2.14.1" is removed, Check 19G should FAIL — anchor regex `^## What's New in v` cannot match the badge URL
- [ ] After merge: tag `v2.14.1` + GitHub release notes (will run from main)

## Pattern (extracted)

Check 19 now covers five drift surfaces with anchored assertions, all co-located:
- A: bare version mention in README (kept — useful breadth check)
- B: `^## v<x.y.z>` in CHANGELOG.md
- C: `^## v<x.y.z>` in docs/wiki/Changelog.md
- D: `latest-v<x.y.z>-blue` badge in wiki
- E: SELF-CHECK.md footer matches git tag history
- F: SELF-CHECK.md per-release rows have no gaps
- **G** (new): `^## What's New in v<x.y.z>` in README.md

Closes #157