### PR TITLE
chore(consistency-check): canonical ID format in dogfood spec (#167 Finding 2)

### DIFF
--- a/docs/specs/consistency-check/design.md
+++ b/docs/specs/consistency-check/design.md
@@ -45,7 +45,7 @@ Read-only data flow. No mutation of source artifacts. Backwards compatible — w
 
 > **STICKY** decisions are load-bearing. Changing them mid-implementation requires re-running `/design`, not patching mid-build. Decisions marked here cannot be reversed without ADR amendment.
 
-### Decision 1: Persistence trigger mechanism — STICKY
+### Decision-1: Persistence trigger mechanism — STICKY
 
 | Option                                                                | Description                                                   | Pro                                             | Con                                                                        |
 | --------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
@@ -54,11 +54,11 @@ Read-only data flow. No mutation of source artifacts. Backwards compatible — w
 | **C: Auto-detect from cwd**                                           | If invoked while cwd is `docs/specs/<slug>/`, persist there   | Zero-config; "magic" UX                         | Implicit; surprising; hard to debug; tied to shell state                   |
 | **D: Frontmatter directive** in conversation                          | User writes `persist: <slug>` line; skill detects             | No arg parsing; conversational                  | Confusing for users; brittle parsing; not discoverable                     |
 
-**Recommendation: B (`--persist <slug>` flag)** — preserves all 15 PRD EARS criteria including the back-compat invariant (PRD-EARS-2). Skills already document `argument-hint` patterns; flag fits naturally.
+**Recommendation: B (`--persist <slug>` flag)** — preserves all 15 PRD EARS criteria including the back-compat invariant (FR-002). Skills already document `argument-hint` patterns; flag fits naturally.
 
 **Rework cost if changed**: ~70% — every skill modification, every doc reference, every test would change. Definite sticky.
 
-### Decision 2: File naming convention — STICKY
+### Decision-2: File naming convention — STICKY
 
 | Option                                                                     | Description                                   | Pro                                                                   | Con                                                                                               |
 | -------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
@@ -71,7 +71,7 @@ Read-only data flow. No mutation of source artifacts. Backwards compatible — w
 
 **Rework cost if changed**: ~50% — file references, validators, examples. Sticky.
 
-### Decision 5: `/consistency-check` input format — STICKY
+### Decision-5: `/consistency-check` input format — STICKY
 
 | Option                                              | Description                                                            | Pro                                    | Con                                     |
 | --------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------- | --------------------------------------- |
@@ -83,7 +83,7 @@ Read-only data flow. No mutation of source artifacts. Backwards compatible — w
 
 **Rework cost if changed**: ~30% — input parsing only. Borderline sticky → marked sticky for safety.
 
-### Decision 6: Severity assignment per pass — STICKY
+### Decision-6: Severity assignment per pass — STICKY
 
 | Option                                                                                                     | Description                                 | Pro                                               | Con                                                                 |
 | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------- |
@@ -103,7 +103,7 @@ Mapping:
 
 **Rework cost if changed**: ~20% — severity table + tests. Sticky for predictability, not for technical reasons.
 
-### Decision 7: Self-application as smoke test — STICKY
+### Decision-7: Self-application as smoke test — STICKY
 
 | Option                                            | Description                                                                                             | Pro                                | Con                                                                                   |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
@@ -119,15 +119,15 @@ Mapping:
 
 ## Semi-Sticky Decisions (decided here, no user re-confirmation needed)
 
-### Decision 3: SKILL_OUTPUT block placement when persisting
+### Decision-3: SKILL_OUTPUT block placement when persisting
 
 **Decision: Both file AND conversation** (Option B). Preserves `/cross-verify` auto-detect (which reads `SKILL_OUTPUT:requirements` from the PRD), and keeps the conversation-only path identical. Persisted file ends with the same block.
 
-### Decision 4: Conflict policy when target file exists
+### Decision-4: Conflict policy when target file exists
 
-**Decision: Prompt user via AskUserQuestion** (Option A). Three choices: overwrite, write to numbered variant (`prd.v2.md`), or abort. Matches PRD-EARS-3.
+**Decision: Prompt user via AskUserQuestion** (Option A). Three choices: overwrite, write to numbered variant (`prd.v2.md`), or abort. Matches FR-003.
 
-### Decision 8: Reference template format
+### Decision-8: Reference template format
 
 **Decision: Inline in `skills/consistency-check/reference.md`** (Option A) — follows the v2.13+ skill split convention (ADR-009). SKILL.md has summary; reference.md has full output template + examples.
 
@@ -141,25 +141,25 @@ Mapping:
 
 ## Constraints (from PRD-derived)
 
-- **Backward compatibility invariant** (PRD-EARS-2): All existing skills must behave identically to v2.14.3 when `--persist` is not used. Tests for current behavior must pass unchanged.
-- **Read-only analyzer invariant** (PRD-EARS-9): `/consistency-check` `allowed-tools` is `Read, Glob, Grep` only. No Write, no Bash, no Edit. Validator-enforced.
+- **Backward compatibility invariant** (FR-002): All existing skills must behave identically to v2.14.3 when `--persist` is not used. Tests for current behavior must pass unchanged.
+- **Read-only analyzer invariant** (FR-009): `/consistency-check` `allowed-tools` is `Read, Glob, Grep` only. No Write, no Bash, no Edit. Validator-enforced.
 - **Skill ≤800 lines** (existing fitness function): SKILL.md and reference.md each must stay under 800 lines.
 - **Hybrid pass evaluation** (Decision 9 — see below): Each pass uses deterministic structural matching when artifacts contain explicit cross-reference IDs (`FR-NNN`, `Decision-N`, `Task #N`). When IDs are absent, passes that require cross-artifact matching (Coverage, Inconsistency) fall back to LLM semantic comparison and emit an explicit "ID linkage absent — using fuzzy match, results approximate" warning at the top of the report. Drift is always semantic. Ambiguity and Underspec are always deterministic.
 - **Plugin boundary** (per CLAUDE.md): no enforcement, no gating. Findings are advisory only.
 
 ---
 
-## Decision 9 (added post-advisor review): Pass evaluation strategy — STICKY
+## Decision-9 (added post-advisor review): Pass evaluation strategy — STICKY
 
 Resolved an internal contradiction caught by advisor — the original "deterministic only except Drift" claim was inconsistent with how Coverage and Inconsistency actually work without explicit IDs in artifacts.
 
-| Option                 | Approach                                                                                                                        | Pro                                                                                                       | Con                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| A: **Hybrid (CHOSEN)** | IDs recommended in templates. If present → deterministic Coverage+Inconsistency. If absent → LLM semantic with explicit warning | Best of both; preserves PRD-EARS-2 back-compat for existing PRDs without IDs; gives users an upgrade path | More complex skill; two code paths per pass                           |
-| B: ID required         | Bake `FR-NNN` / `Decision-N` / `Task #N` into PRD/design/tasks templates as mandatory                                           | Fully deterministic all 5 passes                                                                          | Workflow change to upstream skills; rejects existing PRDs without IDs |
-| C: LLM semantic only   | Relax "deterministic only" claim; accept that 3 of 5 passes are fuzzy                                                           | No template change; ships fastest                                                                         | Non-deterministic; harder to test recall; fuzzy by design             |
+| Option                 | Approach                                                                                                                        | Pro                                                                                                   | Con                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| A: **Hybrid (CHOSEN)** | IDs recommended in templates. If present → deterministic Coverage+Inconsistency. If absent → LLM semantic with explicit warning | Best of both; preserves FR-002 back-compat for existing PRDs without IDs; gives users an upgrade path | More complex skill; two code paths per pass                           |
+| B: ID required         | Bake `FR-NNN` / `Decision-N` / `Task #N` into PRD/design/tasks templates as mandatory                                           | Fully deterministic all 5 passes                                                                      | Workflow change to upstream skills; rejects existing PRDs without IDs |
+| C: LLM semantic only   | Relax "deterministic only" claim; accept that 3 of 5 passes are fuzzy                                                           | No template change; ships fastest                                                                     | Non-deterministic; harder to test recall; fuzzy by design             |
 
-**Decision: A (Hybrid)** — confirmed by user 2026-05-03 after advisor surfaced the contradiction. Rationale: preserves PRD-EARS-2 back-compat invariant, doesn't force template rigidity, and gives users an upgrade path. Templates ship with optional ID guidance; users who add IDs get rigor; users who don't get approximate findings with explicit warning.
+**Decision: A (Hybrid)** — confirmed by user 2026-05-03 after advisor surfaced the contradiction. Rationale: preserves FR-002 back-compat invariant, doesn't force template rigidity, and gives users an upgrade path. Templates ship with optional ID guidance; users who add IDs get rigor; users who don't get approximate findings with explicit warning.
 
 **Rework cost if changed**: ~40% — pass implementations + template guidance + tests. Sticky.
 
@@ -196,25 +196,25 @@ Resolved an internal contradiction caught by advisor — the original "determini
 <!-- SKILL_OUTPUT:design
 decision_count: 9
 decisions:
-  - "D1: Persistence trigger = --persist <slug> flag (Option B) — flag precedent verified in /ai-dev-log + /calibrate"
-  - "D2: File naming = prd.md / design.md / tasks.md (spec-kit aligned, Option A)"
-  - "D3: SKILL_OUTPUT placement = both file AND conversation (Option B)"
-  - "D4: Conflict policy = AskUserQuestion prompt (Option A); v1 limitation: requires interactive context, falls back to numbered variant otherwise (PRD-EARS-20)"
-  - "D5: /consistency-check input = slug OR path auto-detect (Option C)"
-  - "D6: Severity = fixed per pass with single-step upgrade (Option A+)"
-  - "D7: Self-application = validator only in v1 (Option B); manual smoke documented in CONTRIBUTING.md"
-  - "D8: Reference template = reference.md per skill split (Option A, ADR-009)"
-  - "D9: Pass evaluation = HYBRID (Option A) — deterministic when ID markers present, LLM semantic + warning when absent"
+  - "Decision-1: Persistence trigger = --persist <slug> flag (Option B) — flag precedent verified in /ai-dev-log + /calibrate"
+  - "Decision-2: File naming = prd.md / design.md / tasks.md (spec-kit aligned, Option A)"
+  - "Decision-3: SKILL_OUTPUT placement = both file AND conversation (Option B)"
+  - "Decision-4: Conflict policy = AskUserQuestion prompt (Option A); v1 limitation: requires interactive context, falls back to numbered variant otherwise (FR-020)"
+  - "Decision-5: /consistency-check input = slug OR path auto-detect (Option C)"
+  - "Decision-6: Severity = fixed per pass with single-step upgrade (Option A+)"
+  - "Decision-7: Self-application = validator only in v1 (Option B); manual smoke documented in CONTRIBUTING.md"
+  - "Decision-8: Reference template = reference.md per skill split (Option A, ADR-009)"
+  - "Decision-9: Pass evaluation = HYBRID (Option A) — deterministic when ID markers present, LLM semantic + warning when absent"
 sticky_decisions:
-  - "D1 (trigger mechanism) — ~70% rework cost"
-  - "D2 (file naming) — ~50% rework cost"
-  - "D5 (input format) — ~30% rework cost"
-  - "D6 (severity per pass) — predictability sticky"
-  - "D7 (self-application test strategy) — borderline sticky"
-  - "D9 (pass evaluation hybrid) — ~40% rework cost"
+  - "Decision-1 (trigger mechanism) — ~70% rework cost"
+  - "Decision-2 (file naming) — ~50% rework cost"
+  - "Decision-5 (input format) — ~30% rework cost"
+  - "Decision-6 (severity per pass) — predictability sticky"
+  - "Decision-7 (self-application test strategy) — borderline sticky"
+  - "Decision-9 (pass evaluation hybrid) — ~40% rework cost"
 constraints:
-  - "Back-compat invariant (PRD-EARS-2): unchanged behavior without --persist"
-  - "Read-only analyzer (PRD-EARS-9): allowed-tools = Read, Glob, Grep only"
+  - "Back-compat invariant (FR-002): unchanged behavior without --persist"
+  - "Read-only analyzer (FR-009): allowed-tools = Read, Glob, Grep only"
   - "Skill ≤800 lines (existing fitness function)"
   - "Hybrid pass evaluation (D9): deterministic when ID markers present, LLM semantic + explicit warning when absent"
   - "Plugin boundary: advisory only, no gating"

--- a/docs/specs/consistency-check/prd.md
+++ b/docs/specs/consistency-check/prd.md
@@ -63,51 +63,51 @@
 
 ### Persistence half
 
-1. **[Optional]** Where the user passes a persistence argument or flag (e.g., `--persist <feature-slug>`) to `/8-habit-ai-dev:requirements`, `/8-habit-ai-dev:design`, or `/8-habit-ai-dev:breakdown`, the skill SHALL write its full PRD/design/tasks output to `docs/specs/<feature-slug>/{prd,design,tasks}.md` AND emit the `SKILL_OUTPUT` block as before.
+1. **[Optional]** FR-001: Where the user passes a persistence argument or flag (e.g., `--persist <feature-slug>`) to `/8-habit-ai-dev:requirements`, `/8-habit-ai-dev:design`, or `/8-habit-ai-dev:breakdown`, the skill SHALL write its full PRD/design/tasks output to `docs/specs/<feature-slug>/{prd,design,tasks}.md` AND emit the `SKILL_OUTPUT` block as before.
 
-2. **[Ubiquitous]** When persistence is NOT requested, the affected skills SHALL behave exactly as in v2.14.3 — emit `SKILL_OUTPUT` block in conversation only, no file writes.
+2. **[Ubiquitous]** FR-002: When persistence is NOT requested, the affected skills SHALL behave exactly as in v2.14.3 — emit `SKILL_OUTPUT` block in conversation only, no file writes.
 
-3. **[Event-driven]** When a persisted file already exists at the target path, the skill SHALL prompt the user (via AskUserQuestion or equivalent) to choose: overwrite, append revision history, or write to a numbered variant (`prd.v2.md`).
+3. **[Event-driven]** FR-003: When a persisted file already exists at the target path, the skill SHALL prompt the user (via AskUserQuestion or equivalent) to choose: overwrite, append revision history, or write to a numbered variant (`prd.v2.md`).
 
-4. **[Unwanted]** If the target `docs/specs/<feature-slug>/` directory cannot be created (permission denied, read-only filesystem), then the skill SHALL surface the error, fall back to conversation-only output, and continue without aborting.
+4. **[Unwanted]** FR-004: If the target `docs/specs/<feature-slug>/` directory cannot be created (permission denied, read-only filesystem), then the skill SHALL surface the error, fall back to conversation-only output, and continue without aborting.
 
-5. **[Ubiquitous]** All persisted artifact files SHALL include a YAML frontmatter block with: `feature`, `step` (requirements|design|breakdown), `created`, `updated`, `source-issue` (optional), `source-skill-version`.
+5. **[Ubiquitous]** FR-005: All persisted artifact files SHALL include a YAML frontmatter block with: `feature`, `step` (requirements|design|breakdown), `created`, `updated`, `source-issue` (optional), `source-skill-version`.
 
 ### Analyzer half
 
-6. **[Event-driven]** When invoked as `/8-habit-ai-dev:consistency-check <feature-slug>` (or with a directory path), the skill SHALL read all artifact files present in `docs/specs/<feature-slug>/` and run 5 detection passes: Coverage, Drift, Ambiguity, Underspec, Inconsistency.
+6. **[Event-driven]** FR-006: When invoked as `/8-habit-ai-dev:consistency-check <feature-slug>` (or with a directory path), the skill SHALL read all artifact files present in `docs/specs/<feature-slug>/` and run 5 detection passes: Coverage, Drift, Ambiguity, Underspec, Inconsistency.
 
-7. **[Ubiquitous]** The skill SHALL emit findings as a severity-graded table with columns `severity | pass | location | finding | suggested action`. Severities: CRITICAL, HIGH, MEDIUM, LOW. Maximum 30 findings per run (truncate excess with a "+N more, narrow scope" footer).
+7. **[Ubiquitous]** FR-007: The skill SHALL emit findings as a severity-graded table with columns `severity | pass | location | finding | suggested action`. Severities: CRITICAL, HIGH, MEDIUM, LOW. Maximum 30 findings per run (truncate excess with a "+N more, narrow scope" footer).
 
-8. **[Unwanted]** If `docs/specs/<feature-slug>/` does not exist OR contains zero artifact files, then the skill SHALL emit a single CRITICAL finding "No persisted artifacts found — was `--persist <feature-slug>` used during /requirements/design/breakdown?" and exit cleanly.
+8. **[Unwanted]** FR-008: If `docs/specs/<feature-slug>/` does not exist OR contains zero artifact files, then the skill SHALL emit a single CRITICAL finding "No persisted artifacts found — was `--persist <feature-slug>` used during /requirements/design/breakdown?" and exit cleanly.
 
-9. **[State-driven]** While running, the skill SHALL NOT write, edit, or delete any file (read-only by design). The skill's `allowed-tools` SHALL be `Read, Glob, Grep` only.
+9. **[State-driven]** FR-009: While running, the skill SHALL NOT write, edit, or delete any file (read-only by design). The skill's `allowed-tools` SHALL be `Read, Glob, Grep` only.
 
-10. **[Optional]** Where the user has opted in via maturity profile (`~/.claude/habit-profile.md` Significance tier), the skill SHALL emit the dimension summary and band table inline; otherwise it MAY defer to the standard scoring footer.
+10. **[Optional]** FR-010: Where the user has opted in via maturity profile (`~/.claude/habit-profile.md` Significance tier), the skill SHALL emit the dimension summary and band table inline; otherwise it MAY defer to the standard scoring footer.
 
-11. **[Ubiquitous]** Each finding SHALL cite a `file:line` reference in the `location` column when applicable (file-level findings are acceptable when no specific line applies).
+11. **[Ubiquitous]** FR-011: Each finding SHALL cite a `file:line` reference in the `location` column when applicable (file-level findings are acceptable when no specific line applies).
 
-12. **[Unwanted]** If a detection pass finds zero issues in its category, then the skill SHALL emit a "✓ Pass: 0 findings" row for that pass (NOT silence) so absence of evidence is distinguishable from non-execution.
+12. **[Unwanted]** FR-012: If a detection pass finds zero issues in its category, then the skill SHALL emit a "✓ Pass: 0 findings" row for that pass (NOT silence) so absence of evidence is distinguishable from non-execution.
 
 ### Cross-cutting
 
-13. **[Ubiquitous]** Both halves SHALL preserve backward compatibility: every existing test in `tests/validate-structure.sh` and `tests/validate-content.sh` SHALL continue to pass on the modified plugin without modification (new tests may be added; existing tests SHALL NOT be relaxed).
+13. **[Ubiquitous]** FR-013: Both halves SHALL preserve backward compatibility: every existing test in `tests/validate-structure.sh` and `tests/validate-content.sh` SHALL continue to pass on the modified plugin without modification (new tests may be added; existing tests SHALL NOT be relaxed).
 
-14. **[Event-driven]** When the bundled feature ships, ADR-013 SHALL document the persistence-opt-in design decision with at least 3 alternatives considered and rationale for the chosen approach.
+14. **[Event-driven]** FR-014: When the bundled feature ships, ADR-013 SHALL document the persistence-opt-in design decision with at least 3 alternatives considered and rationale for the chosen approach.
 
-15. **[Ubiquitous]** This feature SHALL self-apply: the `docs/specs/consistency-check/` directory containing this PRD SHALL also contain the design.md and tasks.md artifacts produced by the next workflow steps. `/consistency-check` SHALL be runnable manually against itself, with the manual procedure documented in `CONTRIBUTING.md`. (CI invocation deferred — skills cannot be invoked from bash; structural validator confirms artifact presence + frontmatter only.)
+15. **[Ubiquitous]** FR-015: This feature SHALL self-apply: the `docs/specs/consistency-check/` directory containing this PRD SHALL also contain the design.md and tasks.md artifacts produced by the next workflow steps. `/consistency-check` SHALL be runnable manually against itself, with the manual procedure documented in `CONTRIBUTING.md`. (CI invocation deferred — skills cannot be invoked from bash; structural validator confirms artifact presence + frontmatter only.)
 
 ### Added post-advisor review
 
-16. **[Unwanted]** If the user passes a slug that does not match `^[a-z0-9][a-z0-9-]{1,63}$`, then the skill SHALL abort with an error message naming the required pattern and providing an example of a valid slug. (Prevents path traversal, hidden files, shell special chars, excessive length.)
+16. **[Unwanted]** FR-016: If the user passes a slug that does not match `^[a-z0-9][a-z0-9-]{1,63}$`, then the skill SHALL abort with an error message naming the required pattern and providing an example of a valid slug. (Prevents path traversal, hidden files, shell special chars, excessive length.)
 
-17. **[Optional]** Where artifacts in `docs/specs/<slug>/` contain explicit cross-reference ID markers (`FR-NNN`, `Decision-N`, `Task #N`), the Coverage and Inconsistency passes SHALL use deterministic structural matching. Otherwise they SHALL use LLM semantic comparison.
+17. **[Optional]** FR-017: Where artifacts in `docs/specs/<slug>/` contain explicit cross-reference ID markers (`FR-NNN`, `Decision-N`, `Task #N`), the Coverage and Inconsistency passes SHALL use deterministic structural matching. Otherwise they SHALL use LLM semantic comparison.
 
-18. **[Event-driven]** When ANY artifact in `docs/specs/<slug>/` lacks ID markers, the report SHALL emit a single warning at the top: `"ID linkage absent — using fuzzy match for Coverage and Inconsistency; results approximate. See ADR-013 for ID guidance."`
+18. **[Event-driven]** FR-018: When ANY artifact in `docs/specs/<slug>/` lacks ID markers, the report SHALL emit a single warning at the top: `"ID linkage absent — using fuzzy match for Coverage and Inconsistency; results approximate. See ADR-013 for ID guidance."`
 
-19. **[Ubiquitous]** All error messages emitted by the persistence half (directory create failure, slug validation failure, file conflict with no interactive context) SHALL: (a) state what the skill attempted, (b) state what failed and why, (c) state what the user can do next. Generic "error" or "failed" messages are NOT acceptable.
+19. **[Ubiquitous]** FR-019: All error messages emitted by the persistence half (directory create failure, slug validation failure, file conflict with no interactive context) SHALL: (a) state what the skill attempted, (b) state what failed and why, (c) state what the user can do next. Generic "error" or "failed" messages are NOT acceptable.
 
-20. **[Optional]** Where the AskUserQuestion tool is unavailable (non-interactive context, batch invocation), the conflict policy (PRD-EARS-3) SHALL default to writing to a numbered variant (`prd.v2.md`, `prd.v3.md`, ...) rather than prompting, and SHALL emit a warning naming the variant chosen.
+20. **[Optional]** FR-020: Where the AskUserQuestion tool is unavailable (non-interactive context, batch invocation), the conflict policy (FR-003) SHALL default to writing to a numbered variant (`prd.v2.md`, `prd.v3.md`, ...) rather than prompting, and SHALL emit a warning naming the variant chosen.
 
 ---
 

--- a/docs/specs/consistency-check/tasks.md
+++ b/docs/specs/consistency-check/tasks.md
@@ -6,7 +6,7 @@
 **Design**: [./design.md](./design.md) (9 decisions)
 **ADR**: [../../adr/ADR-013-spec-persistence-opt-in.md](../../adr/ADR-013-spec-persistence-opt-in.md)
 
-> **ID linkage convention** (D9 / ADR-013): Each task references the PRD EARS criteria it satisfies and the design Decision(s) it implements. Format: `(PRD-EARS-X, Design-DN)`. This is the dogfood that lets `/consistency-check` run deterministic Coverage + Inconsistency passes against this very PR.
+> **ID linkage convention** (Decision-9 / ADR-013): Each task references the PRD requirements it satisfies and the design Decision(s) it implements. Format: `Task #N implements: Decision-X (FR-Y)`. This is the dogfood that lets `/consistency-check` run deterministic Coverage + Inconsistency passes against this very PR.
 
 ---
 
@@ -14,7 +14,7 @@
 
 ### Phase 1: Skill modifications (parallel-safe — same pattern, 3 files)
 
-#### Task #1 implements: Design-D1, Design-D4 (PRD-EARS-1, 2, 3, 4, 5, 16, 19, 20)
+#### Task #1 implements: Decision-1, Decision-4 (FR-001, FR-002, FR-003, FR-004, FR-005, FR-016, FR-019, FR-020)
 
 **Modify `skills/requirements/SKILL.md`** — add `--persist <slug>` handling.
 
@@ -24,14 +24,14 @@
 - Files: `skills/requirements/SKILL.md` (1 file)
 - Type: parallel-safe with #2 and #3
 
-#### Task #2 implements: Design-D1, Design-D4 (PRD-EARS-1, 2, 3, 4, 5, 16, 19, 20)
+#### Task #2 implements: Decision-1, Decision-4 (FR-001, FR-002, FR-003, FR-004, FR-005, FR-016, FR-019, FR-020)
 
 **Modify `skills/design/SKILL.md`** — same pattern as Task #1, persists to `design.md`.
 
 - Files: `skills/design/SKILL.md` (1 file)
 - Type: parallel-safe with #1 and #3
 
-#### Task #3 implements: Design-D1, Design-D4 (PRD-EARS-1, 2, 3, 4, 5, 16, 19, 20)
+#### Task #3 implements: Decision-1, Decision-4 (FR-001, FR-002, FR-003, FR-004, FR-005, FR-016, FR-019, FR-020)
 
 **Modify `skills/breakdown/SKILL.md`** — same pattern as Task #1, persists to `tasks.md`.
 
@@ -40,7 +40,7 @@
 
 ### Phase 2: New skill (sequential after Phase 1 design pattern locked)
 
-#### Task #4 implements: Design-D2, Design-D5, Design-D6, Design-D8, Design-D9 (PRD-EARS-6, 7, 8, 9, 10, 11, 12, 17, 18)
+#### Task #4 implements: Decision-2, Decision-5, Decision-6, Decision-8, Decision-9 (FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-017, FR-018)
 
 **Create `skills/consistency-check/SKILL.md`** — main skill file.
 
@@ -52,7 +52,7 @@
 - Type: parallel-safe with Phase 3
 - Depends on: Phase 1 patterns established (#1, #2, #3) for consistency
 
-#### Task #5 implements: Design-D8 (PRD-EARS-7, 17 supporting docs)
+#### Task #5 implements: Decision-8 (FR-007, FR-017 supporting docs)
 
 **Create `skills/consistency-check/reference.md`** — full output template + examples.
 
@@ -66,7 +66,7 @@
 
 ### Phase 3: Templates + docs (parallel-safe — independent files)
 
-#### Task #6 implements: Design-D9 (PRD-EARS-17 — supports ID-linkage convention)
+#### Task #6 implements: Decision-9 (FR-017 — supports ID-linkage convention)
 
 **Update `guides/templates/prd-template.md`, `adr-template.md`, `task-list-template.md`** — add OPTIONAL ID marker guidance.
 
@@ -97,7 +97,7 @@
 - Files: `CHANGELOG.md` (1 file)
 - Type: parallel-safe
 
-#### Task #10 implements: PRD-EARS-15, scope_in (CONTRIBUTING manual smoke)
+#### Task #10 implements: FR-015, scope_in (CONTRIBUTING manual smoke)
 
 **Update `CONTRIBUTING.md`** — add manual smoke procedure for `/consistency-check` self-test (run skill against `docs/specs/consistency-check/`, expected: low or zero findings).
 
@@ -120,7 +120,7 @@
 
 ### Phase 4: Validators (sequential after Phase 1+2)
 
-#### Task #13 implements: PRD-EARS-13 (existing tests still pass)
+#### Task #13 implements: FR-013 (existing tests still pass)
 
 **Update `tests/validate-structure.sh`** — new checks: `/consistency-check` SKILL.md exists, has correct frontmatter (name, allowed-tools = Read/Glob/Grep only, prev-skill, next-skill); reference.md exists; `docs/specs/consistency-check/{prd,design,tasks}.md` all exist with valid YAML frontmatter (dogfood enforcement per ADR-013 Verification).
 
@@ -128,7 +128,7 @@
 - Type: sequential after #4, #5
 - Depends on: #4, #5 (must exist for checks to pass)
 
-#### Task #14 implements: PRD-EARS-13, PRD-EARS-15 (validator dogfood)
+#### Task #14 implements: FR-013, FR-015 (validator dogfood)
 
 **Update `tests/validate-content.sh`** — new checks: all 3 modified skills (`/requirements`, `/design`, `/breakdown`) document `--persist` in body and frontmatter; `/consistency-check` SKILL.md mentions all 5 passes by name + hybrid eval + severity table; reference.md has output template; CONTRIBUTING.md has manual smoke section; CHANGELOG has the new release entry; CLAUDE.md has the new convention bullet.
 
@@ -138,9 +138,9 @@
 
 ### Phase 5: Self-application (last, dogfood)
 
-#### Task #15 implements: PRD-EARS-15, PRD-EARS-17 (dogfood ID-linkage)
+#### Task #15 implements: FR-015, FR-017 (dogfood ID-linkage)
 
-**Verify `docs/specs/consistency-check/tasks.md` contains `Task #N implements: Decision-X (PRD-EARS-Y)` markers** (already done in this file). After all other tasks complete, manually run `/consistency-check consistency-check` against this very feature's directory; expected: zero findings (or only acceptable advisory items). Document the manual smoke output in PR description as part of test plan.
+**Verify `docs/specs/consistency-check/tasks.md` contains `Task #N implements: Decision-X (FR-Y)` markers** (already done in this file). After all other tasks complete, manually run `/consistency-check consistency-check` against this very feature's directory; expected: zero findings (or only acceptable advisory items). Document the manual smoke output in PR description as part of test plan.
 
 - Files: none (verification + PR description update)
 - Type: sequential, last
@@ -194,10 +194,10 @@
 <!-- SKILL_OUTPUT:breakdown
 task_count: 15
 tasks:
-  - "Task #1: Modify /requirements SKILL.md — add --persist handling (Design-D1,D4; PRD-EARS-1,2,3,4,5,16,19,20)"
+  - "Task #1: Modify /requirements SKILL.md — add --persist handling (Decision-1, Decision-4; FR-001..005, FR-016, FR-019, FR-020)"
   - "Task #2: Modify /design SKILL.md — same pattern"
   - "Task #3: Modify /breakdown SKILL.md — same pattern"
-  - "Task #4: Create skills/consistency-check/SKILL.md — 5 passes, hybrid eval (Design-D2,D5,D6,D8,D9; PRD-EARS-6-12,17,18)"
+  - "Task #4: Create skills/consistency-check/SKILL.md — 5 passes, hybrid eval (Decision-2, Decision-5, Decision-6, Decision-8, Decision-9; FR-006..012, FR-017, FR-018)"
   - "Task #5: Create skills/consistency-check/reference.md — output template + examples"
   - "Task #6: Update 3 templates (prd, adr, task-list) — add OPTIONAL ID marker guidance"
   - "Task #7: Update CLAUDE.md — convention bullet + skills→habits row"
@@ -211,6 +211,6 @@ tasks:
   - "Task #15: Self-apply — run /consistency-check on docs/specs/consistency-check/, document output in PR description"
 dependencies:
   - "Phase 1 (#1-#3) parallel-safe; Phase 2 (#4) after pattern, #5 after #4; Phase 3 (#6-#12) parallel-safe; Phase 4 (#13-#14) sequential after needed inputs; Phase 5 (#15) last"
-  - "ID-linkage dogfood: each task lists Design-DX and PRD-EARS-Y refs for /consistency-check deterministic Coverage+Inconsistency passes"
+  - "ID-linkage dogfood: each task lists Decision-X and FR-NNN refs for /consistency-check deterministic Coverage+Inconsistency passes"
 estimated_complexity: "medium"
 END_SKILL_OUTPUT -->


### PR DESCRIPTION
## Summary

Mechanical rename across the v2.15.0 dogfood at `docs/specs/consistency-check/` so that re-running `/consistency-check consistency-check` produces `linkage: present` (deterministic mode) instead of `linkage: absent` (semantic mode + warning).

| File | Change |
|------|--------|
| `prd.md` | Prefix each of 20 EARS criteria with `FR-NNN:` (FR-001 → FR-020) |
| `design.md` | Rename `### Decision N` → `### Decision-N` (hyphen) for all 9 decision headers; normalize SKILL_OUTPUT `decisions`/`sticky_decisions` arrays; replace inline `PRD-EARS-N` references with `FR-NNN` |
| `tasks.md` | Replace cross-refs `Design-DN` → `Decision-N` and `PRD-EARS-N` → `FR-NNN` throughout 6 task header lines + SKILL_OUTPUT block + ID linkage convention sentence |

Pure dogfood cleanup. Zero code change. Zero skill change. Zero validator change.

Diff is 71 insertions + 71 deletions (mechanical 1:1 rename, no semantic shift).

## Why this matters

The v2.15.0 release shipped with the `/consistency-check` skill marketed as "deterministic when artifacts include `FR-NNN` / `Decision-N` / `Task #N` markers" — but its own dogfood used three non-canonical formats (`PRD-EARS-N`, `D1`, `Decision-DN`, `### Decision N` with space). Anyone copying `docs/specs/consistency-check/` as a template would copy the non-canonical formats too. This PR fixes the dogfood so it actually demonstrates the marketed deterministic happy path.

## Per advisor guidance (issue #167)

This ships separately from the analyzer behavior change (Finding 1 — backtick-quoted token false-positive in Ambiguity pass). That fix is deferred until real-user signal arrives — the documentation workaround already shipped in [#168](https://github.com/pitimon/8-habit-ai-dev/pull/168) (\"Known Limitation\" line in `reference.md`).

## Test plan

- [x] `bash tests/validate-structure.sh` — 256/0 PASS (unchanged from v2.15.0)
- [x] `bash tests/validate-content.sh` — 214/0/1WARN PASS (1 WARN pre-existing, unchanged by this PR)
- [x] ID-marker count verification:
  - `prd.md` FR-NNN matches: **20** (was 0)
  - `design.md` Decision-N headers (canonical): **9** (was 0)
  - `tasks.md` Task #N matches: **33** (unchanged — was already canonical)
- [x] Zero leftover `PRD-EARS` or `Design-D` patterns across all 3 dogfood files
- [ ] **Manual smoke test (post-merge)**: re-invoke `/8-habit-ai-dev:consistency-check consistency-check` → expected `linkage: present`. Any remaining findings (e.g. coverage gap on FR-014 which is satisfied by ADR-013 existence not by a Task #) are honest spec observations, not regressions.

## Closes

Closes Finding 2 of #167. Finding 1 (analyzer behavior change) remains open per advisor guidance — see issue thread.

Refs #167, #168, ADR-013.