### PR TITLE
feat(advisor-pattern): import 3 doubt-driven techniques (#173)

### DIFF
--- a/guides/advisor-pattern.md
+++ b/guides/advisor-pattern.md
@@ -65,6 +65,64 @@ Testing the workflow-level form on the plugin's own governance loop:
 
 The break-even is low: if the reviewer blocks **one bad proposal per ten**, the pattern pays for itself across typical development velocity.
 
+## Disprove-Mode Disciplines
+
+The Decision Checklist + Cost vs Benefit above cover _whether_ to dispatch the reviewer. The three subsections below cover _how_ to shape the dispatch when the goal is **disprove**, not score — high-stakes irreversible decisions where you want issues surfaced rather than a balanced verdict. Imported from [`addyosmani/agent-skills` — `doubt-driven-development`](https://github.com/addyosmani/agent-skills/blob/main/skills/doubt-driven-development/SKILL.md) (MIT, [PR #139](https://github.com/addyosmani/agent-skills/pull/139)) which formalized these in 2026-05.
+
+### Anti-bias: extract artifact + contract, not the claim (H5)
+
+A fresh-context reviewer biases toward whatever framing you hand them. If you paste your conclusion, you'll get back validation of your conclusion.
+
+**Bad form** (biases the reviewer):
+
+```
+CLAIM: "The new caching layer is thread-safe."
+[paste 200-line diff]
+Please review.
+```
+
+**Good form** (lets the reviewer independently verify):
+
+```
+ARTIFACT: [the diff or function — just the artifact]
+CONTRACT: [the constraints it must satisfy — e.g. "must be thread-safe under read-heavy load per spec §4"]
+```
+
+Pass `ARTIFACT + CONTRACT` only. Hold your `CLAIM` back — that's what the reviewer is supposed to independently re-derive (or refute). Maps to H5: don't accept your own framing as the starting point.
+
+### Iterative review: cap at 3 cycles (H3 + H7)
+
+The default pattern documented above is **single-shot, pre-action**: dispatch the reviewer, get the verdict, act or stop. If you ever depart from that — re-dispatching after edits to converge on an answer (iterative review → fix → re-review) — bound the loop:
+
+- **Cap at 3 cycles.** After cycle 3, escalate to the user / pause for human decision.
+- **Stop early** if a cycle returns only trivial findings (no new actionable issues).
+- **Stop early** if the user issues an override.
+
+The cap prevents reviewer infinite-spiral on contested artifacts; the escalation rule keeps the human in control of the disagreement.
+
+### Adversarial prompt template (H1 + H5)
+
+`@8-habit-reviewer` runs the [17-question checklist](cross-verification.md) and produces a **balanced verdict** (Pass/Fail counts + recommendations). For some decisions — production deploys, schema migrations, public API changes — you want the opposite shape: **disprove-only output**. Dispatch a fresh subagent with **no named agent role** and read-only tools (`Read`, `Glob`, `Grep`) using the prompt below — **not** `@8-habit-reviewer` (whose process is fixed to the 17-question checklist). In Claude Code, this means dispatching a generic Task subagent with the adversarial prompt as the entire instruction (no inherited persona, no checklist load).
+
+```
+Adversarial review. Find what is wrong with this artifact.
+Assume the author is overconfident. Look for:
+- Unstated assumptions
+- Edge cases not handled
+- Hidden coupling or shared state
+- Ways the contract could be violated
+- Existing conventions this might break
+- Failure modes under unexpected input
+
+Do NOT validate. Do NOT summarize. Find issues, or state
+explicitly that you cannot find any after thorough examination.
+
+ARTIFACT: <paste artifact>
+CONTRACT: <paste contract>
+```
+
+Maps to H1 (be proactive — disprove before deploy) + H5 (understand first — don't accept your own framing). Use this _in addition to_ the 17-question dispatch when the decision is irreversible; the two shapes catch different classes of issue.
+
 ## Boundary Note
 
 - **API-level `advisor_20260301`** belongs in projects that call the Claude API directly (e.g., memforge, custom agent loops). It is out of scope for this plugin per [CLAUDE.md](../CLAUDE.md) and the scope decision in [#87](https://github.com/pitimon/8-habit-ai-dev/issues/87).
@@ -73,9 +131,10 @@ The break-even is low: if the reviewer blocks **one bad proposal per ten**, the 
 
 ## Quick Reference
 
-| Pattern            | Solves                                           | Used Before                                    | H-Mapping    |
-| ------------------ | ------------------------------------------------ | ---------------------------------------------- | ------------ |
-| Advisor (workflow) | Context-contaminated proposals on public actions | Filing issues, opening PRs, merging, deploying | H5 + H4 + H1 |
+| Pattern                     | Solves                                                                 | Used Before                                               | H-Mapping    |
+| --------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- | ------------ |
+| Advisor (workflow)          | Context-contaminated proposals on public actions                       | Filing issues, opening PRs, merging, deploying            | H5 + H4 + H1 |
+| Adversarial (disprove-only) | High-stakes irreversible decisions needing issues surfaced, not scored | Production deploys, schema migrations, public API changes | H1 + H5      |
 
 ## See Also
 
@@ -84,6 +143,7 @@ The break-even is low: if the reviewer blocks **one bad proposal per ten**, the 
 - [`guides/orchestration-patterns.md`](orchestration-patterns.md) — related multi-agent discipline patterns
 - [Issue #87](https://github.com/pitimon/8-habit-ai-dev/issues/87) — original reference note and 2026-04-23 experiential comment
 - [`guides/quick-reference.md`](quick-reference.md) — full 8-Habit rule table
+- Upstream source for the Disprove-Mode Disciplines section: [`addyosmani/agent-skills` — `doubt-driven-development`](https://github.com/addyosmani/agent-skills/blob/main/skills/doubt-driven-development/SKILL.md) (MIT, [PR #139](https://github.com/addyosmani/agent-skills/pull/139))
 
 ---
 


### PR DESCRIPTION
## Summary

Imports 3 techniques from [`addyosmani/agent-skills` — `doubt-driven-development`](https://github.com/addyosmani/agent-skills/blob/main/skills/doubt-driven-development/SKILL.md) (MIT, [PR #139](https://github.com/addyosmani/agent-skills/pull/139)) into `guides/advisor-pattern.md` as a new "Disprove-Mode Disciplines" section. The upstream skill was published 2026-05-07 — **27 days after** our prior addyosmani audit (PR #111, 2026-04-11), so this is the post-audit delta, not a re-evaluation of already-rejected mechanics.

Closes #173.

## What changed

- **`guides/advisor-pattern.md`**: +63 / -3 lines
  - New `## Disprove-Mode Disciplines` section between existing `Cost vs Benefit` and `Boundary Note` sections, containing:
    1. `### Anti-bias: extract artifact + contract, not the claim (H5)` — codifies "Pass ARTIFACT + CONTRACT, NOT the CLAIM" with bad-form vs good-form examples.
    2. `### Iterative review: cap at 3 cycles (H3 + H7)` — explicit conditional, single-shot pattern unchanged; cap applies only when re-dispatching after edits.
    3. `### Adversarial prompt template (H1 + H5)` — verbatim-style prompt block. **Dispatches a fresh subagent with no named role** (not `@8-habit-reviewer`, whose 17-question process is fixed per `agents/8-habit-reviewer.md:18-24`).
  - Quick Reference table: second row added for `Adversarial (disprove-only)` pattern.
  - See Also: bullet citing MIT upstream + PR #139.

## Why (and why not more)

The prior audit (PR #111, closed 2026-04-11) imported 1/6 addyosmani mechanics into `/review-ai` and rejected 5 as duplicative. The local-maximum lesson held: don't import what we already have. This PR honors that lesson by:

- Restricting scope to **one file, three subsections, ~63 net lines added**
- Identifying **three specific techniques** that did not exist in `addyosmani` at audit time and do not exist in our plugin today (verified by reading `guides/advisor-pattern.md`, `agents/8-habit-reviewer.md`, `guides/cross-verification.md` in full)
- Explicitly rejecting in-scope candidates in #173 body: new `/doubt-check` skill (duplicates `/cross-verify`), `source-driven-development` import (duplicates `/research` Evidence Standard), cross-model CLI escalation (per ADR-006 boundary), agentskills.io frontmatter migration (ADR-007 NO-GO holds)

## Code review applied

Dispatched `@8-habit-reviewer` agent against the diff before commit. Result: **14/17 pass + 3 N/A + 0 hard blockers** + 3 polish recommendations, all addressed in-PR:

| Recommendation                                    | Status | Resolution                                                                                                                           |
| ------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
| F1 — Quick Reference table stale after edit       | Fixed  | Added second row for adversarial pattern                                                                                             |
| F2 — "Explore-style subagent" undefined           | Fixed  | Replaced with "fresh subagent with no named role and read-only tools (Read, Glob, Grep)" + concrete Claude Code dispatch instruction |
| F3 — Iterative-review heading missing habit label | Fixed  | Added `(H3 + H7)` to match sibling headings                                                                                          |

Reviewer specifically confirmed:

- Habit attribution accurate (H5 / H1+H5, not Spirit) — anti-CLAIM-bias = "don't accept own framing" = H5; adversarial = "disprove before deploy" + "don't accept own framing" = H1+H5
- "Not `@8-habit-reviewer`" claim is verifiable against `agents/8-habit-reviewer.md` (fixed 17-question process)
- MIT attribution sufficient (inline + See Also)
- No drift or contradiction with existing Decision Checklist / Cost vs Benefit / Boundary Note content

## Test plan

- [x] `bash tests/validate-structure.sh` — 256/256 PASS
- [x] `bash tests/validate-content.sh` — 214/214 PASS, 0 FAIL (1 pre-existing WARN on `research` skill unrelated)
- [x] `@8-habit-reviewer` agent dispatched — 14/17 pass, 0 blockers, 3 polish items all addressed
- [x] No skill frontmatter changed → no DAG validator surface affected
- [x] No new files; no new skills/agents/hooks/validators
- [x] Specific `git add guides/advisor-pattern.md` (no `git add -A` per rules)
- [x] Conventional commit message with WHY in body

## Coordination with #172

This PR adds **two new external GitHub URLs** to `guides/advisor-pattern.md`:

- `https://github.com/addyosmani/agent-skills/blob/main/skills/doubt-driven-development/SKILL.md`
- `https://github.com/addyosmani/agent-skills/pull/139`

Both are stable upstream references (skill canonical path + merged PR number). Once #172 (lychee link-check workflow) ships, these references will be protected by CI from silent rot. The two issues are **independent but complementary** — landing this first means #172 picks up the new URLs in its first scan.

## Follow-up

- `/reflect` lesson post-merge capturing "new-since-audit delta pattern" — recognizes when an upstream methodology innovation arrives between audits and warrants re-evaluation (vs. periodic full re-audits).

## References

- Issue: #173
- Prior audit: PR #111 (closes #110), ADR-007
- Advisor pattern origin: #87
- Upstream source (MIT): https://github.com/addyosmani/agent-skills/pull/139
- Coordination: #172 (lychee link-check)
- Plan + cross-verify (local): `/Users/itarun/.claude/plans/https-github-com-addyosmani-agent-skill-rippling-globe.md`, `/tmp/cross-verify-doubt-issue.md`
