### PR TITLE
docs: add Harness Engineering wiki + blog (#160)

### DIFF
--- a/docs/blog/harness-engineering-where-are-you.md
+++ b/docs/blog/harness-engineering-where-are-you.md
@@ -1,0 +1,143 @@
+# คุณกำลังทำงานอยู่ชั้นไหน? — Prompt → Context → Harness Engineer
+
+> _"Anytime you find an agent makes a mistake, you take the time to engineer a solution such that the agent never makes that mistake again."_
+> — Mitchell Hashimoto, _My AI Adoption Journey_, 5 ก.พ. 2026
+
+---
+
+ช่วงนี้คำว่า **Harness Engineer** เริ่มดังในวงการ AI agent dev — โดยเฉพาะหลังจาก Mitchell Hashimoto (คนที่สร้าง Terraform/HashiCorp) เขียน blog post กุมภาพันธ์ 2026 ตั้งชื่อให้ practice นี้, แล้ว Stanford ตามด้วยเปเปอร์ _Meta-Harness_ และ Thoughtworks (Birgitta Böckeler) เขียน reference article บน martinfowler.com ตามมาในเมษา
+
+ถ้าใครยังไม่เห็นภาพ ลองนึกแบบจ้างพนักงานใหม่:
+
+🔹 **Prompt Engineer** = คนที่สั่งงานเก่ง — รู้ว่าต้องพูดยังไง ใส่รายละเอียดแค่ไหน ให้ตัวอย่างกี่ข้อ. สั่งดี = งานออกมาดี, สั่งห่วย = งานพัง. ทุกอย่างขึ้นกับ "คำสั่งในตอนนั้น"
+
+🔹 **Context Engineer** = คนที่ทำ onboarding ให้พนักงาน — เตรียม document, แผนผังองค์กร, ประวัติโปรเจกต์ ให้ครบก่อนเริ่มงาน. แม้สั่งดีแค่ไหน ถ้า context ไม่พอก็ผิดได้
+
+🔹 **Harness Engineer** = คนที่ออกแบบ HR ทั้งระบบ — กำหนดอำนาจ, ระบบตรวจงานก่อน approve, checkpoint ก่อนทำสิ่งสำคัญ, และระบบจัดการเวลาพนักงานทำผิดให้ไม่ซ้ำอีก
+
+🤖 ถ้าเทียบเป็นคอมพิวเตอร์: **Model = CPU, Context = RAM, Harness = OS**. ทั้ง 3 ชั้น **"ครอบกัน"** ไม่ใช่ "แทนกัน" — Harness Engineer ที่ดียังเขียน prompt ดีและประกอบ context เก่งอยู่ แค่ขอบเขตของบทบาทใหญ่กว่า
+
+---
+
+## ทำไมต้องมีชั้น Harness?
+
+🤖 เพราะมีปัญหาที่ Prompt + Context แก้ไม่ได้:
+
+- AI ที่รันงานคนเดียวหลายชั่วโมง อาจ "หลงทาง" ไปแก้ไฟล์นอก scope
+- งาน multi-step มีความผิดพลาดสะสมจนระเบิดในขั้นท้าย
+- บอก "ครั้งหน้าอย่าทำแบบนี้" ไม่ได้ผล — AI ไม่มีความจำข้าม session
+
+แนวคิดหลักของ Harness Engineer ตามนิยาม Hashimoto: **"ทุกครั้งที่ AI ทำผิด อย่าหวังว่ามันจะดีขึ้นเอง — เปลี่ยนระบบให้ความผิดพลาดแบบนั้นเกิดซ้ำได้ยากขึ้นเชิงโครงสร้าง"**
+
+---
+
+## เลข viral "3% vs 28-47%" — เช็คให้ชัด
+
+🤖 มีตัวเลขที่ถูก quote บ่อยว่า "งานวิจัย Stanford พบว่า prompt tuning ดีขึ้นได้สูงสุด 3% แต่ harness ดีขึ้น 28-47%"
+
+⚠️ ผมไป fetch เปเปอร์ Stanford ตัวจริง (Lee et al. _Meta-Harness_, arxiv 2603.28052) ตรงๆ — **ตัวเลขนี้ไม่อยู่ในเปเปอร์**. ตัวจริงรายงาน:
+
+- **+7.7 percentage points** บน text classification — ใช้ token น้อยลง 4 เท่า
+- **+4.7 percentage points** บน math reasoning ระดับ IMO (เฉลี่ย 5 โมเดล)
+- **SOTA** บน TerminalBench-2 agentic coding ด้วย Claude Haiku 4.5
+
+**ทิศทาง** (harness >> prompt tuning) ถูก. แต่เลข "28-47%" น่าจะเป็น paraphrase ของ blog aggregator. ถ้าจะอ้างทางการ ใช้ตัวเลขจริงครับ — น่าเชื่อถือกว่าและ verify ได้
+
+---
+
+## Case study — เขียน Harness ก่อนคำว่า Harness Engineering จะ viral
+
+ผมดูแล plugin ชื่อ [`8-habit-ai-dev`](https://github.com/pitimon/8-habit-ai-dev) สำหรับ Claude Code ตั้งแต่ก่อนคำว่า Harness Engineering จะกลายเป็น industry term. พอเห็นนิยามของ Hashimoto + taxonomy ของ Böckeler แล้ว — plugin นี้คือ **Harness implementation ตรงตามตำรา**
+
+Böckeler แบ่ง harness เป็น 2 ฝั่ง:
+
+- **Feedforward guides** — ตัวกำหนดทิศ "ก่อน" agent ลงมือ
+- **Feedback sensors** — กลไก self-correction "หลัง" agent ทำเสร็จ
+
+ตัวอย่างที่ map กับ plugin (ทุกตัวมี path verify ได้ — ลิสต์ครบใน wiki):
+
+**ฝั่ง Feedforward (6 components):**
+
+- `rules/effective-development.md` — auto-load ทุก session, นิยาม "WHY" ของทุกขั้นตอน
+- `hooks/session-start.sh` — inject 7-step reminder + maturity-adapted verbosity directive ให้ทุก conversation
+- 17 on-demand process skills ใน `skills/*/SKILL.md`
+- `~/.claude/habit-profile.md` — calibration profile ที่ skills อ่านเพื่อปรับ verbosity ตาม maturity ของ user
+- `CLAUDE.md` / `AGENTS.md` ทั้ง project + user-global — ตรงกับ pattern "implicit prompting" ของ Hashimoto
+
+**ฝั่ง Feedback (7 components):**
+
+- `tests/validate-structure.sh` — **74 checks** ของโครงสร้างไฟล์
+- `tests/validate-content.sh` — **132 checks** ของ content (version 4-files consistency, README drift, sidebar)
+- Aux scripts อีก **36 checks**
+- `agents/8-habit-reviewer.md` — read-only review agent (sonnet)
+- `/cross-verify` — 17 คำถาม audit ก่อน commit
+- `/review-ai` — Find→Fix→Re-Verify loop กัน partial-fix
+- `~/.claude/lessons/` cross-session memory — ปิด gap "AI ไม่มีความจำข้าม session" ที่ Hashimoto เจอตรงๆ
+
+🤖 รวม **242 assertion ที่ verify ได้** + 17 คำถาม cross-verification
+
+ตัวอย่าง concrete: patch `v2.14.1` (issue #157) — user แจ้งว่า README "What's New" section drift ไป. fix ของเรา **ไม่ใช่** "เติม README ให้ครั้งเดียว" — แต่คือ **harden `validate-content.sh:578`** ให้ grep แบบ anchor ที่ section header แทน badge URL. ครั้งหน้าใครลืม → validator จับได้ก่อน merge. ตรงตามนิยาม Hashimoto ทุกตัวอักษร
+
+---
+
+## Self-test — ตอนนี้คุณอยู่ชั้นไหน?
+
+ลองติ้กดู (เอา layer ที่ติ้กส่วนใหญ่ได้ = ชั้นที่คุณอยู่):
+
+**Layer 1 — Prompt Engineer**
+
+- [ ] iterate ด้วยการแก้คำพูดในข้อความเป็นข้อๆ
+- [ ] วัดความสำเร็จเป็นรายบทสนทนา
+- [ ] ไม่มีไฟล์ project ที่ auto-load context ทุก session
+- [ ] เวลา agent พลาด แก้ด้วย "บอกครั้งหน้าอย่าทำ"
+- [ ] ไม่มี automated check ที่รันโดยไม่ต้องสั่ง
+
+**Layer 2 — Context Engineer**
+
+- [ ] มี `CLAUDE.md` / `AGENTS.md` / system prompt load ทุก session
+- [ ] curate ไฟล์ใน working set
+- [ ] จัด context-window budget ชัดเจน (token, summarization, RAG)
+- [ ] เพิ่มของเข้า context เวลาเจอปัญหาซ้ำ
+- [ ] แต่: การแก้ยังอาศัยคุณจำว่าต้อง update doc
+
+**Layer 3 — Harness Engineer**
+
+- [ ] มี automated check บล็อกพฤติกรรมแย่ได้แม้ไม่มีคนดู (session hook, pre-commit validator, reviewer agent)
+- [ ] จัดการความผิดพลาด agent เป็น **system bug** — แก้คือเพิ่ม validator/skill/hook ใหม่
+- [ ] versioning guide, validator, decision record (ADR)
+- [ ] วัด agent quality ระดับ system (validator pass rate, regression count)
+- [ ] มี cross-session memory — บทเรียนเก่าเรียกใช้ได้โดยไม่ต้องพิมพ์ใหม่
+
+🤖 ถ้าติ้กส่วนใหญ่ใน Layer 3 ได้ — **คุณเป็น Harness Engineer แล้ว** อาจจะก่อนรู้จักคำนี้ด้วยซ้ำ. ประเด็นของการมี "ชื่อ" ไม่ใช่ gatekeep ใคร — มันคือการให้ชื่อบทบาทเพื่อให้ practice ถูก discuss, สอน, และพัฒนาต่อได้
+
+---
+
+## สรุป
+
+- **Prompt** = "พูดยังไง"
+- **Context** = "รู้อะไร"
+- **Harness** = "ทำอะไรได้บ้าง + ตรวจอย่างไร + เกิดอะไรขึ้นถ้า off"
+
+3 ชั้นนี้ **ซ้อนกัน ไม่ใช่แทนกัน**. Harness Engineer ที่ดียังต้องเก่ง prompt + context — แค่บทบาทใหญ่กว่า
+
+ถ้าคุณกำลังจะเริ่มลงมือทำ harness ของตัวเอง — เริ่มจากสามคำถาม:
+
+1. **ตอน agent พลาดครั้งล่าสุด คุณ "เพิ่ม validator" หรือ "บอกตัวเองว่าจะระวัง"?** (Hashimoto's test)
+2. **บทเรียนจาก session ที่แล้ว เก็บไว้ที่ไหน — disk หรือสมองคุณ?** (cross-session memory test)
+3. **มีคนอื่นในทีมที่ไม่ใช่คุณ run ระบบ harness ได้มั้ย?** (system vs ritual test)
+
+ถ้าทั้ง 3 ข้อตอบ "ตามตำรา" — คุณอยู่ชั้น Harness แล้วจริงๆ
+
+---
+
+## Deep dive
+
+- **Wiki canonical** (รายละเอียดเต็ม + 13-component mapping table + bilingual EN+TH) → [Harness Engineering — 8-habit-ai-dev wiki](https://github.com/pitimon/8-habit-ai-dev/wiki/Harness-Engineering)
+- **Plugin GitHub** → <https://github.com/pitimon/8-habit-ai-dev>
+- **Install ใน Claude Code**: `claude plugin marketplace add pitimon/8-habit-ai-dev && claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev`
+
+## Sources (verified — fetched ตรงไปแต่ละ source)
+
+- Hashimoto, M. _My AI Adoption Journey_, 5 Feb 2026 → <https://mitchellh.com/writing/my-ai-adoption-journey>
+- Lee, Y. et al. _Meta-Harness: End-to-End Optimization of Model Harnesses_ (Stanford) → <https://arxiv.org/abs/2603.28052>
+- Böckeler, B. _Harness engineering for coding agent users_, Thoughtworks, 2 Apr 2026 → <https://martinfowler.com/articles/harness-engineering.html>

--- a/docs/wiki/Harness-Engineering.md
+++ b/docs/wiki/Harness-Engineering.md
@@ -1,0 +1,194 @@
+# Harness Engineering — and where 8-habit-ai-dev lives in the picture
+
+> _"Anytime you find an agent makes a mistake, you take the time to engineer a solution such that the agent never makes that mistake again."_
+> — Mitchell Hashimoto, _My AI Adoption Journey_, 5 February 2026
+
+---
+
+## TL;DR / สรุปสั้น
+
+**EN.** Harness Engineering is the third era of AI-assisted development — after Prompt Engineering and Context Engineering. It is the discipline of designing the entire environment an agent operates within: the guides that direct it, the sensors that catch its mistakes, and the feedback loops that prevent recurrence. `8-habit-ai-dev` is a concrete harness implementation focused on workflow discipline, with **242 verifiable assertions** plus a 17-question cross-verification audit.
+
+**TH.** Harness Engineering คือยุคที่ 3 ของการพัฒนาด้วย AI ต่อจาก Prompt Engineering และ Context Engineering. เป็นระเบียบในการออกแบบ "สภาพแวดล้อมทั้งระบบ" ที่ agent ทำงานภายใต้ — guide ที่ชี้นำ, sensor ที่ตรวจจับความผิดพลาด, และ feedback loop ที่ป้องกันการพลาดซ้ำ. `8-habit-ai-dev` คือ harness implementation ที่เน้น workflow discipline พร้อม **assertion ที่ verify ได้ 242 ข้อ** และ cross-verification audit 17 คำถาม
+
+---
+
+## What is Harness Engineering? / Harness Engineering คืออะไร?
+
+### Origin of the term / ต้นทางของคำ
+
+**EN.** The term was coined by **Mitchell Hashimoto** (HashiCorp / Terraform creator) in his **5 February 2026** blog post _My AI Adoption Journey_. He defined the practice as: _"the idea that anytime you find an agent makes a mistake, you take the time to engineer a solution such that the agent never makes that mistake again."_ He showed two complementary patterns: implicit prompting via `AGENTS.md` updates, and programmed tools (e.g. screenshot utilities, filtered test runners) paired with documentation updates. Days later an OpenAI engineering report cemented the term in industry vocabulary, and at the **AI Engineer World's Fair (April 2026)** three independent speakers named "agent harness" + "context engineering" as priority #1 for production reliability.
+
+**TH.** คำนี้ถูกตกผลึกโดย **Mitchell Hashimoto** (ผู้สร้าง Terraform / HashiCorp) ใน blog post วันที่ **5 กุมภาพันธ์ 2026** ชื่อ _My AI Adoption Journey_. เขานิยามไว้ว่า _"แนวคิดที่ว่าทุกครั้งที่ agent ทำผิดพลาด คุณใช้เวลาออกแบบทางแก้เพื่อให้มันไม่พลาดแบบนั้นอีก"_. เขายกตัวอย่าง 2 รูปแบบ: implicit prompting ผ่านการ update `AGENTS.md`, และ programmed tools (เช่น screenshot utility, filtered test runner) ที่ทำงานคู่กับเอกสาร. ไม่กี่วันถัดมา OpenAI ออก engineering report ตอกย้ำคำนี้, และที่งาน **AI Engineer World's Fair (เมษายน 2026)** มีวิทยากร 3 คนแยกกันชี้ว่า "agent harness" + "context engineering" คือ priority อันดับ 1 ของ production reliability
+
+### The three layers / สามชั้นที่ซ้อนกัน
+
+**EN.** Hashimoto's framing places harness as the outermost of three layers. The popular analogy:
+
+| Layer       | Computer analogy | Question it answers                                                 |
+| ----------- | ---------------- | ------------------------------------------------------------------- |
+| **Model**   | CPU              | _What can the brain compute?_                                       |
+| **Context** | RAM              | _What does it know right now?_                                      |
+| **Harness** | Operating System | _What can it do, how is it checked, what happens when it deviates?_ |
+
+The three layers compose; they do **not** replace one another. A good Harness Engineer still writes good prompts and assembles good context — the role just sits at a higher altitude.
+
+**TH.** Hashimoto วาง harness เป็นชั้นนอกสุดของ 3 ชั้น. analogy ที่ใช้กันทั่วไป:
+
+| ชั้น        | analogy          | คำถามที่ตอบ                                        |
+| ----------- | ---------------- | -------------------------------------------------- |
+| **Model**   | CPU              | _สมองคำนวณอะไรได้?_                                |
+| **Context** | RAM              | _ตอนนี้รู้อะไร?_                                   |
+| **Harness** | Operating System | _ทำอะไรได้บ้าง, ตรวจอย่างไร, เกิดอะไรขึ้นถ้า off?_ |
+
+ทั้ง 3 ชั้น "ครอบกัน" ไม่ใช่ "แทนกัน". Harness Engineer ที่ดียังเขียน prompt ดีและประกอบ context เก่ง — แค่ขอบเขตของบทบาทใหญ่กว่า
+
+---
+
+## The lineage — three primary sources / ที่มาทางวิชาการ
+
+| #   | Source                                                                                                           | Contribution                                         | Date       | Verified URL                                                                   |
+| --- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------- | ------------------------------------------------------------------------------ |
+| 1   | **Hashimoto** — _My AI Adoption Journey_                                                                         | Coined "Engineer the Harness", definition + practice | 5 Feb 2026 | [mitchellh.com](https://mitchellh.com/writing/my-ai-adoption-journey)          |
+| 2   | **Lee, Nair, Zhang, Lee, Khattab, Finn** — _Meta-Harness: End-to-End Optimization of Model Harnesses_ (Stanford) | Quantitative evidence + automated harness search     | 2026       | [arxiv 2603.28052](https://arxiv.org/abs/2603.28052)                           |
+| 3   | **Böckeler** (Thoughtworks) — _Harness engineering for coding agent users_                                       | Taxonomy: feedforward guides + feedback sensors      | 2 Apr 2026 | [martinfowler.com](https://martinfowler.com/articles/harness-engineering.html) |
+
+### ⚠️ Honest correction on the viral "3% vs 28–47%" framing / หมายเหตุเรื่องเลข viral
+
+**EN.** A widely-quoted summary claims Stanford research found that "prompt tuning yields ≤3% improvement while harness changes yield 28–47%." **This number does not appear in the actual Stanford paper** (Lee et al., _Meta-Harness_, arxiv 2603.28052). The figures the paper actually reports are:
+
+- **+7.7 percentage points** on text classification — using **4× fewer context tokens**
+- **+4.7 percentage points** on math reasoning (IMO-level problems, averaged across 5 held-out models)
+- **State-of-the-art** on TerminalBench-2 agentic coding using Claude Haiku 4.5
+
+The **direction** of the popular claim (harness >> prompt tuning) is correct. The specific "28–47%" number appears to be an aggregator paraphrase, not a primary citation. For formal documents, prefer the real figures from arxiv 2603.28052.
+
+**TH.** มีตัวเลข viral ที่ถูก quote กันเยอะว่า "Stanford พบ prompt tuning ดีขึ้นได้สูงสุด 3% แต่ harness ดีขึ้น 28–47%". **ตัวเลขนี้ไม่ปรากฏในเปเปอร์ Stanford ตัวจริง** (Lee et al., _Meta-Harness_, arxiv 2603.28052). ตัวเลขที่เปเปอร์รายงานจริง:
+
+- **+7.7 percentage points** บน text classification — ใช้ token น้อยลง **4 เท่า**
+- **+4.7 percentage points** บน math reasoning (โจทย์ระดับ IMO, เฉลี่ย 5 โมเดลที่ hold out)
+- **SOTA** บน TerminalBench-2 agentic coding ด้วย Claude Haiku 4.5
+
+**ทิศทาง** ของ claim ถูก (harness >> prompt tuning). แต่เลข "28–47%" น่าจะเป็น paraphrase ของ aggregator ไม่ใช่ primary citation. ในเอกสารทางการ ใช้ตัวเลขจริงจาก arxiv 2603.28052 ดีกว่า
+
+---
+
+## 8-habit-ai-dev as a Harness Implementation / ในฐานะ Harness Implementation
+
+**EN.** Böckeler's taxonomy splits a harness into two complementary halves:
+
+- **Feedforward guides** — anticipatory controls. Set context and conventions **before** the agent acts.
+- **Feedback sensors** — self-correction mechanisms. Detect deviations **after** the agent has acted.
+
+The plugin maps cleanly onto both halves. Every row below carries a verifiable file path inside this repository.
+
+**TH.** Böckeler แบ่ง harness เป็น 2 ส่วนที่เสริมกัน:
+
+- **Feedforward guides** — ตัวกำหนดทิศ "ก่อน" agent ลงมือ (set context + convention)
+- **Feedback sensors** — กลไก self-correction "หลัง" agent ทำเสร็จ (ตรวจจับการ deviate)
+
+plugin map ลงทั้ง 2 ฝั่งได้ครบ. ทุกแถวด้านล่างมี path ที่ verify ได้ใน repo นี้
+
+### Feedforward guides
+
+| #   | Component                                    | Path                                                   | What it does                                                                            |
+| --- | -------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| 1   | 8-Habit playbook (auto-loaded every session) | `rules/effective-development.md`                       | Defines the WHY behind every workflow step                                              |
+| 2   | Session-start hook                           | `hooks/session-start.sh`                               | Injects 7-step reminder + maturity-adapted verbosity directive into every conversation  |
+| 3   | 17 on-demand process skills                  | `skills/*/SKILL.md` (17 directories)                   | One per workflow step + standalone (`/cross-verify`, `/calibrate`, `/reflect`, etc.)    |
+| 4   | Habit + guide reference content              | `habits/h*.md`, `guides/*.md`                          | Loaded on-demand by skills (token-efficient — never injected at session start)          |
+| 5   | Maturity profile (per-user calibration)      | `~/.claude/habit-profile.md` (written by `/calibrate`) | Drives runtime verbosity adaptation across all skills (Dependence → Significance)       |
+| 6   | Project + user CLAUDE.md / AGENTS.md         | `CLAUDE.md`, `AGENTS.md`, `~/.claude/CLAUDE.md`        | Hashimoto's "implicit prompting through documentation" pattern, applied at three scopes |
+
+### Feedback sensors
+
+| #   | Component                          | Path                                                                                      | What it catches                                                                                                                 |
+| --- | ---------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 7   | Structural validators (74 checks)  | `tests/validate-structure.sh`                                                             | File structure, frontmatter, required sections                                                                                  |
+| 8   | Content validators (132 checks)    | `tests/validate-content.sh`                                                               | Version-4-files consistency, README "What's New" drift, sidebar consistency, anchor integrity                                   |
+| 9   | Auxiliary test scripts (36 checks) | `tests/test-skill-graph.sh`, `tests/test-verbosity-hook.sh`                               | Skill-graph integrity, hook output regression coverage                                                                          |
+| 10  | Read-only review agent             | `agents/8-habit-reviewer.md`                                                              | Audits without mutating files (model: `sonnet`, tools: `Read`/`Glob`/`Grep`)                                                    |
+| 11  | Pre-commit cross-verification      | `skills/cross-verify/SKILL.md`                                                            | 17-question 8-Habit audit before any commit                                                                                     |
+| 12  | Find→Fix→Re-Verify loop            | `skills/review-ai/SKILL.md`                                                               | Forces re-grep after every fix to prevent partial-fix regressions                                                               |
+| 13  | Cross-session lesson persistence   | `~/.claude/lessons/` (written by `/reflect`, retrieved by `/research` and `/build-brief`) | Closes Hashimoto's "AI has no memory across sessions" gap by writing lessons to disk and loading them on the next relevant task |
+
+**EN.** Counted: **242 verifiable assertions** across 4 test scripts, plus the 17-question cross-verification audit. Every one is a structural correction, not a "please remember." The v2.14.1 patch (issue #157) is a textbook example: a user reported the README "What's New" section had drifted; the fix was **harden `validate-content.sh:578`** (a header-anchored grep instead of a badge-URL grep), not just "backfill the README this once." The next time someone forgets, the validator catches it before merge.
+
+**TH.** นับรวม: **242 assertion ที่ verify ได้** ผ่าน 4 test script บวก cross-verification 17 ข้อ. ทุกข้อคือการแก้เชิงโครงสร้าง ไม่ใช่ "โปรดจำไว้". patch v2.14.1 (issue #157) คือตัวอย่างคลาสสิก: user แจ้งว่า README "What's New" drift ไป → fix คือ **harden `validate-content.sh:578`** (grep แบบ anchor ที่ section header แทน grep ที่ badge URL) ไม่ใช่แค่เติม README ให้ครั้งเดียว. ครั้งหน้าถ้าใครลืม validator จะจับได้ก่อน merge
+
+---
+
+## "Where are you working?" — Self-checklist / "ตอนนี้คุณอยู่ชั้นไหน?"
+
+### Layer 1 — Prompt Engineer
+
+**EN.** You are in the Prompt layer if most of these match:
+
+- [ ] You iterate by editing the wording of individual messages
+- [ ] You measure success per-conversation, not across many runs
+- [ ] You don't have a project file that auto-loads context every session
+- [ ] When the agent makes a mistake, your fix is to "remind it next time"
+- [ ] You have no automated check that runs without you asking
+
+**TH.** คุณอยู่ชั้น Prompt ถ้าข้อพวกนี้ตรงเป็นส่วนใหญ่:
+
+- [ ] iterate ด้วยการแก้คำพูดในข้อความเป็นข้อๆ
+- [ ] วัดความสำเร็จเป็นรายบทสนทนา ไม่ใช่ข้าม run
+- [ ] ไม่มีไฟล์ project ที่ auto-load context ทุก session
+- [ ] เวลา agent พลาด คุณแก้ด้วยการ "บอกครั้งหน้าอย่าทำ"
+- [ ] ไม่มี automated check ที่รันโดยไม่ต้องสั่ง
+
+### Layer 2 — Context Engineer
+
+**EN.** You are in the Context layer if most of these match:
+
+- [ ] You maintain a `CLAUDE.md` / `AGENTS.md` / system prompt that loads every session
+- [ ] You curate the files included in the agent's working set
+- [ ] You manage context-window budgets explicitly (token counts, summarization, RAG)
+- [ ] You add to the loaded context when an issue recurs
+- [ ] But: corrections still rely on you remembering to update the docs
+
+**TH.** คุณอยู่ชั้น Context ถ้าข้อพวกนี้ตรงเป็นส่วนใหญ่:
+
+- [ ] ดูแล `CLAUDE.md` / `AGENTS.md` / system prompt ที่ load ทุก session
+- [ ] curate file ที่เข้า working set ของ agent
+- [ ] จัดการ context window budget ชัดเจน (token count, summarization, RAG)
+- [ ] เพิ่มของเข้า context เวลาเจอปัญหาซ้ำ
+- [ ] แต่: การแก้ยังอาศัยคุณจำได้ว่าต้อง update doc
+
+### Layer 3 — Harness Engineer
+
+**EN.** You are in the Harness layer if most of these match:
+
+- [ ] You have automated checks that block bad behavior even when no human is watching (session hooks, pre-commit validators, reviewer agents)
+- [ ] You treat each agent mistake as a system bug — the fix is a new validator / skill / hook, not a "remember to…" note
+- [ ] You version your guides, validators, and decision records (ADRs)
+- [ ] You measure agent quality at the **system level** (validator pass rate, regression count) not per-conversation
+- [ ] You have **cross-session memory** — past lessons retrievable without you re-typing them
+
+**TH.** คุณอยู่ชั้น Harness ถ้าข้อพวกนี้ตรงเป็นส่วนใหญ่:
+
+- [ ] มี automated check ที่บล็อกพฤติกรรมแย่ได้แม้ไม่มีคนดู (session hook, pre-commit validator, reviewer agent)
+- [ ] จัดการความผิดพลาด agent เป็น system bug — แก้คือเพิ่ม validator/skill/hook ใหม่ ไม่ใช่ note "อย่าลืม..."
+- [ ] versioning guide, validator, และ decision record (ADR)
+- [ ] วัด agent quality ระดับ **system** (validator pass rate, regression count) ไม่ใช่รายบทสนทนา
+- [ ] มี **cross-session memory** — บทเรียนเก่าเรียกใช้ได้โดยไม่ต้องพิมพ์ใหม่
+
+**EN.** If most boxes in Layer 3 tick, you are already a Harness Engineer — possibly before you knew the term. The point of naming the role is not gatekeeping; it is giving the practice a name so it can be discussed, taught, and improved.
+
+**TH.** ถ้าติ้กส่วนใหญ่ใน Layer 3 ได้ — คุณเป็น Harness Engineer แล้ว อาจจะก่อนรู้จักคำนี้ด้วยซ้ำ. ประเด็นของการมี "ชื่อ" ไม่ใช่ gatekeep ใคร — มันคือการให้ชื่อบทบาท เพื่อให้ practice ถูก discuss, สอน, และพัฒนาต่อได้
+
+---
+
+## Further reading / อ่านต่อ
+
+- [Architecture](Architecture) — how the plugin is wired internally / โครงสร้างภายใน plugin
+- [Maturity Model](Maturity-Model) — Dependence → Independence → Interdependence → Significance
+- [Vibe Coding vs Structured](Vibe-Coding-vs-Structured) — the failure mode this harness exists to prevent / failure mode ที่ harness นี้ป้องกัน
+- [Habits Reference](Habits-Reference) — the 8 habits that drive every harness component / 8 habit ที่ขับเคลื่อนทุก component
+
+## Sources
+
+1. Hashimoto, M. _My AI Adoption Journey_, 5 February 2026 — <https://mitchellh.com/writing/my-ai-adoption-journey>
+2. Lee, Y., Nair, R., Zhang, Q., Lee, K., Khattab, O., Finn, C. _Meta-Harness: End-to-End Optimization of Model Harnesses_, 2026 — <https://arxiv.org/abs/2603.28052>
+3. Böckeler, B. _Harness engineering for coding agent users_, Thoughtworks, 2 April 2026 — <https://martinfowler.com/articles/harness-engineering.html>

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -26,6 +26,7 @@ _Structured AI development_
 - [Maturity Model](Maturity-Model)
 - [8 Habits](Habits-Reference)
 - [Vibe Coding vs Structured](Vibe-Coding-vs-Structured)
+- [Harness Engineering](Harness-Engineering)
 
 **Reference**
 


### PR DESCRIPTION
## Summary

Position `8-habit-ai-dev` in the **Harness Engineering** frame that became industry vocabulary in 2026 (Hashimoto Feb 2026 → Lee et al. arxiv 2603.28052 → Böckeler martinfowler.com 2 Apr 2026 → AI Engineer World's Fair April 2026 priority #1).

Closes the gap where external readers saw "another workflow plugin" instead of recognizing the plugin as a concrete harness with **242 verifiable assertions** + 17-question cross-verification audit.

## Files

| Path | Lines | What |
|------|-------|------|
| `docs/wiki/Harness-Engineering.md` (new) | 194 | Canonical bilingual TH+EN reference page — origin, lineage, plugin-as-harness mapping (13 components), self-checklist |
| `docs/blog/harness-engineering-where-are-you.md` (new) | 143 | Thai-primary narrative version, paste-ready for Facebook/LinkedIn/Medium, links back to wiki canonical |
| `docs/wiki/_Sidebar.md` (edit) | +1 | Adds `Harness-Engineering` entry under **Concepts** |

## EARS criteria — verification status

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Wiki page exists, bilingual TH+EN parallel, in `_Sidebar.md` | ✅ |
| 2 | Every primary-source claim cites a URL verified by direct `WebFetch` in this PR | ✅ Hashimoto + Lee et al. + Böckeler |
| 3 | Plugin-as-harness mapping ≥ 6 components with `path` evidence | ✅ 13 components (6 feedforward + 7 feedback) |
| 4 | If "3% vs 28-47%" framing is quoted, includes corrective note with Lee et al. real figures | ✅ Both wiki + blog have ⚠️ correction box citing +4.7 to +7.7 pts |
| 5 | `bash tests/validate-structure.sh` exits 0 with no new failures | ✅ Structure 245/0, Content 205/0, 0 fitness breaches |
| 6 | Where blog exported to 3rd-party, closing section links to canonical wiki URL | ✅ Blog "Deep dive" section links to wiki page |

## Test plan

- [ ] Reviewer confirms wiki page renders correctly in GitHub wiki preview after merge
- [ ] Reviewer confirms blog markdown renders correctly when pasted into Facebook/Medium/LinkedIn (target use case)
- [ ] Reviewer spot-checks 2-3 of the 13 mapping `path` references resolve to real files in this repo
- [ ] Reviewer agrees the "3% vs 28-47%" corrective note is fair and accurate (compare against arxiv 2603.28052 directly)
- [ ] Reviewer confirms `_Sidebar.md` ordering under Concepts reads well (Architecture → Maturity → 8 Habits → Vibe Coding → Harness Engineering)
- [ ] After merge: copy `docs/wiki/Harness-Engineering.md` into the actual GitHub wiki (the in-repo `docs/wiki/` is canonical source, but GitHub's wiki UI requires a sync step)

## Cross-verify

Score **14/17** (3 N/A — Q2 edge cases, Q10 error messages, Q12 reproduce bug — all legitimate doc-only exclusions).
Adjusted **100%** with all four Whole Person dimensions balanced (Body/Mind/Heart/Spirit each 100%). Band: **Well-prepared — proceed with confidence.**

## Out of scope (explicitly deferred)

- Editing `Architecture.md` or `Vibe-Coding-vs-Structured.md` to back-reference (separate follow-up if desired)
- Translating other large wiki pages to bilingual
- Auto-publishing the blog to platforms (artifact is the markdown — publishing is a manual choice per platform)
- Modifying skill descriptions, `session-start.sh`, or any runtime hook to reference the harness frame
- Marketing landing page or video

Refs #160