### PR TITLE
docs(integrity): add commandment #13 — grep-verify quotes before pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ├── guides/
 │   ├── cross-verification.md       # 17-point checklist detail
 │   ├── whole-person-rubrics.md     # 4-dimension maturity rubrics
-│   ├── integrity-principles.md    # 12 AI Integrity Commandments
+│   ├── integrity-principles.md    # 13 AI Integrity Commandments
 │   ├── quick-reference.md          # 19 prioritized rules (scannable)
 │   ├── situation-map.md            # 15 situations → right habit/skill
 │   ├── orchestration-patterns.md   # Multi-agent orchestration (v2.0.0)

--- a/guides/integrity-principles.md
+++ b/guides/integrity-principles.md
@@ -4,7 +4,7 @@
 
 These commandments define what AI-assisted development must **never** do. Rules tell you what TO do; integrity commandments tell you what NEVER to do. Violations are non-negotiable — no exceptions for "small changes" or "obvious fixes."
 
-## The 12 Commandments
+## The 13 Commandments
 
 ### Evidence & Verification
 
@@ -45,6 +45,12 @@ These commandments define what AI-assisted development must **never** do. Rules 
 - **Why**: "This function handles authentication" might be true, but if you haven't read it, it's a guess
 - **Instead**: Mark uncertainty: "Based on the name, this likely handles auth — needs verification"
 
+**13. Never paste a verbatim quote without grep-verifying its source.**
+
+- **Why**: Plausible recollection of external text propagates errors silently. In v2.15.2 a `"Magic" behavior` scare-quote was attributed to ADR-013 Alt-4 (actual source: Alt-2, line 87); the misattribution survived through 4 artifacts before reviewer catch. Habit principle names match by gestalt, not by source text — observed in two consecutive PR reviews (#174, #177) where habit claims were corrected by reviewer pre-commit
+- **Instead**: Before pasting any quoted text — ADR citations, habit principle wording, scare-quoted phrases, external doc references, observation IDs — run `grep` against the source file and cite line numbers. `Source: docs/adr/ADR-013.md:87` beats "I recall it says...". When citing a habit (H1-H8), grep `rules/effective-development.md` to confirm the principle text matches your claim
+- **Scope**: ADR citations, habit principle claims, scare-quoted external text, observation IDs, prior-conversation paraphrases presented as direct quotes
+
 ### Process Discipline
 
 **8. Never skip security checks for "small changes."**
@@ -77,7 +83,7 @@ These commandments define what AI-assisted development must **never** do. Rules 
 | Commandment           | Primary Habit                           | Dimension |
 | --------------------- | --------------------------------------- | --------- |
 | 1-4 (Evidence)        | H4: Win-Win — honest feedback           | Heart     |
-| 5-7 (Honesty)         | H8: Find Voice — conscience             | Spirit    |
+| 5-7, 13 (Honesty)     | H8: Find Voice — conscience             | Spirit    |
 | 8-10 (Process)        | H1: Be Proactive — prevent, don't react | Body      |
 | 11-12 (Communication) | H4: Win-Win — Emotional Bank Account    | Heart     |
 

--- a/skills/review-ai/SKILL.md
+++ b/skills/review-ai/SKILL.md
@@ -197,5 +197,5 @@ See [Step 5 wiki page](../../docs/wiki/Step-5-Review-AI.md) for deeper walkthrou
 
 Load `${CLAUDE_PLUGIN_ROOT}/guides/templates/review-report-template.md` for the output template.
 Load `${CLAUDE_PLUGIN_ROOT}/habits/h4-win-win.md` for the full H4 principle and examples.
-Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards (the 12 commandments).
+Load `${CLAUDE_PLUGIN_ROOT}/guides/integrity-principles.md` for evidence standards (the 13 commandments).
 Load `${CLAUDE_PLUGIN_ROOT}/guides/structured-output-protocol.md` for the structured output block format specification.


### PR DESCRIPTION
## Summary

- Adds commandment **#13** to `guides/integrity-principles.md` under Honesty & Accuracy: *"Never paste a verbatim quote without grep-verifying its source."*
- Addresses habit-attribution drift + quote misattribution patterns observed across PR #174, PR #177, and v2.15.2 reflection
- Updates 3 live cross-references (title, README tree comment, review-ai load directive); preserves historical v1.9.0/v2.0.0 entries

## Why

During v2.15.2 release reflection, two interconnected verification gaps emerged:

1. **Quote attribution error** — `"Magic" behavior` scare-quote was attributed to ADR-013 Alt-4; actual source is Alt-2 at `docs/adr/ADR-013-spec-persistence-opt-in.md:87`. The misattribution propagated through 4 artifacts before reviewer catch.
2. **Habit-attribution drift across sessions** — Both PR #174 (Spirit/Conscience → corrected to H1+H5) and PR #177 (H2 → corrected to H3) showed habit claims pattern-matched from intuition rather than verified against source text.

Both errors share the same shape (plausible recollection vs verified text) and both are preventable with a single grep step before pasting.

## Changes

| File | Change |
|------|--------|
| `guides/integrity-principles.md` | Add #13, title 12→13, mapping table row extended |
| `README.md:355` (tree comment) | "12 AI Integrity Commandments" → "13" |
| `skills/review-ai/SKILL.md:200` (load directive) | "the 12 commandments" → "the 13 commandments" |

**Preserved historical record** (intentionally NOT changed):
- `SELF-CHECK.md:140` — under "v1.9.0 improvements" section
- `README.md:617` — v1.9.0 release line
- `CHANGELOG.md:464` — v2.0.0 deltas entry

## 8-Habit Mapping

- **H8 Find Voice / Spirit** — conscience: honesty about what you actually verified
- **H5 Seek First to Understand** — read the source, don't recall it
- **H1 Be Proactive** — prevent attribution drift before reviewer stage

## Dogfooding

Drafting commandment #13 caught its own meta-violation: initial text quoted `"magic behavior"` (lowercase, two-word) but ADR-013:87 actually says `"Magic" behavior` (capitalized, scare-quote on single word). Self-corrected before commit — demonstrating the rule works.

## Test Plan

- [x] `bash tests/validate-structure.sh` → 256 PASS, 0 FAIL
- [x] Grep-verify ADR-013 Alt-2 line 87 contains `"Magic" behavior`
- [x] Commandment text matches actual ADR phrasing (capitalization preserved)
- [x] Mapping table updated (5-7, 13 row)
- [x] No version bump (release PR follows)

Refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)