### PR TITLE
docs(guides): apply Adopter #2 friction fixes to spec-digest-pattern

### DIFF
--- a/guides/spec-digest-pattern.md
+++ b/guides/spec-digest-pattern.md
@@ -53,7 +53,7 @@ Single-page reference. Read this first when starting a new session.
 - **Data contracts / API shapes** → `CONTRACTS.md`
 - **Lessons & post-mortems** → `LESSONS.md`
 - **Per-event history** → `CHANGELOG.md`
-- <Add project-specific pointers here. Wrap each filename in Markdown link syntax in your own copy if you want clickable references — kept as plain backticked names here so the template stays portable.>
+- <Add project-specific pointers here. Wrap each filename in Markdown link syntax in your own copy if you want clickable references — kept as plain backticked names here so the template stays portable. **One path per bullet** — comma-listing siblings (`a.md`, `b.md`, `c.md` on one line) defeats the verification grep at the bottom of this guide; expand them into separate bullets even if they share a category.>
 
 ## 2. Decisions snapshot (pointer)
 
@@ -67,10 +67,10 @@ Per-event history: `CHANGELOG.md`. Root-cause post-mortems: `LESSONS.md`.
 
 ## 3. Live backlog
 
-**The only place backlog is maintained.** Stale items are deleted, not archived.
+**The only place backlog is maintained.** Stale items are deleted from day 1 — once a §3 item is captured in a changelog entry, ADR, or the §2 decisions snapshot, **delete** it from the backlog the same day. Do not let §3 become a done-list — that responsibility belongs to your changelog or detail file. The "stale" threshold is _exists in canonical form elsewhere_, not _more than N days old_. The `[x] ~~<shipped>~~` example below is illustrative only; in practice the row gets deleted once the canonical record exists.
 
 - [ ] <Active backlog item — what + where + blocker if any>
-- [x] ~~<Shipped item, with date + source link>~~
+- [x] ~~<Shipped item, with date + source link — delete this row once it lands in CHANGELOG or §2>~~
 
 ## 4. Current state — save point
 
@@ -107,11 +107,25 @@ To keep `SPEC.md` honest without remembering, add this to the project's `CLAUDE.
 
 1. Update `SPEC.md` §4 (Current state) — what changed, what's next, last-updated timestamp
 2. Update `SPEC.md` §3 (Backlog) — check off completed items, add new ones surfaced
