### PR TITLE
chore: v2.14.3 — post-migration cleanups + validator self-discipline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "8-habit-ai-dev",
       "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification",
-      "version": "2.14.2",
+      "version": "2.14.3",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"
@@ -28,12 +28,7 @@
         "covey",
         "8-habits"
       ],
-      "tags": [
-        "workflow",
-        "quality",
-        "planning",
-        "review"
-      ]
+      "tags": ["workflow", "quality", "planning", "review"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8-habit-ai-dev",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Anti-Vibe-Coding plugin — 7-step workflow discipline + 8-Habit cross-verification for AI-assisted development",
   "author": {
     "name": "Pitimon",

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Claude Code local session artifacts (settings, agent worktrees, lessons cache)
+/.claude/
+
+# Sibling plugins / scratch dirs (cross-plugin testing artifacts)
+# Example: piercelamb/deep-project clone — not part of this plugin
+/deep-project/
+
+# macOS
+.DS_Store
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v2.14.3 — Post-Migration Cleanup + Validator Self-Discipline (2026-05-03)
+
+Patch release closing post-v2.14.2 metadata drift surfaced by [#163](https://github.com/pitimon/8-habit-ai-dev/issues/163) and applying the 800-line file-size rule the validator enforces on skills to the validator itself.
+
+### Fixed
+
+- **ADR-012 metadata closure** — `SELF-CHECK.md` lines 103-104 reframed (described deleted files `docs/research/eu-ai-act-obligations.md` + `guides/eu-ai-act-mapping.md` as if still present); `docs/adr/ADR-012-eu-ai-act-migration-completion.md` status header upgraded with `**Implementation**:` field naming commit `ed65b97` (v2.14.2 release) and the metadata-closure date.
+
+### Added
+
+- **`.gitignore`** — created with `/deep-project/` and `/.claude/` entries to gate against accidental `git add .` of third-party plugin clones (e.g. `piercelamb/deep-project` cross-plugin testing checkouts) and Claude Code session artifacts. Working copies preserved locally.
+
+### Changed
+
+- **`tests/validate-content.sh` trim** — 831 → 793 lines via comment consolidation across Check 15 (EU AI Act stub explainer), Check 19 sub-checks B/C/D/E/F/G (drift-guard rationale blocks), F2 validation coverage explainer, and F3 SIGPIPE-fix explainer. Logic untouched; total checks unchanged (10); PASS count preserved (205). Closes the credibility gap where the validator violated the 800-line rule it enforces on skills (Check 5 in `validate-structure.sh`).
+
+Pattern: validator self-discipline — when a fitness function applies to the rest of the codebase, it applies to the validator too. Same shape as v2.14.1's "validator assertion, not checklist" principle.
+
+---
+
 ## v2.14.2 — EU AI Act Migration Completion (2026-05-02)
 
 Completes the migration of the EU AI Act compliance toolkit from this plugin to [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) v3.1.0 per the plugin boundary established in memory observation #233270 (2026-04-07): `8-habit-ai-dev` = workflow discipline; `claude-governance` = compliance enforcement + framework mappings. EU AI Act compliance is a framework mapping, not a workflow step. Original placement here was a boundary error; ADR-005 (the original toolkit ADR) is now marked Superseded by ADR-012 (this migration). See [`pitimon/claude-governance` PR #26](https://github.com/pitimon/claude-governance/pull/26) for the canonical landing.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-17-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.14.2-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.14.2)
+[![Version](https://img.shields.io/badge/Version-2.14.3-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.14.3)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).
@@ -317,7 +317,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ```
 8-habit-ai-dev/
 ├── .claude-plugin/
-│   ├── plugin.json                 # Plugin metadata (v2.14.2)
+│   ├── plugin.json                 # Plugin metadata (v2.14.3)
 │   └── marketplace.json            # Marketplace listing
 ├── skills/                         # 17 skills (8 workflow + 9 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
@@ -392,6 +392,20 @@ Both agents use the `sonnet` model for fast, focused analysis.
 - **Output templates** — structured formats for PRD, ADR, task list, review report, research brief
 - **Dimension mapping** — all 17 cross-verify questions tagged with Body/Mind/Heart/Spirit
 - **Zero dependencies** — pure markdown + bash. No npm, no pip, no runtime requirements
+
+---
+
+## What's New in v2.14.3
+
+**Theme: Post-Migration Cleanup + Validator Self-Discipline** ([#163](https://github.com/pitimon/8-habit-ai-dev/issues/163))
+
+Patch release closing post-v2.14.2 metadata drift and applying the 800-line file-size rule the validator enforces on skills to the validator itself.
+
+- **ADR-012 metadata closure** — `SELF-CHECK.md` lines 103-104 reframed (described deleted files as if still present); ADR-012 status header upgraded with `Implementation:` field naming commit `ed65b97` (v2.14.2) and metadata-closure date.
+- **`.gitignore` hardening** — created with `/deep-project/` and `/.claude/` entries to gate against accidental `git add .` of third-party plugin clones and Claude Code session artifacts. Working copies preserved locally.
+- **`tests/validate-content.sh` trim** — 831 → 793 lines via comment consolidation across Check 15, Check 19 sub-checks B/C/D/E/F/G, and F2/F3 sections. Logic untouched, total checks unchanged (10), PASS count preserved (205). Closes the credibility gap where the validator violated the 800-line rule it enforces.
+
+Pattern: validator self-discipline — when a fitness function applies to the rest of the codebase, it applies to the validator too. Same shape as v2.14.1's "validator assertion, not checklist" principle.
 
 ---
 
@@ -657,4 +671,4 @@ MIT
 
 ---
 
-_Version: 2.14.2 | Last updated: 2026-05-02_
+_Version: 2.14.3 | Last updated: 2026-05-03_

--- a/SELF-CHECK.md
+++ b/SELF-CHECK.md
@@ -1,6 +1,6 @@
 # Self-Check: 8-Habit Cross-Verification on This Plugin
 
-**Version**: 2.14.2 | **Date**: 2026-05-02 | **Previous**: 2.14.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)
+**Version**: 2.14.3 | **Date**: 2026-05-03 | **Previous**: 2.14.2 (post-EU AI Act migration)
 
 Running our own 17-question checklist against the plugin itself. H8 Modeling: "Follow the process always, no shortcuts when unwatched."
 
@@ -100,8 +100,8 @@ v2.4.0 improvements (/using-8-habits meta-skill):
 v2.3.0 improvements (EU AI Act Compliance Toolkit — Flagship feature):
 
 - **`/eu-ai-act-check`** — 9-obligation tiered checklist for EU high-risk AI systems (Articles 9-15). Pre-flight scope check skips if not high-risk or not EU-targeted.
-- **`docs/research/eu-ai-act-obligations.md`** — verified-quote research brief.
-- **`guides/eu-ai-act-mapping.md`** — MUST/SHOULD/COULD tier mapping.
+- **`docs/research/eu-ai-act-obligations.md`** — verified-quote research brief. _(Migrated to `claude-governance` v3.1.0+ in v2.14.2 per ADR-012; deleted from this plugin in commit `ed65b97`.)_
+- **`guides/eu-ai-act-mapping.md`** — MUST/SHOULD/COULD tier mapping. _(Migrated; same reference.)_
 - **`scripts/generate-ai-dev-log.sh`** — Article 11 transparency (AI-assisted dev log from git history).
 - **ADR-005**: EU AI Act compliance toolkit scope + plugin-boundary decision (eventually migrating to `claude-governance`).
 - Spirit dimension strengthened: compliance depth without enforcement theater.
@@ -171,7 +171,8 @@ The cross-verify score (16/16) measures **plan discipline**. The Whole Person sc
 - v2.14.0: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (TOH Framework Inspirations — milestone #15: #151 SKILL_OUTPUT attribution lines + Check 22, #149 argument-driven smart-routing in /using-8-habits, #150 Verification Phase in /review-ai with explicit "guidance only, NOT a hook" boundary qualifier — three workflow-discipline imports from external framework, all stayed within plugin boundary)
 - v2.14.1: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#157 README "What's New" Drift Guard — external QA found Check 19A passes on badge URL not section header, README "What's New" missing v2.14.0 entry, TOC anchor broken since v2.3.0, architecture tree under-enumerated 4 skills; same bug class as #124/#141 recurring on sibling surface; fix is doc backfill + Check 19 sub-check G anchored grep + Check 20 hardening pinning Find→Fix→Re-Verify loop name and step count — capability-level pattern closed with fitness function not checklist)
 - v2.14.2: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (EU AI Act Migration Completion — second half of cross-plugin migration coordinated with `pitimon/claude-governance` v3.1.0; deleted reference.md + research + mapping guide; rewrote SKILL.md as redirect stub preserving NOT LEGAL ADVICE disclaimer + ADR-012 reference; ADR-005 marked Superseded; Check 15 in validate-content.sh rewritten as stub-mode + negative-restore assertions; cross-refs reframed in RESOLVER, using-8-habits, design Step 5, ai-dev-log, session-start, README skill table; wiki + README badge deferred to follow-up doc-only PR per `pitimon/claude-governance` PR #25 + #26 formatter precedent — boundary correction completes the contract from memory observation #233270, plugin boundary integrity restored)
+- v2.14.3: Body 5, Mind 5, Heart 5, Spirit 5 = **5.0** (#163 Post-Migration Cleanup + Validator Self-Discipline — ADR-012 metadata closure (SELF-CHECK lines 103-104 reframed + `**Implementation**:` field added to ADR-012 header naming commit ed65b97), `.gitignore` created with `/deep-project/` + `/.claude/` entries, `tests/validate-content.sh` trimmed 831 → 793 lines via comment consolidation across Check 15 + Check 19 sub-checks B/C/D/E/F/G + F2 + F3 — logic untouched, 10 checks preserved, PASS count 205 stable; closes credibility gap where validator violated 800-line rule it enforces on skills via Check 5 in validate-structure.sh)
 
 ---
 
-_Updated with each release. Previous: 2.14.1 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_
+_Updated with each release. Previous: 2.14.2 (Body 5, Mind 5, Heart 5, Spirit 5 = 5.0)_

--- a/docs/adr/ADR-012-eu-ai-act-migration-completion.md
+++ b/docs/adr/ADR-012-eu-ai-act-migration-completion.md
@@ -1,6 +1,7 @@
 # ADR-012: EU AI Act Compliance Toolkit Migration Completion
 
 **Status**: Accepted
+**Implementation**: 2026-05-02 in commit `ed65b97` (v2.14.2 release); metadata closure 2026-05-03 in v2.14.3
 **Date**: 2026-05-02
 **Decision makers**: Pitimon (human) + Claude Opus 4.7 (AI, 1M context)
 **Supersedes**: ADR-005 (EU AI Act Compliance Toolkit, v2.3.0 Flagship)

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,10 +1,20 @@
-![Version](https://img.shields.io/badge/latest-v2.14.2-blue)
+![Version](https://img.shields.io/badge/latest-v2.14.3-blue)
 
 # Changelog
 
 Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
 
 > Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+
+## v2.14.3 — Post-Migration Cleanup + Validator Self-Discipline (May 2026)
+
+Patch release closing [#163](https://github.com/pitimon/8-habit-ai-dev/issues/163) — three small cleanups left in v2.14.2's wake plus applying the validator's own 800-line rule to itself.
+
+- **ADR-012 metadata closure** — `SELF-CHECK.md` reframed two lines describing the deleted EU AI Act research + mapping files as if they still existed; `docs/adr/ADR-012-eu-ai-act-migration-completion.md` status header upgraded with `**Implementation**:` field naming commit `ed65b97` (v2.14.2 release) and the metadata-closure date
+- **`.gitignore`** — created with `/deep-project/` and `/.claude/` entries to gate against accidental `git add .` of cross-plugin checkouts and Claude Code session artifacts
+- **`tests/validate-content.sh` trim** — 831 → 793 lines via comment consolidation across Check 15 (EU AI Act stub explainer), Check 19 sub-check rationales, F2 + F3 explainers; logic untouched, 10 checks preserved, PASS count = 205
+
+Pattern: validator self-discipline — when a fitness function applies to the rest of the codebase, it applies to the validator too.
 
 ## v2.14.2 — EU AI Act Migration Completion (May 2026)
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -186,18 +186,9 @@ echo ""
 
 # --- Check 15: v2.14.2 EU AI Act stub (post-migration to claude-governance v3.1.0) ---
 echo "--- Check 15: v2.14.2 EU AI Act stub (post-migration) ---"
-
-# Per ADR-012 (2026-05-02), the EU AI Act compliance toolkit migrated to
-# pitimon/claude-governance v3.1.0. This plugin retains a single redirect
-# stub at skills/eu-ai-act-check/SKILL.md. The deleted files (research,
-# guide, reference) now live in the governance plugin; their content
-# assertions moved there too (governance-side validate-plugin.sh section 6).
-#
-# The stub-mode checks below verify:
-#   - the redirect stub exists
-#   - it points users to the canonical location
-#   - it preserves the NOT LEGAL ADVICE disclaimer (regulatory communication)
-#   - the deleted files are NOT present (catches accidental restore)
+# Per ADR-012 (2026-05-02): EU AI Act toolkit migrated to claude-governance v3.1.0.
+# This plugin retains a redirect stub; deleted files live in governance-side validate-plugin.sh §6.
+# Verifies: stub exists, redirects, preserves NOT LEGAL ADVICE, deleted files absent (catches restore).
 
 EU_STUB="skills/eu-ai-act-check/SKILL.md"
 if [ -f "$EU_STUB" ]; then
@@ -543,12 +534,9 @@ fi
 echo ""
 
 # --- Check 19: Docs freshness vs plugin.json version ---
-# Enforces downstream propagation from plugin.json across all changelog surfaces.
-# Prevents the "stuck at v2.N-5" drift scenario (see issue #106, fix in PR #107).
-# Tightened 2026-04-17 per issue #124 F1+F2 after v2.9.0 + v2.11.0 recurrence:
-# pointer-to-CHANGELOG.md fallback removed (the wiki was passing just by containing
-# the string "CHANGELOG.md" even when the actual entry was missing).
-# See CONTRIBUTING.md § Testing Conventions for rationale.
+# Enforces version propagation across changelog surfaces. Issue #106/#107 (stuck-at-v2.N-5 drift);
+# tightened 2026-04-17 per #124 F1+F2 after v2.9.0+v2.11.0 (pointer-to-CHANGELOG.md fallback removed —
+# wiki was passing on literal string "CHANGELOG.md" even when entry missing). See CONTRIBUTING.md § Testing Conventions.
 echo "--- Check 19: Docs freshness vs plugin.json version ---"
 
 # Extract current version from plugin.json — no pipe, SIGPIPE-safe (see CONTRIBUTING.md)
@@ -564,49 +552,39 @@ else
     fail "README.md does not mention v${current_version} — CHANGELOG.md likely updated but downstream propagation was skipped. See CONTRIBUTING.md § Testing Conventions."
   fi
 
-  # B. CHANGELOG.md must contain a version section header (^## v<version>)
-  # Added 2026-04-17: v2.9.0 (issue #124 F1) and v2.11.0 both shipped without this
-  # entry because nothing asserted it. Root CHANGELOG is authoritative per ADR-004.
+  # B. CHANGELOG.md must have version header ^## v<version> (added 2026-04-17 per #124 F1
+  # after v2.9.0 + v2.11.0 missed entries). Root CHANGELOG is authoritative per ADR-004.
   if grep -q "^## v${current_version}" CHANGELOG.md; then
     pass "CHANGELOG.md contains v${current_version} entry"
   else
     fail "CHANGELOG.md missing '## v${current_version}' section header — backfill before release. See issue #124 F1."
   fi
 
-  # C. docs/wiki/Changelog.md must contain a version section header — pointer-to-CHANGELOG.md
-  # is no longer sufficient (the pointer existed in both v2.9.0 and v2.11.0 misses,
-  # and the old assertion passed purely on the literal string "CHANGELOG.md").
+  # C. docs/wiki/Changelog.md must have ^## v<version>. Pointer-only assertion broke in v2.9.0/v2.11.0
+  # (passed on literal "CHANGELOG.md" string even when entry missing); requires actual entry now.
   if grep -q "^## v${current_version}" docs/wiki/Changelog.md; then
     pass "docs/wiki/Changelog.md contains v${current_version} entry"
   else
     fail "docs/wiki/Changelog.md missing '## v${current_version}' section — pointer-to-CHANGELOG.md no longer sufficient. See issue #124 F2."
   fi
 
-  # D. docs/wiki/Changelog.md badge must match the current version
-  # Added 2026-04-17: v2.11.0 shipped with a stale latest-v2.10.0 badge.
+  # D. docs/wiki/Changelog.md badge must match current version (added 2026-04-17 after v2.11.0 stale-badge ship).
   if grep -q "badge/latest-v${current_version}-blue" docs/wiki/Changelog.md; then
     pass "docs/wiki/Changelog.md badge matches v${current_version}"
   else
     fail "docs/wiki/Changelog.md badge stale — bump 'latest-v…' to v${current_version}."
   fi
 
-  # E + F. SELF-CHECK.md body freshness vs git tag history
-  # Added 2026-04-25 per issue #141: header was v2.13.0 but footer said Previous: 2.7.1
-  # and per-release score list ended at v2.8.0 — 6 releases shipped silently.
-  # Source of truth: git tag -l "v2.*" (v2.x release line; v2.0.0 onwards per #141 decision).
-  # Older v1.x tags predate the SELF-CHECK.md per-release list convention and are
-  # documented elsewhere (see CHANGELOG.md note "For v2.2.0 and earlier, see docs/wiki/Changelog.md").
-  # Dev-env resilience: if no tags available (shallow clone without fetch-tags),
-  # emit WARN and skip — CI has tags (.github/workflows/validate.yml sets fetch-tags: true)
-  # so drift is still caught at merge time.
+  # E + F. SELF-CHECK.md body freshness vs git tag history (added 2026-04-25 per #141
+  # — v2.13.0 footer said Previous: 2.7.1 + per-release list ended at v2.8.0 = 6 silent ships).
+  # Source of truth: git tag -l "v2.*" (v1.x predates per-release convention; see CHANGELOG.md note).
+  # Dev-env: no tags → WARN+skip (CI sets fetch-tags: true so drift still caught at merge).
   all_tags=$(git tag -l "v2.*" 2>/dev/null | sort -V)
   if [ -z "$all_tags" ]; then
     warn "git tag history unavailable — skipping SELF-CHECK.md body freshness (sub-checks E + F). CI sets fetch-tags: true."
   else
-    # E. Footer Previous: version must match the tag preceding current_version.
-    # Two shapes are valid:
-    #   1. Post-release (current_version is tagged): previous = tag before current in sorted list
-    #   2. Pre-release (plugin.json bumped but tag not yet pushed): previous = last tag in sorted list
+    # E. Footer Previous: must match tag before current_version. Two shapes:
+    #   post-release (current tagged) → prior tag in sorted list; pre-release (bumped, not pushed) → last tag.
     if echo "$all_tags" | grep -qx "v${current_version}"; then
       prev_version=$(echo "$all_tags" | awk -v cur="v${current_version}" '
         $0 == cur { print prev; exit }
@@ -624,8 +602,7 @@ else
       fail "SELF-CHECK.md footer stale — expected 'Previous: ${prev_version}' (derived from git tags); update the last line of the file."
     fi
 
-    # F. Per-release score list must have one row per tagged version — no gaps.
-    # Plus: row for current_version must exist even if tag not yet pushed (release-in-progress).
+    # F. Per-release score list: one row per tagged version (no gaps) + row for current_version (release-in-progress safe).
     missing=()
     while IFS= read -r tag; do
       ver="${tag#v}"
@@ -645,12 +622,9 @@ else
     fi
   fi
 
-  # G. README.md "What's New in v<current_version>" section header anchored.
-  # Added 2026-05-02 per issue #157: sub-check A (line 578) only checks bare
-  # version mention, which the badge URL "releases/tag/v<x.y.z>" satisfies even
-  # when the section header is missing. Same bug class as #124 pointer-fallback
-  # loophole — tighter assertion required so README "What's New" cannot drift
-  # like SELF-CHECK.md did before sub-checks E + F (#141/#144).
+  # G. README.md "## What's New in v<current_version>" section header (added 2026-05-02 per #157).
+  # Sub-check A passes on badge URL alone (releases/tag/v<x.y.z>) — same bug class as #124 pointer-fallback.
+  # Tighter assertion prevents README "What's New" drift like SELF-CHECK.md did before #141/#144.
   if grep -q "^## What's New in v${current_version}" README.md; then
     pass "README.md contains '## What's New in v${current_version}' section header"
   else
@@ -660,10 +634,7 @@ fi
 
 echo ""
 
-# ===================================================================
-# Architecture Fitness Functions
-# These track health metrics over time. A BREACH fails the build.
-# ===================================================================
+# --- Architecture Fitness Functions: track health metrics; BREACH fails the build ---
 echo "=== Architecture Fitness Functions ==="
 echo ""
 FITNESS_BREACH=0
@@ -705,8 +676,7 @@ echo ""
 echo "--- F2: Validation Coverage Ratio ---"
 # Count assertable items: skills × 8 checkable properties + agents × 4 + ADRs × 6 + cross-refs
 ASSERTABLE=0
-# Skills: frontmatter(3) + sections(2) + chain(2) + content-depth(2) + handoff(2) = 11 per workflow skill
-# Skills: frontmatter(3) + sections(2) + chain(2) + content-depth(2) = 9 per standalone skill
+# Per-skill checkable items: workflow skills = 11 (frontmatter 3 + sections 2 + chain 2 + content-depth 2 + handoff 2); standalone = 9 (no handoff).
 for skill_dir in skills/*/; do
   [ ! -d "$skill_dir" ] && continue
   sname=$(basename "$skill_dir")
@@ -727,10 +697,7 @@ ASSERTABLE=$((ASSERTABLE + ADR_COUNT * 6))
 # Cross-references: version(3) + readme-skills(1) + load-directives(1) + self-check(1) + size(1)
 ASSERTABLE=$((ASSERTABLE + 7))
 
-# Total assertions = structure script PASS + content script PASS
-# We only know our own PASS count here; structure script runs separately
-# Use combined count from both scripts
-# Read structure script pass count (written by validate-structure.sh)
+# Total assertions = structure PASS (read from /tmp/validate-structure-pass.txt) + this script's PASS.
 STRUCT_ASSERTIONS=157  # fallback if structure script hasn't run
 if [ -f /tmp/validate-structure-pass.txt ]; then
   STRUCT_ASSERTIONS=$(cat /tmp/validate-structure-pass.txt | tr -d ' ')
@@ -765,14 +732,9 @@ for skill_dir in skills/*/; do
   TOTAL_SKILLS=$((TOTAL_SKILLS + 1))
   skill_ok=1
 
-  # Check: frontmatter exists with 3 required fields
-  # Use awk (not sed|head) to avoid SIGPIPE under set -o pipefail when
-  # head closes stdout early — same fix pattern as validate-structure.sh:27.
-  # Triggered by skills/ai-dev-log/SKILL.md body `---` horizontal rule at
-  # line 65 which makes `sed -n '/^---$/,/^---$/p'` emit 187 lines (12
-  # frontmatter + 175 body-past-rule), overflowing head -20 and causing
-  # GNU sed exit 4 "couldn't flush stdout: Broken pipe" on Linux CI while
-  # BSD sed on macOS silently ignores SIGPIPE → intermittent CI failure.
+  # Check: frontmatter exists with 3 required fields. Uses awk (not sed|head) for SIGPIPE safety
+  # under set -o pipefail. Triggered by ai-dev-log/SKILL.md `---` rule at line 65 → sed emits 187 lines,
+  # overflows head -20, GNU sed exit 4 on Linux (BSD sed silent). See validate-structure.sh:27.
   fm=$(awk '/^---$/{c++; print; if(c==2) exit; next} c==1' "$skill_file")
   for field in "name:" "description:" "user-invocable:"; do
     echo "$fm" | grep -q "$field" || skill_ok=0


### PR DESCRIPTION
Closes #163

## Summary

Three small post-v2.14.2 cleanups + applying the 800-line file-size rule the validator enforces on skills to the validator itself. All in one bundled patch PR (precedent: v2.14.1).

- **ADR-012 metadata closure** — `SELF-CHECK.md` lines 103-104 reframed (described deleted EU AI Act files as if still present); ADR-012 status header upgraded with `**Implementation**:` field naming commit `ed65b97` (v2.14.2 release) and the metadata-closure date
- **`.gitignore`** — created with `/deep-project/` and `/.claude/` entries to gate against accidental `git add .` of cross-plugin checkouts (e.g. `piercelamb/deep-project`) and Claude Code session artifacts; working copies preserved locally
- **`tests/validate-content.sh` trim** — 831 → 793 lines via comment consolidation across Check 15, Check 19 sub-checks B/C/D/E/F/G, and F2/F3 sections; logic untouched, 10 checks preserved, PASS count = 205

## Test plan

- [x] `bash tests/validate-structure.sh` — 245 PASS / 0 FAIL
- [x] `bash tests/validate-content.sh` — 205 PASS / 0 FAIL / 1 WARN (long-standing research DoD warn, unchanged)
- [x] `bash tests/test-skill-graph.sh` — 57 PASS / 0 FAIL
- [x] `bash tests/test-verbosity-hook.sh` — 19 PASS / 0 FAIL
- [x] `wc -l tests/validate-content.sh` — 793 (under 800-line rule)
- [x] 4-file version sync to 2.14.3: plugin.json, marketplace.json, README (badge + footer), SELF-CHECK header
- [x] CHANGELOG.md + docs/wiki/Changelog.md + SELF-CHECK.md per-release rows added (Check 19 B/C/D/F enforces)
- [x] `git status --short | grep deep-project` — empty (gated by .gitignore)
- [x] `grep -rn "eu-ai-act-mapping |eu-ai-act-obligations|skills/eu-ai-act-check/reference"` — only legitimate hits remain (annotated migration notes, historical "What's New", canonical claude-governance pointer)
- [ ] `/cross-verify` 17-question checklist — to run on this PR before merge

## Process

- Issue first (#163) with full rationale + DoD
- Branch `chore/163-v2.14.3-cleanup` from `main`
- Two review rounds during planning: 8-habit-reviewer caught a phantom "delete 3 files" Item 1 (files were already deleted in `ed65b97`); reframed to metadata closure. Advisor cross-confirmed and surfaced trim-vs-split sub-decision for Item 3 (user picked trim)
- Single bundled PR per v2.14.1 precedent (Option A in Issue #163)
- Lesson captured: assertions about file presence/absence in plans must `ls` or `git log --diff-filter=D` before writing — Explore agents are unreliable for dynamic state. Saved as feedback memory.

## Refs

- ADR-012: `docs/adr/ADR-012-eu-ai-act-migration-completion.md` (status now Accepted + Implementation: 2026-05-02)
- Migration commit: `ed65b97` (v2.14.2 release)
- Plan: `~/.claude/plans/8-habit-ai-dev-refraction-virtual-coral.md`