### PR TITLE
feat(persistence-convention): add Current State File + Auto-Update Recipe (#176)

### DIFF
--- a/guides/persistence-convention.md
+++ b/guides/persistence-convention.md
@@ -96,6 +96,59 @@ For maximum rigor when running `/consistency-check`, persisted artifacts SHOULD 
 
 When IDs are present, `/consistency-check` runs deterministic Coverage and Inconsistency passes. When absent, it falls back to LLM semantic comparison and emits an explicit warning at the top of its report. IDs are RECOMMENDED, not REQUIRED.
 
+## Current State File (Optional, User-Owned)
+
+In addition to the 3 skill-managed artifacts above, this convention recommends a **4th file** for capturing **where the work stands right now** (running state, not immutable spec):
+
+```
+docs/specs/<slug>/current-state.md
+```
+
+**User-owned, manual.** No plugin skill writes to this file — the user creates and maintains it manually. It exists to solve the **resume-after-context-loss** problem: when `/clear`, `/compact`, or a session crash flushes conversation context, this file is the fine-grained task-level anchor the next session reads to continue without re-explanation.
+
+**Frontmatter exemption (explicit)**: unlike the skill-managed artifacts above (`prd.md` / `design.md` / `tasks.md`), `current-state.md` is user-owned and **not** subject to the [YAML frontmatter](#yaml-frontmatter) MUST. The file is free-form Markdown using the template below — no `feature`/`step`/`created`/`updated` fields required (a `Last updated` line in the body is sufficient).
+
+### Template
+
+```markdown
+# Current State — <feature name>
+
+**Doing now**: <specific task/sub-task currently active, e.g. "Task #4 — implement GET /users/:id endpoint">
+**Blocked on / stuck at**: <what's holding it up, or "nothing" / "waiting for review">
+**Next**: <the immediate next action when this completes>
+**Last updated**: <ISO 8601 datetime>
+```
+
+### Why a separate file rather than a section in `tasks.md`
+
+Re-running `/breakdown --persist <slug>` is legitimate when scope changes and a re-breakdown is needed. The [Conflict policy](#conflict-policy) above triggers and either overwrites `tasks.md` or writes to a numbered variant. A hand-maintained `## Current State` H2 inside `tasks.md` would be at risk either way — overwrite loses it; numbered variant splits user-edited state from skill-regenerated tasks. Isolating Current State in its own user-owned file (no skill writer) eliminates the ownership conflict.
+
+### Granularity vs `hooks/session-start.sh`
+
+`hooks/session-start.sh` already detects which `--persist` artifacts exist and nudges the **next workflow step** (e.g. `prd.md` present → suggest `/design`). That's **step-level** resume awareness.
+
+`current-state.md` is **task-level** resume awareness — which specific task is in flight, what blocker, what immediate next action. The two are complementary; both can be used together.
+
+### `/consistency-check` exclusion (explicit)
+
+`/consistency-check` does **NOT** analyze `current-state.md`. Informal running state is out of scope for cross-artifact consistency passes, which operate on the PRD ↔ design ↔ tasks immutable specs. The exclusion is by design — running state changes constantly and would create noise in drift/coverage analysis.
+
+## Auto-Update Recipe (User-Side, Optional)
+
+To keep `current-state.md` honest without remembering to update it each time, users can adopt a CLAUDE.md rule in their own `~/.claude/CLAUDE.md` or project `CLAUDE.md`:
+
+```markdown
+## After completing any task:
+
+1. Update `docs/specs/<slug>/current-state.md` — what's doing now, blockers, next action, last-updated timestamp
+2. Update data contracts in `docs/specs/<slug>/design.md` if any interface changed
+3. Never claim "done" without updating `current-state.md` first
+```
+
+**Plugin does not enforce this.** [ADR-013 Alternative 4](../docs/adr/ADR-013-spec-persistence-opt-in.md) rejected plugin-side auto-persist as violating the no-build philosophy ("skills are read-only guidance"; always-writing skills create unintended file artifacts) — that decision stands. The recipe above is **user-side adoption**: the user opts into the discipline by adding the rule to their own CLAUDE.md. The plugin teaches the pattern; the user owns enforcement.
+
+This split honors the plugin boundary: workflow discipline lives here, runtime enforcement lives in `claude-governance` (or in user CLAUDE.md hooks for self-enforcement).
+
 ## Verification
 
 To verify the convention is working:
@@ -106,3 +159,9 @@ ls docs/specs/add-user-login/
 head -10 docs/specs/add-user-login/prd.md  # frontmatter visible
 grep "SKILL_OUTPUT:requirements" docs/specs/add-user-login/prd.md  # block present
 ```
+
+---
+
+## Attribution
+
+The "Current State File" + "Auto-Update Recipe" sections paraphrase a community pattern from the Thai-language article _"ผมไม่เคยกลัว /clear กับ /compact"_, which proposes a single `spec.md` with 4 sections (architecture / done / todo / current state) auto-updated via a CLAUDE.md rule. This plugin imports the **current-state save-point** insight and the **auto-update recipe** template as a 4th user-owned file rather than collapsing onto a single file — the existing 3-file skill-managed model is better suited to `/consistency-check`'s cross-artifact passes (PRD ↔ design ↔ tasks). See [#176](https://github.com/pitimon/8-habit-ai-dev/issues/176).


### PR DESCRIPTION
## Summary

Adds 2 new H2 sections + Attribution to `guides/persistence-convention.md`, importing a community-article save-point pattern (Thai-language article _"ผมไม่เคยกลัว /clear กับ /compact"_) as a user-owned 4th file convention.

Closes #176.

## What's added

| Section                                            | Lines   | Purpose                                                                                                                                                                                                                                |
| -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **`## Current State File (Optional, User-Owned)`** | 99-132  | Documents `docs/specs/<slug>/current-state.md` template (doing-now / stuck-at / next / last-updated). User-owned (no skill writes), frontmatter-exempt, `/consistency-check` excluded. Solves resume-after-context-loss at task level. |
| **`## Auto-Update Recipe (User-Side, Optional)`**  | 134-148 | CLAUDE.md rule template users can adopt in `~/.claude/CLAUDE.md` or project `CLAUDE.md`. Plugin does NOT enforce — preserves ADR-013 Alt-4 invariant.                                                                                  |
| **`## Attribution`**                               | 161-165 | Credits the community article + #176 issue.                                                                                                                                                                                            |

File grew 109 → 167 lines (well under 220 cap).

## Why a separate file rather than a section in `tasks.md`

Re-running `/breakdown --persist <slug>` triggers the existing [Conflict policy](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/persistence-convention.md#conflict-policy) (overwrite / numbered / abort). A hand-maintained `## Current State` H2 inside `tasks.md` would be at risk either way — overwrite loses it; numbered variant splits user-edited state from skill-regenerated tasks. Isolating Current State in its own user-owned file (no skill writer) eliminates the ownership conflict.

## Why these, why not more

Honors PR #111's local-maximum lesson: no new skill, no new agent, no validator change, no DAG change. The one new file is **convention-only** — user-owned, plugin teaches the pattern, user owns enforcement.

Rejected candidates (documented in #176 body):

- ❌ **Single-file `spec.md` format** — breaking change to ADR-013's 3-file model; trades `/consistency-check` cross-artifact analysis for resume convenience
- ❌ **Plugin-side auto-persist hook** — ADR-013 Alt-4 explicitly rejected (violates no-build philosophy: "skills are read-only guidance"; always-writing skills create unintended file artifacts)
- ❌ **Data contracts as new section** — already covered by `/design` Step 4
- ❌ **New `/save-point` or `/resume` skill** — duplicates `/reflect` invocation pattern
- ❌ **Single-file priming command (`read spec.md`)** — `hooks/session-start.sh:83-115` already detects all 3 artifacts and nudges next skill (Issue #119)

## Code review applied

`@8-habit-reviewer` agent dispatched on diff pre-commit. Result: **17/17 PASS + 2 polish items**, both addressed in-PR:

| Recommendation                         | Status | Resolution                                                                                                                                                                                                                     |
| -------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| F1 — ADR-013 Alt-4 misattributed quote | Fixed  | Replaced `"magic behavior"` scare-quote (actually from Alt-2 line 87) with Alt-4's actual wording: "violating the no-build philosophy (skills are read-only guidance; always-writing skills create unintended file artifacts)" |
| F2 — Frontmatter MUST scope ambiguity  | Fixed  | Added explicit "Frontmatter exemption" paragraph stating `current-state.md` is user-owned and NOT subject to the YAML frontmatter requirement that applies to skill-managed artifacts                                          |

Reviewer confirmed:

- Habit attribution accurate (H5 + H3 for Current State, H1 for Auto-Update — NOT H2, NOT Spirit)
- Regeneration-safety rationale clearly stated (both failure paths named)
- `/consistency-check` exclusion explicit and rationale-backed
- "Plugin doesn't enforce" caveat adequate after F1 fix
- No drift / contradiction with existing sections after F2 fix
- Attribution adequate (paraphrased title + issue link is maximum achievable — no canonical URL exists)

## Habit mapping

- **Current State File** = H5 (Seek First to Understand — read running state before guessing) + H3 (First Things First — anchor _current_ task across context loss)
- **Auto-Update Recipe** = H1 (Be Proactive — capture state before crash forces it)

Plan + cross-verify scored 15/17 PASS (2 N/A) on the plan itself before implementation.

## Test plan

- [x] `bash tests/validate-structure.sh` — 256/256 PASS
- [x] `bash tests/validate-content.sh` — PASS, 0 FAIL, 0 fitness breaches (1 pre-existing WARN on `research` skill unrelated)
- [x] `@8-habit-reviewer` agent dispatched pre-commit — 17/17 PASS + 2 polish items both addressed
- [x] `wc -l guides/persistence-convention.md` = 167 (cap 220)
- [x] No skill frontmatter changed → no DAG validator surface affected
- [x] No new files, skills, agents, hooks, or validators
- [x] Specific `git add guides/persistence-convention.md` (no `git add -A` per rules)
- [x] Conventional commit message with WHY in body

## References

- Issue: #176
- Prior-art / similar pattern import: #173 → PR #174 → v2.15.1 (addyosmani doubt-driven techniques)
- Local-max lesson source: PR #111 (closes #110, v2.7.1)
- Plugin's persistence machinery: ADR-013, `guides/persistence-convention.md`
- Related: #119 (session-start workflow awareness), #165 (consistency analyzer + persistence v2.15.0)
- Cross-verify report (local, 15/17 pass + 2 N/A): `/tmp/cross-verify-current-state.md`
- Plan file (local): `/Users/itarun/.claude/plans/https-github-com-addyosmani-agent-skill-rippling-globe.md`