-3. Update data contracts in the file referenced from `SPEC.md` §1 if any interface changed
+3. Update the relevant pointer-target file from `SPEC.md` §1 if any operational fact changed (data contracts, runbooks, server state, changelog entries, etc. — whatever the §1 pointers actually point to in your repo archetype)
 4. Never claim "done" without updating `SPEC.md` first
 ```
 
 **Plugin does not enforce this.** Same boundary as the feature-spec mode auto-update recipe ([`persistence-convention.md`](./persistence-convention.md#auto-update-recipe-user-side-optional)) — the plugin teaches the pattern; the user owns enforcement via their own CLAUDE.md rule.
+
+## Adopting alongside doc-blocker hooks
+
+If your repo runs a PreToolUse hook that blocks `.md` file operations (e.g. policies preventing untracked planning-doc sprawl), §4 save-point updates will collide with the hook on every task. The hook category typically conflates two distinct operations:
+
+- **Create-new** `.md` file (`Write` to a path that does not yet exist or is not git-tracked) — what the hook is meant to prevent
+- **Edit-tracked** `.md` file (`Write`/`Edit` against a committed path) — legitimate SPEC.md updates, CHANGELOG entries, runbook revisions
+
+Two postures:
+
+1. **Allowlist `SPEC.md` specifically in the hook config** — quickest fix, but a per-file allowlist doesn't scale across other doc-update workflows (`current-state.md`, CHANGELOG entries, runbook revisions, ADR drafts) that share the same friction shape.
+2. **Wait for / upgrade to a hook that distinguishes Write-new vs Edit-tracked** — the architectural fix lives in the hook layer (runtime enforcement), not in this guide (workflow discipline). Tracked at [pitimon/claude-governance#34](https://github.com/pitimon/claude-governance/issues/34).
+
+Adopters with hardened doc-blocker hooks: expect this friction until the hook ecosystem catches up. The discipline lives here; the runtime fix belongs in `claude-governance` per the plugin boundary.
 
 ## What this pattern is NOT
 
@@ -156,13 +170,22 @@ To verify a `SPEC.md` follows this pattern:
 grep -E '^## [1-4]\.' SPEC.md | wc -l   # expect 4
 
 # Save-point hint present in §4?
-grep -A1 '## 4. Current state' SPEC.md | grep -i 'clear.*compact'
+# (awk range — robust against blank-line-after-heading per markdownlint MD022;
+# the older `grep -A1` would miss the hint if your §4 has the standard blank line)
+awk '/^## 4\. Current state/,/^## /' SPEC.md | grep -i 'clear.*compact'
 
 # Last-updated timestamp present?
 grep -E 'Last updated' SPEC.md
 
-# Pointers actually resolve?
+# Pointers actually resolve? (bracket-paren link syntax for backticked label)
 grep -oE '\]\([^)]+\.md\)' SPEC.md | sed 's/[])(]//g' | xargs -I{} ls {}
+
+# Pointers actually resolve? (Backtick syntax — `path.md`; the template default)
+# Carve-out: paths starting with `/` are treated as documentation references
+# (remote-only paths in ops repos), not local files. One path per backtick-span.
+grep -oE '`[^`]+\.(md|sh|py|yaml|yml|json)`' SPEC.md | sed 's/`//g' | sort -u | while read p; do
+  if [ -e "$p" ] || [[ "$p" =~ ^/ ]]; then echo "OK    $p"; else echo "MISS  $p"; fi
+done
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes 6 of 7 items from [issue #197](https://github.com/pitimon/8-habit-ai-dev/issues/197) — Adopter #2 report on the v2.15.9 spec-digest pattern from `claude-all/netbird-sit` (ops/infra archetype). Item 4 architectural fix (PreToolUse hook should distinguish Write vs Edit on `.md` files) is split to [pitimon/claude-governance#34](https://github.com/pitimon/claude-governance/issues/34) — runtime enforcement belongs there per plugin boundary.

## Fixes

| # | Item | Change |
|---|---|---|
| 2.1 | Bug — `grep -A1` false-negative on standard markdown blank-line-after-heading | Replace with awk range scan (robust against MD022) |
| 2.2 | Bug — verification command misses backtick-wrapped paths (template default) | Add companion grep with `/`-prefix carve-out for ops repos referencing remote paths |
| 2.3 | Bug — comma-listed siblings defeat the verification grep | Explicit \"one path per bullet\" guidance in §1 template |
| 3 | Enhancement — \"stale items deleted\" needs explicit day-1 definition | Define stale as \"exists in canonical form elsewhere\", not \"more than N days old\". Day-1 deletion rule prevents §3 from drifting into a done-list |
| 5 | Enhancement — recipe step 3 wording is feature-spec-flavoured | Generalize from \"data contracts\" to \"pointer-target file from §1 if any operational fact changed\" — covers data contracts, runbooks, server state, changelog |
| 4(c) | Stop-gap — doc-blocker hook friction | NEW section \"Adopting alongside doc-blocker hooks\" naming the Write-new vs Edit-tracked conflation + cross-reference to pitimon/claude-governance#34 |

## Out of scope (handled elsewhere)

- **Item 4 architectural fix** — opened as [pitimon/claude-governance#34](https://github.com/pitimon/claude-governance/issues/34). The hook layer is the right place for the Write-vs-Edit distinction.
- **Promotion to `/save-spec` skill** — `n≥2 adoption` criterion is now met (netbox-sit + netbird-sit) and adoption-friction criterion has evidence (this PR). Scope-conflict criterion is implicitly resolved by Adopter #2 (\"both adopt project-orientation mode without using `--persist`; the two modes serve different repos\"), but should be documented in writing before promotion. Defer to a follow-up issue.

## Test plan

- [x] `validate-structure.sh` 256/256 PASS
- [x] `validate-content.sh` 216 PASS / 0 FAIL / 1 WARN / 0 fitness breaches (after fixing one self-induced Check 12b false-positive — a markdown-link example in a code comment, ironic given that's exactly what the user reported in item 2.2)
- [ ] CI green
- [ ] Reviewer reads the new \"Adopting alongside doc-blocker hooks\" section and confirms the plugin-boundary framing reads cleanly

## Habit mapping

- **H5 (Seek First to Understand)** — every fix maps to an explicit cited line in #197 + the user's own verbatim suggestions where they supplied them (items 3, 5, and the companion grep in 2.2)
- **H4 (Win-Win)** — every fix improves the next adopter's experience; cross-reference to claude-governance#34 leaves a paper trail for future hook-aware adopters
- **H8 (Voice/Conscience)** — split into two PRs/issues at the plugin boundary rather than gluing a hook-aware allowlist into the guide

Refs #197, pitimon/claude-governance#34