### PR TITLE
docs(consistency-check): Known Limitation for backtick-quoted tokens (#167)

### DIFF
--- a/skills/consistency-check/reference.md
+++ b/skills/consistency-check/reference.md
@@ -140,6 +140,7 @@ source-skill-version: <plugin version, e.g. 2.15.0>
 - Single-feature analysis only — no cross-feature comparison (out of scope per PRD)
 - No auto-fix or remediation suggestions beyond the `suggested action` column (read-only by design)
 - Numbered variants (`prd.v2.md`, etc.) — analyzer reads the latest version of each, but does not compare across versions
+- Ambiguity pass cannot distinguish backtick-quoted documentation references from unresolved markers. If you need to mention a token like `[NEEDS CLARIFICATION]` or `TBD` in artifact prose without it firing a finding, write it in plain text (e.g., "the NEEDS-CLARIFICATION marker") rather than inside a code span. The analyzer's own dogfood spec hits this false-positive at `docs/specs/consistency-check/prd.md:45` — tracked in [#167](https://github.com/pitimon/8-habit-ai-dev/issues/167).
 
 ## See Also
 


### PR DESCRIPTION
## Summary

1-line addition to `skills/consistency-check/reference.md` under the existing `## Limitations (v1)` section. Documents the analyzer's inability to distinguish backtick-quoted documentation references from unresolved markers, and provides the plain-text workaround.

## Why this lands now (vs. waiting for v2.15.1)

Per advisor reframe on [#167](https://github.com/pitimon/8-habit-ai-dev/issues/167#issuecomment-4366084630): the analyzer behavior change is too risky to ship without real-user evidence (Option A would silently under-detect legitimate backticked unresolved tokens). Honest documentation is the responsible workaround until usage signal arrives.

This is a doc-only change — zero behavior change, zero contract risk, zero validator impact.

## Test plan

- [x] `bash tests/validate-structure.sh` — passes (no structural change)
- [x] `bash tests/validate-content.sh` — passes (TODO/XXX whitelist for `skills/consistency-check/` already in place from v2.15.0)
- [x] Manual visual check — bullet appears under existing `## Limitations (v1)` section in `reference.md`
- [ ] Re-running `/consistency-check consistency-check` against the dogfood will still flag the prd.md:45 false-positive (expected — this PR doesn't fix it, only documents the workaround)

Refs #167