### PR TITLE
fix(consistency-check): backtick-aware Ambiguity pass + dogfood ID cleanup

### DIFF
--- a/docs/specs/consistency-check/tasks.md
+++ b/docs/specs/consistency-check/tasks.md
@@ -45,7 +45,7 @@
 **Create `skills/consistency-check/SKILL.md`** — main skill file.
 
 - Frontmatter: `name: consistency-check`, `argument-hint: "<slug> | <path-to-spec-dir>"`, `allowed-tools: ["Read", "Glob", "Grep"]`, `prev-skill: any`, `next-skill: any`, `user-invocable: true`
-- Body: input resolution (slug-OR-path auto-detect per Decision-D5), 5 detection passes (Coverage, Drift, Ambiguity, Underspec, Inconsistency) with hybrid eval per Decision-D9, severity table (Coverage=HIGH, Drift=CRITICAL, Ambiguity=MEDIUM, Underspec=LOW, Inconsistency=HIGH), max 30 findings, ✓ Pass row for zero-finding passes, file:line citations
+- Body: input resolution (slug-OR-path auto-detect per Decision-5), 5 detection passes (Coverage, Drift, Ambiguity, Underspec, Inconsistency) with hybrid eval per Decision-9, severity table (Coverage=HIGH, Drift=CRITICAL, Ambiguity=MEDIUM, Underspec=LOW, Inconsistency=HIGH), max 30 findings, ✓ Pass row for zero-finding passes, file:line citations
 - ID-linkage warning: emit at top when any artifact lacks markers
 - Empty-dir handling: single CRITICAL finding, exit cleanly
 - Files: `skills/consistency-check/SKILL.md` (1 file new)

