### PR TITLE
docs(guides): add spec-digest-pattern.md — project-orientation hub mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,16 +158,17 @@ You don't need all steps every time. Start with **`/requirements` before buildin
 
 Start from **your situation**, not the skill name.
 
-| I want to...                      | Start with      | Then                        | Habit                   |
-| --------------------------------- | --------------- | --------------------------- | ----------------------- |
-| Build a new feature from scratch  | `/requirements` | `/design` → `/breakdown`    | H2: Define done first   |
-| Review code before committing     | `/review-ai`    | `/security-check` if needed | H4: Never skip review   |
-| Understand an unfamiliar codebase | `/research`     | `/build-brief`              | H5: Read before writing |
-| Deploy to production              | `/deploy-guide` | `/monitor-setup`            | H1: Staging first       |
-| Assess overall project health     | `/cross-verify` | `/whole-person-check`       | All 8 habits            |
-| Fix a production bug              | `/build-brief`  | Reproduce first             | H5: Understand first    |
-| Something feels off about a plan  | `/cross-verify` | Check dimension scores      | H1-H8                   |
-| Learn the full workflow           | `/workflow`     | (guided walkthrough)        | All                     |
+| I want to...                      | Start with                                                                                                                                                                                                          | Then                              | Habit                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ----------------------- |
+| Build a new feature from scratch  | `/requirements`                                                                                                                                                                                                     | `/design` → `/breakdown`          | H2: Define done first   |
+| Review code before committing     | `/review-ai`                                                                                                                                                                                                        | `/security-check` if needed       | H4: Never skip review   |
+| Understand an unfamiliar codebase | `/research`                                                                                                                                                                                                         | `/build-brief`                    | H5: Read before writing |
+| Deploy to production              | `/deploy-guide`                                                                                                                                                                                                     | `/monitor-setup`                  | H1: Staging first       |
+| Assess overall project health     | `/cross-verify`                                                                                                                                                                                                     | `/whole-person-check`             | All 8 habits            |
+| Fix a production bug              | `/build-brief`                                                                                                                                                                                                      | Reproduce first                   | H5: Understand first    |
+| Something feels off about a plan  | `/cross-verify`                                                                                                                                                                                                     | Check dimension scores            | H1-H8                   |
+| Learn the full workflow           | `/workflow`                                                                                                                                                                                                         | (guided walkthrough)              | All                     |
+| Survive `/clear` and `/compact`   | See [`guides/spec-digest-pattern.md`](guides/spec-digest-pattern.md) (project-orientation hub) or [`current-state.md`](guides/persistence-convention.md#current-state-file-optional-user-owned) (feature-spec mode) | Adopt one based on repo archetype | H5: Understand first    |
 
 ### Recommended Paths
 

--- a/docs/adr/ADR-013-spec-persistence-opt-in.md
+++ b/docs/adr/ADR-013-spec-persistence-opt-in.md
@@ -137,3 +137,24 @@ This ADR is satisfied when:
 - [ ] `tests/validate-content.sh` includes a check that `docs/specs/consistency-check/{prd,design,tasks}.md` exists and has valid frontmatter (dogfood enforcement)
 - [ ] CHANGELOG records the new opt-in convention
 - [ ] CLAUDE.md "Key Conventions" section adds a bullet for the new convention
+
+---
+
+## Addendum — 2026-05-17: scope clarification (feature-spec mode only)
+
+**Trigger**: issue [#194](https://github.com/pitimon/8-habit-ai-dev/issues/194) surfaced a real-world `SPEC.md` artifact (`scanopy/netbox-sit/SPEC.md`, 153 lines) using a single project-root digest pointing to project-specific detail files — a shape this ADR's Alternative 1 / Alternative 4 rejections did **not** evaluate.
+
+**Clarification**: the rejections in this ADR cover:
+
+1. Merging `prd.md` + `design.md` + `tasks.md` into one file under `docs/specs/<slug>/` (Alt-1 — breaks `/consistency-check`)
+2. Always-on PostToolUse auto-write of any spec file (Alt-4 — violates no-build philosophy)
+3. A new `/save-point` or `/resume` skill that duplicates `/reflect` (CHANGELOG v2.15.0)
+
+The rejections do **NOT** cover:
+
+- A **project-root `SPEC.md` digest** that points to project-specific detail files (e.g. `PLAYBOOK.md`, `CONTRACTS.md`) and acts as a save point for `/clear` / `/compact` — this is a different deployment archetype ("project-orientation hub mode"), not a competing format within the feature-spec mode this ADR governs.
+- A **user-invoked** `/save-spec <slug>` skill (analogous to `/reflect` or `/requirements --persist`) that would generate/update such a digest. This remains deferred pending a second independent adoption signal — see promotion criteria in [`guides/spec-digest-pattern.md`](../../guides/spec-digest-pattern.md#promotion-to-a-skill-deferred).
+
+**Scope statement**: ADR-013 governs the **feature-spec mode** (`docs/specs/<slug>/{prd,design,tasks,current-state}.md`). The complementary **project-orientation hub mode** is documented in [`guides/spec-digest-pattern.md`](../../guides/spec-digest-pattern.md) and is **pattern documentation only** (no skill, no hook, no enforcement). Both modes can coexist; most projects pick one based on archetype.
+
+**No change to the original decision.** The opt-in `--persist <slug>` convention, slug validation, conflict policy, frontmatter requirement, and ID-linkage guidance from the Decision section all stand unchanged.

--- a/guides/persistence-convention.md
+++ b/guides/persistence-convention.md
@@ -106,6 +106,8 @@ docs/specs/<slug>/current-state.md
 
 **User-owned, manual.** No plugin skill writes to this file — the user creates and maintains it manually. It exists to solve the **resume-after-context-loss** problem: when `/clear`, `/compact`, or a session crash flushes conversation context, this file is the fine-grained task-level anchor the next session reads to continue without re-explanation.
 
+> **Project archetype note**: this convention is the **feature-spec mode** — per-feature persistence under `docs/specs/<slug>/`. For single-system / operational / infrastructure repos where one project-root `SPEC.md` digest pointing to project-specific detail files fits better, see the complementary [`spec-digest-pattern.md`](./spec-digest-pattern.md) (project-orientation hub mode). The two modes can coexist but most projects pick one.
+
 **Frontmatter exemption (explicit)**: unlike the skill-managed artifacts above (`prd.md` / `design.md` / `tasks.md`), `current-state.md` is user-owned and **not** subject to the [YAML frontmatter](#yaml-frontmatter) MUST. The file is free-form Markdown using the template below — no `feature`/`step`/`created`/`updated` fields required (a `Last updated` line in the body is sufficient).
 
 ### Template

--- a/guides/spec-digest-pattern.md
+++ b/guides/spec-digest-pattern.md
@@ -1,0 +1,172 @@
+# Project SPEC.md Digest Pattern (project-orientation hub mode)
+
+A single-page `SPEC.md` at the project root that points to project-specific detail files, surfaces a compact decision digest, and acts as the read-first save point after `/clear` or `/compact`.
+
+This is **complementary** to the `--persist <slug>` feature-spec mode documented in [`persistence-convention.md`](./persistence-convention.md) — different shape for a different project archetype, not a replacement.
+
+**Plugin enforcement**: none. This guide documents a pattern; users adopt it manually in their own repo. There is no `/save-spec` skill (yet — see [Promotion criteria](#promotion-to-a-skill-deferred) below).
+
+---
+
+## Two deployment modes
+
+| Mode                                          | Shape                                                                                                             | Fits                                                                              | Maintained by                                                                                          |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Feature-spec mode** (v2.15.0+)              | `docs/specs/<slug>/{prd,design,tasks,current-state}.md` per feature                                               | Greenfield features, EARS requirements, multi-feature repos                       | `/requirements --persist`, `/design --persist`, `/breakdown --persist` + user-owned `current-state.md` |
+| **Project-orientation hub mode** (this guide) | Single project-root `SPEC.md` + project-specific detail files (`PLAYBOOK.md`, `CONTRACTS.md`, `LESSONS.md`, etc.) | Operational repos, infra pipelines, integration projects, single-system codebases | User-owned, manual (or via CLAUDE.md rule)                                                             |
+
+Both can coexist in the same repo if needed — they don't reference each other. Most projects pick one.
+
+## When to use the digest pattern
+
+Use it when:
+
+- The repo has **one coherent system**, not many independent features
+- Detail naturally lives in **project-specific files** (e.g. `PLAYBOOK.md` for ops, `CONTRACTS.md` for data shapes, `CHANGELOG.md` for history) — not in per-feature `prd.md`/`design.md`
+- You frequently `/clear` or `/compact` mid-task and re-orient via a single file read
+- A new contributor (human or AI) needs **one page** to understand "what is this repo, what's been decided, what's in flight"
+
+Use the feature-spec mode instead when:
+
+- You ship multiple parallel features, each with its own scope
+- You want `/consistency-check` to validate PRD ↔ design ↔ tasks drift
+- Your work is greenfield specification, not maintenance of a running system
+
+## Template
+
+Copy this into `SPEC.md` at the project root. Fill the four sections. Keep it ≤ 200 lines — if it grows past that, push detail into pointer-targets.
+
+````markdown
+# SPEC.md — <project-name> save point
+
+Single-page reference. Read this first when starting a new session.
+
+> **Rule** (per [CLAUDE.md](CLAUDE.md)): every completed task updates §4 (Current state) and §3 (Backlog). Never claim "done" without updating this file.
+
+---
+
+## 1. Architecture (pointer)
+
+<One paragraph summarizing what this system is + where it runs.>
+
+- **Detailed runbook / ops** → [PLAYBOOK.md](PLAYBOOK.md)
+- **Data contracts / API shapes** → [CONTRACTS.md](CONTRACTS.md)
+- **Lessons & post-mortems** → [LESSONS.md](LESSONS.md)
+- **Per-event history** → [CHANGELOG.md](CHANGELOG.md)
+- <Add project-specific pointers here.>
+
+## 2. Decisions snapshot (pointer)
+
+The N most load-bearing decisions. Each row = one line + canonical source. Keep ≤ 10 rows — if it grows, prune to the most active.
+
+| #   | Decision          | Why               | Source                  |
+| --- | ----------------- | ----------------- | ----------------------- |
+| D1  | <terse statement> | <terse rationale> | [`<file>:<line>`](file) |
+
+Per-event history: [CHANGELOG.md](CHANGELOG.md). Root-cause post-mortems: [LESSONS.md](LESSONS.md).
+
+## 3. Live backlog
+
+**The only place backlog is maintained.** Stale items are deleted, not archived.
+
+- [ ] <Active backlog item — what + where + blocker if any>
+- [x] ~~<Shipped item, with date + source link>~~
+
+## 4. Current state — save point
+
+**Read this section first after `/clear` or `/compact`.**
+
+> **Last updated**: <ISO 8601 date>
+> **Last apply / commit / deploy event**: <terse note + timestamp>
+
+### What's happening now
+
+<Specific task/sub-task active right now, with file paths and progress.>
+
+### Stuck / waiting on
+
+<What blocks progress, or "nothing".>
+
+### Next session entry point
+
+```bash
+cd <repo-root>
+cat SPEC.md                  # this file
+# then inspect §4 above for "what changed last"
+```
+
+<Optional: command sequence to resume the in-flight work, e.g. health check + next step.>
+````
+
+## CLAUDE.md auto-update rule (user-side)
+
+To keep `SPEC.md` honest without remembering, add this to the project's `CLAUDE.md`:
+
+```markdown
+## After completing any task:
+
+1. Update `SPEC.md` §4 (Current state) — what changed, what's next, last-updated timestamp
+2. Update `SPEC.md` §3 (Backlog) — check off completed items, add new ones surfaced
+3. Update data contracts in the file referenced from `SPEC.md` §1 if any interface changed
+4. Never claim "done" without updating `SPEC.md` first
+```
+
+**Plugin does not enforce this.** Same boundary as the feature-spec mode auto-update recipe ([`persistence-convention.md`](./persistence-convention.md#auto-update-recipe-user-side-optional)) — the plugin teaches the pattern; the user owns enforcement via their own CLAUDE.md rule.
+
+## What this pattern is NOT
+
+To prevent confusion with rejected alternatives in [ADR-013](../docs/adr/ADR-013-spec-persistence-opt-in.md):
+
+- **Not a replacement for `prd.md` / `design.md` / `tasks.md`** — `SPEC.md` is a **digest layer above** them (when feature-spec mode is also in use), or stands alone (when it isn't). It points; it doesn't subsume.
+- **Not auto-written by a skill or hook** — ADR-013 Alternative 4 rejected always-on auto-persist. This pattern relies on user-side discipline + the optional CLAUDE.md rule above.
+- **Not a `/consistency-check` input** — that analyzer operates on the 3-file PRD↔design↔tasks artifacts in `docs/specs/<slug>/`. A free-form `SPEC.md` is out of scope by design.
+- **Not a `/save-point` or `/resume` skill** — those were rejected as duplicating `/reflect` (see CHANGELOG v2.15.0). The digest is a hand-curated file, not a generated artifact.
+
+## Decisions table — formatting guidance
+
+The Decisions table (§2) is the highest-value section after §4. Treat it as a **compact ADR digest**:
+
+- One row per load-bearing decision — the ones a new contributor would otherwise re-litigate
+- Three columns: **Decision** (statement), **Why** (one-line rationale), **Source** (canonical file:line or ADR link)
+- Cap at 10 rows — if you exceed, prune the least active (the original ADR lives on; the digest is just the pointer)
+- Use `file:line` links for runtime decisions encoded in code; use ADR links for architectural decisions encoded in docs
+
+Example row format:
+
+```markdown
+| D1 | **IP address = idempotency key** (not name) | Vendor-default names collide ("Proxmox VE" × 20) | [`promote.py:100-114`](sync/promote.py) + [LESSONS §22](LESSONS.md) |
+```
+
+## Promotion to a skill (deferred)
+
+A user-invoked `/save-spec <slug>` skill that generates/updates this digest from existing files is plausible but **not shipped**. Promotion criteria, per the working-with-pitimon "minimal additions, user-demand-driven" stance:
+
+1. ≥ 2 independent projects adopt the digest pattern from this guide
+2. The scope question (project-root `SPEC.md` vs per-slug `current-state.md` in multi-feature repos) has a resolved answer in writing
+3. There is at least one captured `/reflect` lesson naming "manually maintaining the digest was tedious" or equivalent friction signal
+
+Until those three signals exist, the guide is the canonical form. Track adoption in [#194](https://github.com/pitimon/8-habit-ai-dev/issues/194) and downstream issues.
+
+## Verification
+
+To verify a `SPEC.md` follows this pattern:
+
+```bash
+# All four sections present?
+grep -E '^## [1-4]\.' SPEC.md | wc -l   # expect 4
+
+# Save-point hint present in §4?
+grep -A1 '## 4. Current state' SPEC.md | grep -i 'clear.*compact'
+
+# Last-updated timestamp present?
+grep -E 'Last updated' SPEC.md
+
+# Pointers actually resolve?
+grep -oE '\]\([^)]+\.md\)' SPEC.md | sed 's/[])(]//g' | xargs -I{} ls {}
+```
+
+---
+
+## Attribution
+
+This pattern is documented from a production artifact (`netbox-sit/SPEC.md`, 153 lines, May 2026) that independently arrived at the four-section shape after the user observed `/clear` and `/compact` repeatedly flushing in-flight context. The same Thai-language community article (_"ผมไม่เคยกลัว /clear กับ /compact"_) inspired both the per-feature `current-state.md` convention ([#176](https://github.com/pitimon/8-habit-ai-dev/issues/176)) and this project-orientation digest pattern ([#194](https://github.com/pitimon/8-habit-ai-dev/issues/194)) — different shapes from the same insight, fitting different repo archetypes.

--- a/guides/spec-digest-pattern.md
+++ b/guides/spec-digest-pattern.md
@@ -41,7 +41,7 @@ Copy this into `SPEC.md` at the project root. Fill the four sections. Keep it �
 
 Single-page reference. Read this first when starting a new session.
 
-> **Rule** (per [CLAUDE.md](CLAUDE.md)): every completed task updates §4 (Current state) and §3 (Backlog). Never claim "done" without updating this file.
+> **Rule** (per `CLAUDE.md`): every completed task updates §4 (Current state) and §3 (Backlog). Never claim "done" without updating this file.
 
 ---
 
@@ -49,21 +49,21 @@ Single-page reference. Read this first when starting a new session.
 
 <One paragraph summarizing what this system is + where it runs.>
 
-- **Detailed runbook / ops** → [PLAYBOOK.md](PLAYBOOK.md)
-- **Data contracts / API shapes** → [CONTRACTS.md](CONTRACTS.md)
-- **Lessons & post-mortems** → [LESSONS.md](LESSONS.md)
-- **Per-event history** → [CHANGELOG.md](CHANGELOG.md)
-- <Add project-specific pointers here.>
+- **Detailed runbook / ops** → `PLAYBOOK.md`
+- **Data contracts / API shapes** → `CONTRACTS.md`
+- **Lessons & post-mortems** → `LESSONS.md`
+- **Per-event history** → `CHANGELOG.md`
+- <Add project-specific pointers here. Wrap each filename in Markdown link syntax in your own copy if you want clickable references — kept as plain backticked names here so the template stays portable.>
 
 ## 2. Decisions snapshot (pointer)
 
 The N most load-bearing decisions. Each row = one line + canonical source. Keep ≤ 10 rows — if it grows, prune to the most active.
 
-| #   | Decision          | Why               | Source                  |
-| --- | ----------------- | ----------------- | ----------------------- |
-| D1  | <terse statement> | <terse rationale> | [`<file>:<line>`](file) |
+| #   | Decision          | Why               | Source          |
+| --- | ----------------- | ----------------- | --------------- |
+| D1  | <terse statement> | <terse rationale> | `<file>:<line>` |
 
-Per-event history: [CHANGELOG.md](CHANGELOG.md). Root-cause post-mortems: [LESSONS.md](LESSONS.md).
+Per-event history: `CHANGELOG.md`. Root-cause post-mortems: `LESSONS.md`.
 
 ## 3. Live backlog
 
@@ -131,10 +131,10 @@ The Decisions table (§2) is the highest-value section after §4. Treat it as a 
 - Cap at 10 rows — if you exceed, prune the least active (the original ADR lives on; the digest is just the pointer)
 - Use `file:line` links for runtime decisions encoded in code; use ADR links for architectural decisions encoded in docs
 
-Example row format:
+Example row format (linkify filenames in your own copy if you want clickable refs — backticks here keep the template portable across renderers):
 
 ```markdown
-| D1 | **IP address = idempotency key** (not name) | Vendor-default names collide ("Proxmox VE" × 20) | [`promote.py:100-114`](sync/promote.py) + [LESSONS §22](LESSONS.md) |
+| D1 | **IP address = idempotency key** (not name) | Vendor-default names collide ("Proxmox VE" × 20) | `sync/promote.py:100-114` + `LESSONS.md §22` |
 ```
 
 ## Promotion to a skill (deferred)


### PR DESCRIPTION
## Summary

- Adds `guides/spec-digest-pattern.md` documenting the **project-orientation hub mode** — a single project-root `SPEC.md` digest pattern, complementary to the existing **feature-spec mode** (ADR-013, v2.15.0+)
- Updates `guides/persistence-convention.md` and `README.md` with cross-link to the new guide
- Adds an additive **2026-05-17 addendum** to `docs/adr/ADR-013-spec-persistence-opt-in.md` clarifying ADR-013 scope (feature-spec mode only); the original Decision section is unchanged
- **No new skill, no new hook, no enforcement.** Pattern documentation only.

## Why

A real-world artifact (`scanopy/netbox-sit/SPEC.md`, 153 lines, production use) independently arrived at a four-section `SPEC.md` shape after the user observed `/clear` and `/compact` repeatedly flushing in-flight context. That artifact uses a project-root digest pointing to project-specific detail files (`PLAYBOOK.md`, `CONTRACTS.md`, `LESSONS.md`, etc.) — a deployment archetype that v2.15.2 does not yet document. The two patterns serve different repo archetypes; both can coexist or a project can pick one.

## Scope discipline

A `/save-spec <slug>` skill that would generate/update such a digest is **explicitly deferred** until:

1. ≥ 2 independent projects adopt the pattern from this guide
2. The scope question (root `SPEC.md` vs per-slug `current-state.md` in multi-feature repos) has a resolved answer in writing
3. A captured `/reflect` lesson naming maintenance-friction surfaces

This matches the working-with-pitimon "minimal additions, user-demand-driven" stance + PR #111 local-maximum lesson.

## ADR addendum honesty

The addendum is **additive only**. It clarifies that ADR-013's rejections of (Alt-1) unified spec.md merge, (Alt-4) always-on auto-write hook, and the /save-point skill rejection in CHANGELOG v2.15.0 cover the **feature-spec mode** specifically. A project-root digest layer above existing detail files is a different shape that those rejections did not evaluate. No change to the original Decision section.

## Files changed

| File | Change |
|---|---|
| `guides/spec-digest-pattern.md` | NEW — full guide (template, when-to-use, CLAUDE.md rule, what-it-is-NOT, promotion criteria, verification) |
| `guides/persistence-convention.md` | MOD — cross-link note in "Current State File" section pointing to the new guide for the alternate archetype |
| `README.md` | MOD — one new row in "Use Cases" table for "Survive /clear and /compact" |
| `docs/adr/ADR-013-spec-persistence-opt-in.md` | MOD — appended 2026-05-17 addendum after the Verification section |

## Test plan

- [x] `tests/validate-structure.sh` — 256 PASS / 0 FAIL on the branch
- [x] 8-habit-reviewer agent — REVISE → fix applied (nested code fence rendering), re-verified
- [x] Citation grep-verify per lesson 2026-05-12: all ADR-013 line refs, persistence-convention anchors, and CHANGELOG quote confirmed against source files
- [x] No version bump required (docs-only, no skill/manifest/SKILL_OUTPUT touch)
- [ ] Reviewer reads `guides/spec-digest-pattern.md` end-to-end and confirms it accurately reflects the netbox-sit SPEC.md it paraphrases
- [ ] Reviewer confirms the ADR addendum does not implicitly re-open the original Decision

## Habit mapping

- **H5 (Understand First)** — verified existing convention via 3-agent research + advisor + 8-habit-reviewer before proposing; addendum honestly reflects scope of original ADR
- **H2 (Begin with End in Mind)** — acceptance criteria + out-of-scope list in the issue before code; verification commands in the guide
- **H8 (Find Your Voice)** — plugin recognizes two legitimate deployment modes, not a one-size-fits-all
- **H3 (First Things First)** — guide-first is lowest-commitment reversible path; skill comes after adoption signal
- **H4 (Win-Win)** — "What this is NOT" + "Promotion criteria" + verification commands give future contributors everything they need to evaluate

Refs #194