### PR TITLE
docs(guide): add /design producer + Q4/Q14/Q16 consumer entries

### DIFF
--- a/guides/structured-output-protocol.md
+++ b/guides/structured-output-protocol.md
@@ -54,6 +54,28 @@ success_criteria_count: 3
 END_SKILL_OUTPUT -->
 ```
 
+### `/design` → `SKILL_OUTPUT:design`
+
+```
+[/design] COMPLETE SKILL_OUTPUT:design
+<!-- SKILL_OUTPUT:design
+decision_count: 4
+decisions:
+  - "PostgreSQL for persistence"
+  - "REST API with versioned endpoints"
+  - "JWT for authentication"
+  - "Redis for session cache"
+sticky_decisions:
+  - "PostgreSQL — >50% rework to change"
+constraints:
+  - "Must support 10k concurrent users"
+adr_references:
+  - "ADR-007: Database choice"
+article_14_applicable: false
+article_14_pass: n/a
+END_SKILL_OUTPUT -->
+```
+
 ### `/breakdown` → `SKILL_OUTPUT:breakdown`
 
 ```
@@ -96,9 +118,11 @@ When `/cross-verify` runs, it should:
 
 1. Search for `<!-- SKILL_OUTPUT:` blocks in recent files (PRD, task list, review report) in the current directory
 2. If blocks found, auto-populate evidence for relevant questions:
-   - **Q4** (success criteria): Check `ears_count > 0` and `success_criteria_count > 0` from requirements block
+   - **Q4** (success criteria): Check `ears_count > 0` and `success_criteria_count > 0` from requirements block; cross-check `decision_count` from design block against `success_criteria_count` — flag if decisions don't cover all criteria
    - **Q5** (test plan): Check `test_coverage_checked: true` from review block
    - **Q8** (scope creep): Compare `task_count` from breakdown vs `ears_count` from requirements — flag if `task_count > ears_count * 3` (one requirement typically decomposes into 1-3 tasks)
+   - **Q14** (third alternative): Extract `decision_count` from design block — flag if only 1 option was presented (no third alternative considered)
+   - **Q16** (sticky decisions): Extract `sticky_decisions` from design block — flag if 0 sticky decisions in a design with >3 decisions (WHY not captured)
 3. If no blocks found, fall back to manual assessment (current behavior)
 4. Report which blocks were found and which were missing
 


### PR DESCRIPTION
## Summary

Closes #153. Adds `/design` producer entry to `guides/structured-output-protocol.md` + fixes same-shape consumer drift (Q14/Q16 documented in cross-verify SKILL.md but missing from the guide).

## Producer (issue scope)

`/design` is an active `SKILL_OUTPUT:design` producer per `skills/design/SKILL.md:128-142` consumed by `/cross-verify` Q14 and Q16, but was missing from the guide's "Producer Skills" section. Inserted between `/requirements` and `/breakdown` matching workflow step order (Step 1 → Step 2 → Step 3). Schema matches SKILL.md exactly; example values are concrete (matching the existing producer style — `ears_count: 5`, `task_count: 5`).

## Consumer (in-scope drift)

`skills/cross-verify/SKILL.md:35-41` documents 5 SKILL_OUTPUT-consuming questions (Q4, Q5, Q8, Q14, Q16) but the guide's Consumer section only had Q4/Q5/Q8. Same-shape drift as the producer gap — both stem from `/design`'s SKILL_OUTPUT being added without doc sync. Added Q14 + Q16 + extended Q4 with the design-block cross-check.

Adding the producer without documenting where its keys are consumed would itself be the "confusion point" the issue cites (H4 + H1).

## Verification

- [x] `bash tests/validate-structure.sh` → 256 PASS, 0 FAIL
- [x] `bash tests/validate-content.sh` → 217 PASS, 0 FAIL, 0 fitness breaches
- [x] Producer schema cross-verified against `skills/design/SKILL.md:128-142`
- [x] Consumer entries cross-verified against `skills/cross-verify/SKILL.md:35-41`

## Acceptance Criteria (from #153)

- [x] `/design` appears in "Producer Skills" section of the guide
- [x] Example block matches the schema declared in `skills/design/SKILL.md`
- [x] No validator changes required (documentation-only)

Refs #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)