--- a/skills/consistency-check/SKILL.md
+++ b/skills/consistency-check/SKILL.md
@@ -119,6 +119,8 @@ If the report has 0 CRITICAL/HIGH findings, the bundle is ready for `/build-brie
 - `TBD`, `TODO`, `???`, `XXX` → MEDIUM
 - `<placeholder>` patterns (e.g., `<insert here>`) → MEDIUM
 
+**Backtick-context filter (required)**: Tokens inside `` `…` `` inline code spans are treated as documentation-references, not unresolved markers. Before applying the token match above, pre-strip backtick-quoted segments from each line; only check the remaining plain-text. Rationale: PRDs legitimately mention these tokens as detection-target documentation (e.g., ``"the `[NEEDS CLARIFICATION]` token"``); flagging them as findings would punish writers for documenting the analyzer's own contract. This rule applies to single-backtick inline spans and triple-backtick fenced code blocks; it does NOT apply to plain-text occurrences elsewhere on the same line.
+
 ### Pass 4: Underspec
 
 **Purpose**: Every design decision should have rationale + at least 2 alternatives considered.

--- a/skills/consistency-check/reference.md
+++ b/skills/consistency-check/reference.md
@@ -140,7 +140,6 @@ source-skill-version: <plugin version, e.g. 2.15.0>
 - Single-feature analysis only — no cross-feature comparison (out of scope per PRD)
 - No auto-fix or remediation suggestions beyond the `suggested action` column (read-only by design)
 - Numbered variants (`prd.v2.md`, etc.) — analyzer reads the latest version of each, but does not compare across versions
-- Ambiguity pass cannot distinguish backtick-quoted documentation references from unresolved markers. If you need to mention a token like `[NEEDS CLARIFICATION]` or `TBD` in artifact prose without it firing a finding, write it in plain text (e.g., "the NEEDS-CLARIFICATION marker") rather than inside a code span. The analyzer's own dogfood spec hits this false-positive at `docs/specs/consistency-check/prd.md:45` — tracked in [#167](https://github.com/pitimon/8-habit-ai-dev/issues/167).
 
 ## See Also
 

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -539,6 +539,42 @@ else
 fi
 echo ""
 
+# --- Check 21: /consistency-check Pass 3 backtick-aware contract (Issue #167) ---
+# Asserts the Ambiguity pass spec includes the backtick-context filter rule.
+# Prevents regression where SKILL.md drifts back to plain `grep -nE` semantics
+# and the analyzer's own dogfood (docs/specs/consistency-check/prd.md:45) gets
+# falsely flagged as an unresolved [NEEDS CLARIFICATION] marker.
+echo "--- Check 21: /consistency-check Pass 3 backtick-aware contract ---"
+CC_SKILL="skills/consistency-check/SKILL.md"
+CC_FAIL=0
+if [ -f "$CC_SKILL" ]; then
+  # Backtick-context filter label present
+  if grep -q "Backtick-context filter" "$CC_SKILL"; then
+    pass "$CC_SKILL Pass 3 has 'Backtick-context filter' label"
+  else
+    fail "$CC_SKILL Pass 3 missing 'Backtick-context filter' label (Issue #167)"
+    CC_FAIL=$((CC_FAIL + 1))
+  fi
+  # Documentation-references semantic stated (vs unresolved markers)
+  if grep -q "documentation-references" "$CC_SKILL"; then
+    pass "$CC_SKILL Pass 3 states tokens-in-backticks are documentation-references"
+  else
+    fail "$CC_SKILL Pass 3 missing 'documentation-references' semantic (Issue #167)"
+    CC_FAIL=$((CC_FAIL + 1))
+  fi
+  # Pre-strip workflow specified (the actionable contract)
+  if grep -q "pre-strip" "$CC_SKILL"; then
+    pass "$CC_SKILL Pass 3 specifies pre-strip workflow"
+  else
+    fail "$CC_SKILL Pass 3 missing 'pre-strip' workflow contract (Issue #167)"
+    CC_FAIL=$((CC_FAIL + 1))
+  fi
+else
+  fail "$CC_SKILL not found"
+  CC_FAIL=$((CC_FAIL + 1))
+fi
+echo ""
+
 # --- Check 19: Docs freshness vs plugin.json version ---
 # Enforces version propagation across changelog surfaces. Issue #106/#107 (stuck-at-v2.N-5 drift);
 # tightened 2026-04-17 per #124 F1+F2 after v2.9.0+v2.11.0 (pointer-to-CHANGELOG.md fallback removed —


### PR DESCRIPTION
## Summary

Closes #167 — addresses both findings bundled in the issue.

**Finding 1 (CRITICAL false-positive)**: `/consistency-check` Pass 3 (Ambiguity) now skips tokens inside `` `…` `` inline code spans and triple-backtick fenced blocks. Eliminates the v2.15.0 dogfood false-positive at `docs/specs/consistency-check/prd.md:45`.

**Finding 2 (MEDIUM residual)**: `tasks.md:48` had two stale `Decision-D5` / `Decision-D9` references missed by PR #169's earlier ID canonicalization. Now aligned to `Decision-N` (no D prefix) per ADR-013.

## Why

Option A (backtick-context filter) was the recommended approach in #167:
> Fewer escape hatches, principled, generalizes.

This brings the analyzer's runtime semantics into alignment with the validator-side whitelist that already exists for `skills/consistency-check/` in `tests/validate-content.sh` Check 12c. The two-tier design (validator whitelist for skill prose + analyzer backtick-filter for spec artifacts) is now consistent: tokens inside backticks are documentation-references everywhere.

## Changes

| File | Change |
|------|--------|
| `skills/consistency-check/SKILL.md` | Pass 3 gains "Backtick-context filter (required)" subsection — pre-strip backtick-quoted segments before token match; covers single-backtick inline spans + triple-backtick fenced blocks |
| `skills/consistency-check/reference.md` | Known-limitation note (line 143, the one citing #167) removed — limitation is now fixed |
| `docs/specs/consistency-check/tasks.md:48` | `Decision-D5` → `Decision-5`; `Decision-D9` → `Decision-9` |
| `tests/validate-content.sh` | New Check 21 — asserts 3 contract signals: "Backtick-context filter" label, "documentation-references" semantic, "pre-strip" workflow |

## Verification

- [x] `bash tests/validate-structure.sh` → 256 PASS, 0 FAIL
- [x] `bash tests/validate-content.sh` → 217 PASS, 0 FAIL, 1 WARN, 0 fitness breaches
- [x] Check 21 fires 3 new pass signals when SKILL.md has the contract
- [x] `grep -rn "#167"` across non-worktree markdown returns empty (no orphan refs after removing reference.md note)
- [ ] **Manual smoke test** (per CONTRIBUTING.md): re-run `/consistency-check consistency-check` after merge — `prd.md:45` should no longer be flagged as CRITICAL Ambiguity. (Analyzer is a Claude-runtime skill, not bash-invokable; this verification is for the next maintainer running the smoke test.)
- [ ] Real unresolved tokens outside backticks still flag (manual verification by inserting a plain-text `TBD` into a test spec)

## Acceptance Criteria from #167

**Finding 1:**
- [x] Re-running `/consistency-check consistency-check` no longer flags `prd.md:45` (contract documented; runtime applies on next invocation)
- [ ] Real unresolved tokens (plain-text TBD/TODO) still flag at MEDIUM (deferred to manual smoke test — semantics unchanged for non-backticked tokens)
- [x] Documented in `skills/consistency-check/SKILL.md` Pass 3 description: tokens inside `` `…` `` are documentation-references
- [x] Validator test added (`tests/validate-content.sh` Check 21) — asserts contract presence; closer to the "at minimum suppresses the false-positive" tier of the criterion

**Finding 2:**
- [x] `tasks.md:48` residual cleaned up
- [x] No MEDIUM/HIGH findings related to ID format expected (PR #169 + this PR together close the gap)

## 8-Habit Mapping

- **H1 Be Proactive** — analyzer self-awareness now matches validator self-awareness; closes credibility gap
- **H5 Seek First to Understand** — pre-strip workflow makes the analyzer read the documentation context before judging
- **H7 Sharpen the Saw** — Check 21 invests in future capability (regression prevention) over output

## Pattern

**Bug fix of a feature shipped 9 days ago** — distinct shape from v2.15.1/2/3 (which were content-additions and convention imports). This is the first true bug-fix patch in the v2.15.x line. Issue surfaced via dogfood smoke test on the day v2.15.0 shipped (#167 filed 2026-05-03); fix deferred because the bug is non-blocking (false-positive, not false-negative) and three intervening features had reflection-driven priority.

Refs #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)