### PR TITLE
docs: refresh README + wiki for current state (23 skills, v2.18.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-7C3AED)](https://github.com/pitimon/8-habit-ai-dev)
-[![Skills](https://img.shields.io/badge/Skills-22-blue)]()
+[![Skills](https://img.shields.io/badge/Skills-23-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
 [![Version](https://img.shields.io/badge/Version-2.18.1-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.18.1)
@@ -12,7 +12,7 @@
 
 > **"ทำเสร็จ ≠ ทำดี"** — Shipping code is not the same as shipping _good_ code.
 >
-> AI coding tools are powerful — but "build me X" without requirements, review, or staging creates fast, fragile code. This plugin adds the discipline AI lacks: **17 skills** across a **7-step workflow**, grounded in **Covey's 8 Habits** of effective development.
+> AI coding tools are powerful — but "build me X" without requirements, review, or staging creates fast, fragile code. This plugin adds the discipline AI lacks: **23 skills** across a **7-step workflow**, grounded in **Covey's 8 Habits** of effective development.
 
 ---
 
@@ -28,7 +28,7 @@
 
 - [Design Principle](#design-principle) — Thin harness, fat skills
 - [7-Step Workflow](#the-7-step-workflow) — Visual pipeline from research to monitoring
-- [Skills Reference](#skills-reference) — All 17 skills with habit mappings
+- [Skills Reference](#skills-reference) — All 23 skills with habit mappings
 - [Use Cases](#use-cases-which-skill-when) — Common scenarios and recommended paths
 - [The 8 Habits](#the-8-habits) — Principles behind the workflow
 - [Maturity Model](#the-maturity-model) — Dependence to Significance
@@ -100,7 +100,7 @@ claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev
 
 **New to the plugin?** Start with `/workflow` for a guided walkthrough, or see [Use Cases](#use-cases-which-skill-when) to find the right skill for your situation.
 
-Two commands to install. The plugin loads a session reminder and makes 17 skills available.
+Two commands to install. The plugin loads a session reminder and makes 23 skills available.
 
 ---
 
@@ -148,7 +148,7 @@ You don't need all steps every time. Start with **`/requirements` before buildin
 | `/reflect`            | H7: Sharpen the Saw | 5-question micro-retrospective (5 min max) with action tracking                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `/workflow`           | All                 | Guided 7-step walkthrough — invoke or skip each step                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `/calibrate`          | H8: Find Your Voice | Self-assessment (5-7 questions) → writes `~/.claude/habit-profile.md` so other skills adapt verbosity to your maturity level                                                                                                                                                                                                                                                                                                                                                                 |
-| `/using-8-habits`     | H5 + H8             | Onboarding meta-skill — all 17 skills + decision tree for "which skill next?"                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `/using-8-habits`     | H5 + H8             | Onboarding meta-skill — all 23 skills + decision tree for "which skill next?"                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `/eu-ai-act-check`    | H1 + H8 (Spirit)    | Redirect stub — migrated to [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) v3.1.0+ on 2026-05-02 (ADR-012). Install that plugin for the canonical 9-obligation checklist.                                                                                                                                                                                                                                                                                       |
 | `/ai-dev-log`         | H4 + H1             | Generate AI-assisted dev log from git history for audit trail                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `/save-spec`          | H8 + H2             | **Deployment-mode helper (not a workflow step)** — scaffold a project-root `SPEC.md` digest when the repo fits the project-orientation hub mode. Generator-only Phase 1 (v2.16.0); refuses to overwrite. **Skip if you already have a memory-MCP + short `CLAUDE.md`** (v2.16.4 — see `/save-spec` "When to Skip" for details)                                                                                                                                                               |
@@ -327,7 +327,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 ├── .claude-plugin/
 │   ├── plugin.json                 # Plugin metadata (v2.15.0)
 │   └── marketplace.json            # Marketplace listing
-├── skills/                         # 18 skills (8 workflow + 10 standalone)
+├── skills/                         # 23 skills (8 workflow + 15 standalone)
 │   ├── research/SKILL.md           #   Step 0 → H5 (depth levels + modes)
 │   ├── requirements/SKILL.md       #   Step 1 → H2
 │   ├── design/SKILL.md             #   Step 2 → H8
@@ -900,7 +900,7 @@ Every habit in this plugin exists because **skipping it caused real damage**.
 
 ## FAQ
 
-**Q: Do I need to use all 17 skills for every task?**
+**Q: Do I need to use all 23 skills for every task?**
 No. Start with `/requirements` before building and `/review-ai` before committing. Those two alone eliminate most Vibe Coding problems. Add more skills as they feel natural. See [Use Cases](#use-cases-which-skill-when).
 
 **Q: What is "Vibe Coding"?**

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -39,7 +39,7 @@ Responsibilities:
 
 ### Layer 3: Skills (on-demand)
 
-17 skills in `skills/*/SKILL.md`, loaded only when the user invokes them (e.g., `/requirements`, `/design`). Each skill has YAML frontmatter:
+23 skills in `skills/*/SKILL.md`, loaded only when the user invokes them (e.g., `/requirements`, `/design`). Each skill has YAML frontmatter:
 
 ```yaml
 ---

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,4 +1,4 @@
-![Version](https://img.shields.io/badge/version-2.10.0-blue) ![Skills](https://img.shields.io/badge/skills-17-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange) ![Review](https://img.shields.io/badge/external_review-9.5%2F10-gold)
+![Version](https://img.shields.io/badge/version-2.18.1-blue) ![Skills](https://img.shields.io/badge/skills-23-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange) ![Review](https://img.shields.io/badge/external_review-9.5%2F10-gold)
 
 # 8-Habit AI Dev
 
@@ -16,9 +16,9 @@ AI-assisted coding is fast but often undisciplined: missing requirements, skippe
 
 |                       |                                                                                                           |
 | --------------------- | --------------------------------------------------------------------------------------------------------- |
-| **17 skills**         | 7 workflow + 5 assessment + 2 meta + 2 compliance + 1 orchestrator                                        |
+| **23 skills**         | 8 workflow + 5 assessment + 3 meta + 2 debug + 2 compliance + 3 helpers (orchestrator/spec/audience)      |
 | **8 Habits**          | Covey's 7 + The 8th, adapted for AI-assisted development                                                  |
-| **9 ADRs**            | Every non-trivial decision documented                                                                     |
+| **17 ADRs**           | Every non-trivial decision documented                                                                     |
 | **4 maturity levels** | [Dependence → Independence → Interdependence → Significance](Maturity-Model)                              |
 | **Zero dependencies** | Pure markdown — no npm, no build step                                                                     |
 | **EU AI Act ready**   | First Claude Code plugin with [compliance toolkit](Skills-Reference#compliance--audit-skills)             |
@@ -72,13 +72,29 @@ Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
 
 **Assessment** — run at any point for deeper analysis:
 
-| Skill                                                        | Purpose                                         |
-| ------------------------------------------------------------ | ----------------------------------------------- |
-| [`/cross-verify`](Skills-Reference#cross-verify)             | 17-question 8-Habit checklist                   |
-| [`/whole-person-check`](Skills-Reference#whole-person-check) | Body/Mind/Heart/Spirit balance                  |
-| [`/security-check`](Skills-Reference#security-check)         | OWASP Top 10 focused review                     |
-| [`/reflect`](Skills-Reference#reflect)                       | Post-task retrospective with lesson persistence |
-| [`/workflow`](Skills-Reference#workflow)                     | Interactive guided walkthrough                  |
+| Skill                                                        | Purpose                                                        |
+| ------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/cross-verify`](Skills-Reference#cross-verify)             | 17-question 8-Habit checklist                                  |
+| [`/whole-person-check`](Skills-Reference#whole-person-check) | Body/Mind/Heart/Spirit balance                                 |
+| [`/security-check`](Skills-Reference#security-check)         | OWASP Top 10 focused review                                    |
+| [`/scrutinize`](Skills-Reference#scrutinize)                 | Outsider-perspective review — questions if change should exist |
+| [`/consistency-check`](Skills-Reference#consistency-check)   | Cross-artifact drift detection (PRD ↔ design ↔ tasks)          |
+| [`/reflect`](Skills-Reference#reflect)                       | Post-task retrospective with lesson persistence                |
+| [`/workflow`](Skills-Reference#workflow)                     | Interactive guided walkthrough                                 |
+
+**Debug Discipline** — active investigation + post-fix record:
+
+| Skill                                          | Purpose                                                |
+| ---------------------------------------------- | ------------------------------------------------------ |
+| [`/diagnose`](Skills-Reference#diagnose)       | 6-phase active bug investigation (feedback-loop first) |
+| [`/post-mortem`](Skills-Reference#post-mortem) | Canonical RCA writeup after a validated fix lands      |
+
+**Spec & Communication** — helpers orthogonal to the 7-step workflow:
+
+| Skill                                                  | Purpose                                          |
+| ------------------------------------------------------ | ------------------------------------------------ |
+| [`/save-spec`](Skills-Reference#save-spec)             | Scaffold project-root SPEC.md orientation hub    |
+| [`/management-talk`](Skills-Reference#management-talk) | Reshape engineer content for leadership channels |
 
 **Meta & Onboarding** — learn and adapt:
 
@@ -107,7 +123,7 @@ Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
 ## Reference
 
 - **[8 Habits](Habits-Reference)** — the full playbook
-- **[Skills Catalog](Skills-Reference)** — all 17 skills, when to use each
+- **[Skills Catalog](Skills-Reference)** — all 23 skills, when to use each
 - **[Architecture](Architecture)** — how the plugin works internally
 - **[Maturity Model](Maturity-Model)** — adaptive guidance levels
 - **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)** — side-by-side comparison

--- a/docs/wiki/Maturity-Model.md
+++ b/docs/wiki/Maturity-Model.md
@@ -66,7 +66,7 @@ The adaptation happens at session start, not per-skill:
 
 1. `hooks/session-start.sh` reads `~/.claude/habit-profile.md`
 2. Emits a level-specific directive into session context
-3. All 17 skills automatically adapt their verbosity — **zero per-skill changes needed**
+3. All 23 skills automatically adapt their verbosity — **zero per-skill changes needed**
 
 This means a single calibration affects every skill invocation for the rest of the session. The canonical adaptation rules are in [`guides/verbosity-adaptation.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/verbosity-adaptation.md).
 

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,6 +1,6 @@
 # Skills Catalog
 
-All **17 skills** shipped with `8-habit-ai-dev` v2.10.0. Skills are **read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves.
+All **23 skills** shipped through `8-habit-ai-dev` v2.18.1. Skills are **read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves.
 
 > [!TIP]
 > Not sure which skill to use? Type `/using-8-habits` for an interactive decision tree, or see the [quick-select matrix](#quick-select-matrix) below.
@@ -46,6 +46,22 @@ Focused security review — secrets, injection, auth, dependencies, OWASP Top 10
 - **When to use**: Any change touching user input, auth, data handling, or dependencies
 - **Source**: [`skills/security-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/security-check/SKILL.md)
 
+### `/scrutinize` {#scrutinize}
+
+Outsider-perspective end-to-end review — questions intent first ("is there a simpler way?"), then traces the actual code path (not just the diff) to verify the change does what it claims. Pairs with `/review-ai` (scope-question vs diff-local). Operating Rules hardened in v2.18.1 (ADR-017) with MUST/NEVER + Why blocks.
+
+- **Habit**: H5 Understand First + H8 Find Your Voice
+- **When to use**: Before committing to an implementation, or before merging a PR alongside `/review-ai`
+- **Source**: [`skills/scrutinize/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/scrutinize/SKILL.md)
+
+### `/consistency-check` {#consistency-check}
+
+Cross-artifact consistency analyzer — runs 5 detection passes (Coverage, Drift, Ambiguity, Underspec, Inconsistency) across persisted spec artifacts (PRD ↔ design ↔ tasks). Read-only — reports drift, coverage gaps, contradictions. Inspired by github/spec-kit `/analyze`.
+
+- **Habit**: H5 Understand First + H1 Be Proactive
+- **When to use**: After `/requirements`, `/design`, `/breakdown` have been run with `--persist <slug>` to catch drift before code
+- **Source**: [`skills/consistency-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/consistency-check/SKILL.md)
+
 ### `/reflect` {#reflect}
 
 Post-task micro-retrospective — 6 questions, 5 minutes. Captures lessons to `~/.claude/lessons/` for future retrieval by `/research` and `/build-brief`. Includes skill-effectiveness signal (Q6) feeding `SKILL-EFFECTIVENESS.md`.
@@ -62,13 +78,53 @@ Interactive guided walkthrough of the 7-step workflow. Prompts at each step to i
 - **When to use**: Starting a new feature when you're unsure which step comes next
 - **Source**: [`skills/workflow/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/workflow/SKILL.md)
 
+## Debug Discipline Skills
+
+Active bug investigation and post-fix engineering record. Ported from prior-art (mattpocock/skills, 9arm-skills) per ADR-014 + ADR-015.
+
+### `/diagnose` {#diagnose}
+
+6-phase active bug investigation methodology — feedback-loop → reproduce → hypothesise → instrument → fix-with-regression-test → cleanup. Closes the gap between `/research` (too broad) and `/post-mortem` (too late). Phase 6 hardened in v2.18.1 (ADR-017) with MUST re-run Phase 1 feedback loop, citing Anthropic pptx.
+
+- **Habit**: H1 Be Proactive + H5 Understand First
+- **When to use**: When a bug needs to be fixed and the cause isn't obvious from stack trace; hands off to `/post-mortem` once fix lands
+- **Source**: [`skills/diagnose/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/diagnose/SKILL.md)
+
+### `/post-mortem` {#post-mortem}
+
+Engineering RCA writeup — canonical record of a fixed bug (root cause, mechanism, fix, validation, how it slipped through). Refuses to draft without 4 inputs (reliable repro, known cause, identified fix, validated outcome).
+
+- **Habit**: H4 Win-Win + H7 Sharpen the Saw
+- **When to use**: AFTER a debug session lands a validated fix, BEFORE closing the ticket
+- **Source**: [`skills/post-mortem/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/post-mortem/SKILL.md)
+
+## Spec & Communication Skills
+
+Helpers for project orientation and audience reshape — orthogonal to the 7-step workflow.
+
+### `/save-spec` {#save-spec}
+
+Scaffolds a project-root `SPEC.md` digest following the spec-digest-pattern archetype (project orientation hub). User-invoked. Generator-only Phase 1; refuses to overwrite an existing SPEC.md. Distinct from per-feature `/requirements --persist <slug>` mode.
+
+- **Habit**: H2 Begin with End in Mind + H5 Understand First
+- **When to use**: When starting on an unfamiliar repo or after a `/clear` flushing pain — gives Claude a 4-section orientation hub
+- **Source**: [`skills/save-spec/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/save-spec/SKILL.md)
+
+### `/management-talk` {#management-talk}
+
+Channel-aware audience reshape — converts engineer-to-engineer content into leadership-channel-shaped form (JIRA / Slack / standup / email / meeting). Strips function/file/SHA noise but keeps JIRA keys, PR numbers, workload names. Inspired by 9arm-skills (v2.17.0).
+
+- **Habit**: H4 Win-Win + H6 Synergize
+- **When to use**: When VPs, directors, PMs, or release managers need a status — and your raw engineering notes are too dense
+- **Source**: [`skills/management-talk/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/management-talk/SKILL.md)
+
 ## Meta & Onboarding Skills
 
 Learn the plugin and adapt it to your style.
 
 ### `/using-8-habits` {#using-8-habits}
 
-Onboarding meta-skill — explains the 8 habits, all 17 skills, and provides a decision tree for "which skill next?". Includes a complete walkthrough example (password-reset feature).
+Onboarding meta-skill — explains the 8 habits, all 23 skills, and provides a decision tree for "which skill next?". Includes a complete walkthrough example (password-reset feature).
 
 - **Habit**: H5 Understand First + H8 Find Your Voice
 - **When to use**: First time using the plugin, or when unsure which skill applies
@@ -106,20 +162,26 @@ Generates an AI-assisted development log from `git log` + `Co-Authored-By` trail
 
 ## Quick-Select Matrix
 
-| I need to...                          | Use                                                                    |
-| ------------------------------------- | ---------------------------------------------------------------------- |
-| Start a new feature from scratch      | [`/workflow`](#workflow) or [`/requirements`](#7-step-workflow-skills) |
-| Understand this plugin                | [`/using-8-habits`](#using-8-habits)                                   |
-| Adjust guidance verbosity             | [`/calibrate`](#calibrate)                                             |
-| Research before deciding              | [`/research`](Step-0-Research)                                         |
-| Review AI-generated code              | [`/review-ai`](Step-5-Review-AI)                                       |
-| Check all 8 habits at once            | [`/cross-verify`](#cross-verify)                                       |
-| Assess Body/Mind/Heart/Spirit balance | [`/whole-person-check`](#whole-person-check)                           |
-| Run a focused security review         | [`/security-check`](#security-check)                                   |
-| Check EU AI Act compliance            | [`/eu-ai-act-check`](#eu-ai-act-check)                                 |
-| Generate AI audit trail               | [`/ai-dev-log`](#ai-dev-log)                                           |
-| Capture lessons after a task          | [`/reflect`](#reflect)                                                 |
-| Deploy safely to production           | [`/deploy-guide`](Step-6-Deploy-Guide)                                 |
+| I need to...                             | Use                                                                    |
+| ---------------------------------------- | ---------------------------------------------------------------------- |
+| Start a new feature from scratch         | [`/workflow`](#workflow) or [`/requirements`](#7-step-workflow-skills) |
+| Understand this plugin                   | [`/using-8-habits`](#using-8-habits)                                   |
+| Adjust guidance verbosity                | [`/calibrate`](#calibrate)                                             |
+| Research before deciding                 | [`/research`](Step-0-Research)                                         |
+| Review AI-generated code                 | [`/review-ai`](Step-5-Review-AI)                                       |
+| Check all 8 habits at once               | [`/cross-verify`](#cross-verify)                                       |
+| Assess Body/Mind/Heart/Spirit balance    | [`/whole-person-check`](#whole-person-check)                           |
+| Run a focused security review            | [`/security-check`](#security-check)                                   |
+| Check EU AI Act compliance               | [`/eu-ai-act-check`](#eu-ai-act-check)                                 |
+| Generate AI audit trail                  | [`/ai-dev-log`](#ai-dev-log)                                           |
+| Capture lessons after a task             | [`/reflect`](#reflect)                                                 |
+| Deploy safely to production              | [`/deploy-guide`](Step-6-Deploy-Guide)                                 |
+| Question whether the change should exist | [`/scrutinize`](#scrutinize)                                           |
+| Catch drift between PRD↔design↔tasks     | [`/consistency-check`](#consistency-check)                             |
+| Investigate a bug from feedback-loop     | [`/diagnose`](#diagnose)                                               |
+| Write the engineering record post-fix    | [`/post-mortem`](#post-mortem)                                         |
+| Scaffold a project orientation hub       | [`/save-spec`](#save-spec)                                             |
+| Reshape engineer content for leadership  | [`/management-talk`](#management-talk)                                 |
 
 ## Skill Anatomy
 

--- a/docs/wiki/Workflow-Overview.md
+++ b/docs/wiki/Workflow-Overview.md
@@ -94,6 +94,6 @@ These skills complement the pipeline and can run at any point:
 
 ## See also
 
-- **[Skills Catalog](Skills-Reference)** — all 17 skills with when-to-use guidance
+- **[Skills Catalog](Skills-Reference)** — all 23 skills with when-to-use guidance
 - **[Habits Reference](Habits-Reference)**
 - **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)**


### PR DESCRIPTION
## Summary

Stale-reference sweep across 6 docs files. Previous content reflected v2.10.0 state (17 skills shipped April 2026) before the v2.13.0+ growth to 23 skills. This PR brings current-state references aligned with v2.18.1.

**No version bump** — docs-only refresh per ADR-016 C5 (SKILL.md files are not touched in this PR; the user-facing changes already shipped in v2.18.1).

## Files changed

| File | What changed |
|------|---|
| `README.md` | 7 sites: badge `Skills-22` → `Skills-23`, tagline / TOC / install description / `/using-8-habits` row / FAQ / repo structure tree |
| `docs/wiki/Home.md` | Badges + At-a-Glance breakdown ("17 skills" + "9 ADRs" → "23 skills" + "17 ADRs"); Skills Catalog link; **new Debug Discipline + Spec & Communication tables**; 2 new Assessment rows |
| `docs/wiki/Skills-Reference.md` | Header version (`v2.10.0` → `v2.18.1`); **6 new skill entries added** (`/scrutinize`, `/consistency-check`, `/diagnose`, `/post-mortem`, `/save-spec`, `/management-talk`); Quick-Select Matrix extended |
| `docs/wiki/Architecture.md` | Line 42: `17 skills` → `23 skills` |
| `docs/wiki/Maturity-Model.md` | Line 69: `All 17 skills` → `All 23 skills` |
| `docs/wiki/Workflow-Overview.md` | Line 97: `all 17 skills` → `all 23 skills` |

## Historical content preserved (intentionally)

README "What's New in v2.17.0" at line 484 still says "Plugin total: 22 skills" — that's a snapshot of what shipped at v2.17.0 (before `/diagnose` was added in v2.18.0). Same for "All 17 skills in 3 sections" in the v2.13.0 section at line 776. These are correct as historical record.

## Test plan

- [x] `bash tests/validate-structure.sh` → 357 PASS / 0 FAIL
- [x] `bash tests/validate-content.sh` → 257 PASS / 0 FAIL / 1 WARN / 0 fitness breaches
- [x] Stale-ref grep — only matches remaining are inside historical "What's New" sections (verified)
- [x] Specific-file staging (no `git add -A`)
- [ ] CI green (validate + linkcheck)
- [ ] Human review

## Why this matters

Wiki was significantly stale: `Skills-Reference.md` had not been updated since v2.10.0 (April 2026), missing 6 skills (`/scrutinize`, `/consistency-check`, `/save-spec`, `/diagnose`, `/post-mortem`, `/management-talk`). New users landing on the wiki would get an incomplete picture. README's `Skills-22` badge was wrong since v2.18.0 (when `/diagnose` made it 23).

Caught during post-v2.18.1 release audit prompted by maintainer. H4 (Win-Win) — the next person finding the wiki gets accurate information.