### PR TITLE
ADR-018 follow-ups: release checklist (#227), PR template (#225), CLAUDE.md audit (#226)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- 1-3 bullet points: what changed and why. -->
+
+## Test plan
+
+- [ ] `bash tests/validate-structure.sh` passes
+- [ ] `bash tests/validate-content.sh` passes (if content/wiki/links changed)
+- [ ] Related skill/agent invoked manually if behavior changed
+
+## Refs
+
+<!-- e.g. Refs #123, Closes #456 -->
+
+<details>
+<summary>Skill PR? Optional Falsifiable Contract fields (ADR-018 Edge #2)</summary>
+
+If this PR adds or substantially modifies a skill, fill these in so the next `SKILL-EFFECTIVENESS.md` review can validate the prediction. Optional — no runtime enforcement. Non-skill PRs ignore this section.
+
+- **predicted_uses**: brief list of session types or scenarios where this skill should help (e.g., "post-mortem of failed deploy", "new feature requirements gathering").
+- **validation_window**: number of sessions (default `30`) after which absence of citation in `/reflect` Q6 → `SKILL-EFFECTIVENESS.md` becomes a deprecation signal.
+- **risk_skills**: existing skills this might overlap or displace, if any.
+
+These fields feed the next [`SKILL-EFFECTIVENESS.md`](../SKILL-EFFECTIVENESS.md) tally review. See [ADR-018](../docs/adr/ADR-018-memory-layer-activation.md) for rationale (memory-layer activation, lightweight Falsifiable Contract per AHE paper). Automated validation/rollback belongs in `claude-governance` per plugin boundary.
+
+</details>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,96 +6,81 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A **Claude Code plugin** (not a runnable application). No build system, no dependencies — the entire plugin is structured markdown files that Claude Code loads at runtime. Structural validation via `tests/validate-structure.sh` (pure bash, no test framework). The plugin provides a 7-step workflow discipline based on Covey's 8 Habits, designed to replace "vibe coding" with structured AI-assisted development.
-
-**Install**: `claude plugin marketplace add pitimon/8-habit-ai-dev && claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev`
+A **Claude Code plugin** (not a runnable application). No build system, no dependencies — the entire plugin is structured markdown files that Claude Code loads at runtime. Structural validation via `tests/validate-structure.sh` (pure bash, no test framework). The plugin provides a 7-step workflow discipline based on Covey's 8 Habits, designed to replace "vibe coding" with structured AI-assisted development. Install: `claude plugin marketplace add pitimon/8-habit-ai-dev && claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev`.
 
 ## Architecture
 
 The plugin has three loading mechanisms with distinct timing:
 
 1. **`rules/effective-development.md`** — Auto-loaded into every Claude Code session (via Claude's rules system). Contains the full 8-Habit playbook with Rules, Anti-patterns, and Checkpoints per habit.
-2. **`hooks/session-start.sh`** — Runs at SessionStart (registered in `hooks/hooks.json`). Prints a ≤300-token reminder of the 7-step workflow. Must stay concise — this is injected into every conversation.
-3. **`skills/*/SKILL.md`** — Loaded on-demand when user invokes `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`, `/cross-verify`, `/consistency-check`, or `/calibrate`.
-
-**On-demand loading**: Skills reference habit content via `Load ${CLAUDE_PLUGIN_ROOT}/habits/h*.md` — the habit files are NOT loaded at session start. This keeps the token budget lean.
+2. **`hooks/session-start.sh`** — Runs at SessionStart (registered in `hooks/hooks.json`). Prints a ≤300-token reminder of the 7-step workflow.
+3. **`skills/*/SKILL.md`** — Loaded on-demand when user invokes a skill. Skills reference habit content via `Load ${CLAUDE_PLUGIN_ROOT}/habits/h*.md` — habit files are NOT loaded at session start. Keeps the token budget lean.
 
 ## Skill Authoring Conventions
 
-Each skill file (`skills/<name>/SKILL.md`) follows this structure:
+Each skill file (`skills/<name>/SKILL.md`) uses this frontmatter:
 
 ```yaml
 ---
 name: <skill-name> # Must match directory name
 description: > # Multi-line, explains when to use
-user-invocable: true # Always true for workflow skills
-argument-hint: "[description]" # Shown in skill list
-allowed-tools: ["Read", "Glob", "Grep"] # Bash only when needed (e.g., review-ai)
+user-invocable: true
+argument-hint: "[description]"
+allowed-tools: ["Read", "Glob", "Grep"] # Bash only when justified
 prev-skill: <skill-name|none|any> # Predecessor in 7-step chain
 next-skill: <skill-name|none|any> # Successor in 7-step chain
 ---
 ```
 
-Body pattern: Habit mapping → Process steps → Handoff → When to Skip → Definition of Done → H\* Checkpoint → Load directive.
+Body pattern: Habit mapping → Process steps → Handoff → When to Skip → Definition of Done → H\* Checkpoint → Load directive. Standalone skills use `any` for prev/next. See [ADR-009](docs/adr/ADR-009-skill-split-convention.md) for convention rationale.
 
-**Handoff protocol**: Each skill declares what it expects from its predecessor and what it produces for its successor. Standalone skills (cross-verify, whole-person-check) use `any` for both.
+## Key Conventions (cited)
 
-## Key Conventions
-
-- **Skills are read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves
-- **Bash tool is allowed in skills only when needed** — currently used by `review-ai`, `eu-ai-act-check`, `ai-dev-log`. New skills should default to `Read/Glob/Grep` only and add `Bash` only with justification
-- **`habits/`, `guides/`, `rules/` are reference content** — never generated or modified by skills
-- **Agent (`agents/8-habit-reviewer.md`)** uses model `sonnet` with read-only tools (`Read`, `Glob`, `Grep`) — it analyzes and reports, never edits
-- **Plugin metadata** lives in `.claude-plugin/plugin.json` (plugin config) and `.claude-plugin/marketplace.json` (marketplace listing)
-- **Lesson persistence** (v2.6.0): `/reflect` saves lesson files to `~/.claude/lessons/YYYY-MM-DD-<slug>.md`. `/research` and `/build-brief` search these before starting work. This closes the learning loop: reflect → persist → retrieve → apply
-- **Verbosity adaptation** (v2.7.0): `hooks/session-start.sh` reads `~/.claude/habit-profile.md` and emits a level-specific adaptation directive into session context. Zero per-skill changes — the directive shapes Claude's behavior at runtime for all subsequent skill invocations. Canonical rules in `guides/verbosity-adaptation.md`. 8-branch regression coverage in `tests/test-verbosity-hook.sh`. Respects existing `HABIT_QUIET=1` opt-out from ADR-006. Closes #96 (the reader half of the #90 calibrate loop)
-- **Session hook budget**: `hooks/session-start.sh` output must stay ≤300 tokens
-- **Version lives in 4 files** — must bump together: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` (badge + footer), and `SELF-CHECK.md` header. `tests/validate-structure.sh` enforces consistency across all four — CI will fail if any drifts.
+- **Session hook ≤300 tokens** — `hooks/session-start.sh` output budget (file header line 2). Compliance tracked in [ADR-005](docs/adr/ADR-005-eu-ai-act-compliance-toolkit.md) §"Session hook ≤300 tokens" check; relaxation discussed in [ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md).
+- **Version lives in 4 files** — `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` (badge + footer), `SELF-CHECK.md` header. Bumped together; `tests/validate-structure.sh` fails CI on drift. See [issue #106](https://github.com/pitimon/8-habit-ai-dev/issues/106) (the drift incident that motivated `SELF-CHECK.md` enforcement) and `CONTRIBUTING.md` §"Version Bumping".
+- **Lesson persistence** — `/reflect` saves lesson files to `~/.claude/lessons/YYYY-MM-DD-<slug>.md` (v2.6.0); `/research` and `/build-brief` search these before starting. Feedback loop activated in [ADR-018](docs/adr/ADR-018-memory-layer-activation.md) (memory-layer activation).
+- **Verbosity adaptation** — `hooks/session-start.sh` reads `~/.claude/habit-profile.md` and emits a level-specific directive into session context (v2.7.0). Closes [#96](https://github.com/pitimon/8-habit-ai-dev/issues/96) (reader half of the [#90](https://github.com/pitimon/8-habit-ai-dev/issues/90) `/calibrate` loop). Respects `HABIT_QUIET=1` opt-out from [ADR-006](docs/adr/ADR-006-audience-honesty-and-superpowers-deferral.md). Canonical rules in [`guides/verbosity-adaptation.md`](guides/verbosity-adaptation.md).
+- **Release checklist must include the SKILL-EFFECTIVENESS tally update** — anti-dormancy forcing function per [ADR-018](docs/adr/ADR-018-memory-layer-activation.md) §"Forward-Guardrail Sunset". See `CONTRIBUTING.md` §"Release Checklist" and [issue #227](https://github.com/pitimon/8-habit-ai-dev/issues/227). Skipping ≥2 cycles triggers ADR-018 reversal review.
 
 ## Plugin Boundary
 
-`8-habit-ai-dev` and [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) are **complementary by design** (see memory obs #233270, 2026-04-07, titled "Both Recommended for Maximum Coverage"). Do not duplicate features across plugins.
+`8-habit-ai-dev` and [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) are **complementary by design** (memory obs #233270, 2026-04-07). Do not duplicate features across plugins. Historical violations and their corrections are documented in [ADR-005](docs/adr/ADR-005-eu-ai-act-compliance-toolkit.md) and [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md) (EU AI Act toolkit migration).
 
-| Plugin                      | Domain                                                                                     | Examples                                                                                                                                                                                                                                                                                        |
-| --------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`8-habit-ai-dev`** (this) | Workflow **discipline** — how to develop well                                              | 7-step workflow, 8 Habits, Whole Person Model, `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`, `/cross-verify`, `/reflect`, `/calibrate` (user maturity), `/ai-dev-log` (transparency), `/security-check` (review lens) |
-| **`claude-governance`**     | Compliance **enforcement** + **frameworks** — blocking bad behavior + mapping to standards | PreToolUse secret-scanner hook (25 patterns), Three Loops Decision Model (ADR-002 consequence-based auth), OWASP DSGAI mapping (11 controls), EU AI Act compliance toolkit (planned v3.1.0+), `/governance-check`, `/spec-driven-dev`, `/create-adr`, `governance-reviewer` agent               |
+| Plugin                  | Domain                                              | Examples                                                                                                                     |
+| ----------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **`8-habit-ai-dev`**    | Workflow **discipline** — how to develop well       | 7-step workflow, 8 Habits, Whole Person Model, `/research`…`/monitor-setup`, `/cross-verify`, `/reflect`, `/calibrate`       |
+| **`claude-governance`** | Compliance **enforcement** + **framework mappings** | PreToolUse hooks, Three Loops Decision Model, OWASP DSGAI, EU AI Act, `/governance-check`, `/spec-driven-dev`, `/create-adr` |
 
-**Rule of thumb before adding a new feature here**:
-
-- If it's a **workflow step** or **discipline practice** → belongs here
-- If it's a **runtime hook** (PreToolUse, PostToolUse), **compliance framework mapping** (DSGAI, EU AI Act, SOC2, NIST, etc.), **enforcement gate** that blocks actions, or **formal decision-authorization model** → belongs in `claude-governance`
-- When uncertain, check both plugins' existing files first (`ls ~/claude-governance/skills/ ~/claude-governance/hooks/`) and search memory (`mem_search "plugin boundary"`)
-
-**Historical boundary violations (corrected)**: Issues #58 (PreToolUse secret blocker) and #60 (OWASP DSGAI mapping) were originally scoped here despite being enforcement/compliance concerns — closed as wrong-plugin on 2026-04-09. Issue #57 (EU AI Act toolkit) shipped here in v2.3.0 via PRs #65-70, then was identified as a boundary error; Path C hybrid migration will move it to `claude-governance` (tracked in pitimon/claude-governance#21) in a future v2.3.1 release. See ADR-005 (and the future ADR-006 once Stage B ships) for full rationale.
-
-**Users who want maximum coverage**: install both plugins together. They compose cleanly — no conflicts.
-
-**Cross-plugin specs** (defined here, implemented in `claude-governance`):
-
-- [`guides/habit-nudges.md`](guides/habit-nudges.md) (v2.6.0) — specification for proactive workflow nudges; hook implementation belongs in `claude-governance`. Catalog of 6 nudges with triggers, cooldowns, and opt-out via `HABIT_QUIET=1`.
+**Rule of thumb**: workflow step or discipline practice → here. Runtime hook, compliance framework mapping, enforcement gate, or formal decision-authorization model → `claude-governance`. When uncertain: `ls ~/claude-governance/skills/ ~/claude-governance/hooks/` and `mem_search "plugin boundary"`. Cross-plugin specs (defined here, implemented there) live alongside their owners — e.g., [`guides/habit-nudges.md`](guides/habit-nudges.md) (v2.6.0 spec, hook implementation in `claude-governance`).
 
 ## Skills → Habits Mapping
 
-> For phrase-based lookup ("given these words, which skill?"), see [`skills/RESOLVER.md`](skills/RESOLVER.md). The table below indexes by workflow step; RESOLVER indexes by user intent.
+> For phrase-based lookup ("given these words, which skill?"), see [`skills/RESOLVER.md`](skills/RESOLVER.md). The table below indexes by workflow step.
 
-| Skill                 | Step | Habit                 | Purpose                                                                                                                                                 |
-| --------------------- | ---- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                                           |
-| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                                             |
-| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                                              |
-| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                                            |
-| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                                                |
-| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                                                     |
-| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready                                                                                                                           |
-| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                                                 |
-| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                                               |
-| `/consistency-check`  | —    | H5 + H1               | Cross-artifact analyzer — 5 detection passes (Coverage, Drift, Ambiguity, Underspec, Inconsistency) over persisted PRD↔design↔tasks (v2.15.0, ADR-013)  |
-| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                                           |
-| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                                                  |
-| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                                          |
-| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation tiered checklist (v2.3.0, migrating to claude-governance)                                                                        |
-| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                                           |
-| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question post-task retrospective + persistent lesson file (`~/.claude/lessons/`) + skill-effectiveness signal (v2.6.1, Q6 → `SKILL-EFFECTIVENESS.md`) |
-| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` so other skills adapt verbosity to maturity level (v2.6.0)                                               |
-| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                                               |
+| Skill                 | Step | Habit                 | Purpose                                                                                                                         |
+| --------------------- | ---- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                   |
+| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                     |
+| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                      |
+| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                    |
+| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                        |
+| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                             |
+| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready                                                                                                   |
+| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                         |
+| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                       |
+| `/consistency-check`  | —    | H5 + H1               | Cross-artifact analyzer (v2.15.0, [ADR-013](docs/adr/ADR-013-spec-persistence-opt-in.md))                                       |
+| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                   |
+| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                          |
+| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                  |
+| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation checklist (migrating per [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md))                  |
+| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                   |
+| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question retrospective + lesson file + Q6 → `SKILL-EFFECTIVENESS.md` ([ADR-018](docs/adr/ADR-018-memory-layer-activation.md)) |
+| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` ([ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md))                |
+| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                       |
+
+## Proposed (awaiting evidence)
+
+Rules below have no traceable lesson, ADR, or memory obs ID yet. Per [ADR-018](docs/adr/ADR-018-memory-layer-activation.md) "Earn each line" discipline and [ADR-016](docs/adr/ADR-016-t2-bag-drop-date-eviction-policy.md) eviction convention: **drop date 2026-11-24**. If no citation accumulates by then, the rule is dropped (soft fail, not silent deletion). If a lesson cites the rule, ratchet back into "Key Conventions" with the citation.
+
+- **Bash tool minimization in skills** — new skills default to `Read/Glob/Grep` only; Bash is added only with justification. Currently used by `/review-ai`, `/eu-ai-act-check`, `/ai-dev-log`. Rationale is least-privilege but no failure mode has been recorded.
+- **Reference directories are skill-immutable** — `habits/`, `guides/`, `rules/` are reference content; skills must never generate or modify them. No incident has been recorded of a skill attempting this; rule stands on convention alone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,17 @@ Version lives in **4 files** — all must be bumped together:
 
 `tests/validate-structure.sh` enforces consistency across all four — CI fails if any drifts. See [issue #106](https://github.com/pitimon/8-habit-ai-dev/issues/106) for the drift incident that motivated the SELF-CHECK.md addition.
 
+## Release Checklist
+
+Before bumping the version files above and tagging a release, run through this list. Each item is a forcing function against drift — skipping any item is how dormancy starts (see ADR-018 §"Context" for the 13-month dormancy precedent that motivated this checklist).
+
+- [ ] Run [`SKILL-EFFECTIVENESS.md`](SKILL-EFFECTIVENESS.md) tally update per its §"Maintainer update protocol" — grep Q6 across new lessons since last tally, increment counters, refresh `Last updated` + `Lessons analyzed`, note any new trends or zero-signal skills. ADR-018 Edge #1, anti-dormancy mechanism per issue [#227](https://github.com/pitimon/8-habit-ai-dev/issues/227).
+- [ ] CHANGELOG entry added (or explicitly marked doctrine-only per ADR-017 §C5).
+- [ ] Version bumped in all 4 files (see "Version Bumping" above) — `tests/validate-structure.sh` will fail CI if any drifts.
+- [ ] `README.md` "What's New" mentions the bumped version (Check 19 enforces this).
+
+**ADR-018 reversal trigger**: if the SKILL-EFFECTIVENESS tally is not updated for ≥2 release cycles, ADR-018 itself enters reversal review per its Forward-Guardrail Sunset criteria. This checklist's existence is part of the proof-of-life mechanism.
+
 ## Quality Checklist
 
 Before submitting:

--- a/docs/adr/ADR-018-memory-layer-activation.md
+++ b/docs/adr/ADR-018-memory-layer-activation.md
@@ -111,18 +111,18 @@ A secondary finding: **"Earn each line"** prescription from the corpus (rules mu
 
 ### Deferred to follow-up PRs (Edges #2, #3 — ADR records the decision, execution is separate work)
 
-- [ ] PR template includes `predicted_uses` and `validation_window` fields documented as optional, with example. **Filed as issue** before merge.
-- [ ] `CLAUDE.md` main body ≤ 80 lines (excluding `Proposed` section). **Filed as issue** before merge.
-- [ ] Each rule in CLAUDE.md main body cites a lesson, ADR, or memory obs ID. **Filed as issue** before merge.
-- [ ] Next release PR checklist includes "Run SKILL-EFFECTIVENESS tally update." **Filed as issue** before merge.
+- [x] PR template includes `predicted_uses` and `validation_window` fields documented as optional, with example. Shipped via [#225](https://github.com/pitimon/8-habit-ai-dev/issues/225) → `.github/PULL_REQUEST_TEMPLATE.md`.
+- [x] `CLAUDE.md` main body ≤ 80 lines (excluding `Proposed` section). Shipped via [#226](https://github.com/pitimon/8-habit-ai-dev/issues/226) (80 lines exact, 2 uncited rules moved to Proposed with 2026-11-24 drop date).
+- [x] Each rule in CLAUDE.md main body cites a lesson, ADR, or memory obs ID. Shipped via [#226](https://github.com/pitimon/8-habit-ai-dev/issues/226).
+- [x] Next release PR checklist includes "Run SKILL-EFFECTIVENESS tally update." Shipped via [#227](https://github.com/pitimon/8-habit-ai-dev/issues/227) → `CONTRIBUTING.md` §"Release Checklist".
 
 ### PR completion checklist (this merge)
 
 - [x] Lesson file dogfooded (`~/.claude/lessons/2026-05-24-notebook-agent-harness-audit-adr018.md` saved — Edge #1 hypothesis tested on live session before ADR ratification).
 - [x] INDEX.md updated additively (43 lessons, 8-habit-ai-dev project section 10 → 11).
 - [x] ADR Validation section marks Edge #1 as ratified by output (not just promised).
-- [ ] Follow-up issues filed for Edges #2-3 + release-checklist note.
-- [ ] CHANGELOG entry added if doctrine-only commits warrant it (per ADR-017 §C5 doctrine compliance rule).
+- [x] Follow-up issues filed for Edges #2-3 + release-checklist note (issues #225, #226, #227 — all closed in the follow-up PR).
+- [x] CHANGELOG entry added if doctrine-only commits warrant it (decision: doctrine-only per ADR-017 §C5, no entry — recorded for PR #224 and reaffirmed for the #225-227 follow-up PR).
 
 ## Forward-Guardrail Sunset (per ADR-017 convention)
 


### PR DESCRIPTION
## Summary

ADR-018 Edges #2 and #3 follow-ups + the anti-dormancy forcing function. Three issues, three per-issue commits. Doctrine-only per ADR-017 §C5 — no CHANGELOG entry, no version bump.

- **#227 — `CONTRIBUTING.md` §"Release Checklist"**: tally-update line is now a checkbox in the release ceremony. Skipping ≥2 cycles triggers ADR-018 reversal review per its Forward-Guardrail Sunset criteria. Anti-dormancy forcing function — directly prevents the 13-month dormancy that triggered the audit.
- **#225 — `.github/PULL_REQUEST_TEMPLATE.md` (new)**: standard Summary / Test plan / Refs sections plus a collapsible "Skill PR?" block with `predicted_uses`, `validation_window`, `risk_skills` fields. Non-skill PRs unaffected (block is collapsed, fields explicitly optional). No runtime enforcement — automated validation belongs in `claude-governance` per plugin boundary.
- **#226 — `CLAUDE.md` Earn-each-line audit, 101 → 80 lines main body**: every behavioral rule now cites a lesson file, ADR, issue, or memory obs ID. Two uncited rules ("Bash tool minimization in skills", "Reference directories are skill-immutable") moved to a new "Proposed (awaiting evidence)" section with 2026-11-24 drop date per ADR-016 — soft fail, not deletion.
- **ADR-018 Validation checklist**: all four deferred `[ ]` items flipped to `[x]` with shipping references — the ADR's own record is now in sync with reality.

### Discrimination call-out for reviewers (re: #226)

Three lines from the old "Key Conventions" were trimmed (not moved to Proposed) because they describe **what the plugin IS**, not behavioral rules: skills' read-only nature (enforced by `allowed-tools` YAML field), the agent's read-only configuration (lives in `agents/8-habit-reviewer.md` frontmatter), and where plugin metadata files live (described in CONTRIBUTING.md §"Version Bumping"). The information is preserved in those authoritative sources — they aren't subject to rule-citation discipline because they aren't rules. The Proposed/keep choice was reserved for actual behavioral instructions ("do X / don't do Y").

## Test plan

- [x] `bash tests/validate-structure.sh` → PASS 357, FAIL 0
- [x] `bash tests/validate-content.sh` → PASS 263, FAIL 0, FITNESS BREACHES 0
- [x] `wc -l CLAUDE.md` → 86 total; main body (lines 1–80) = 80 exact, satisfying ≤80 target
- [x] Three per-issue commits with `Closes #NNN` trailers
- [x] All ADR-018 Validation `[ ]` items flipped with shipping evidence

## Refs

Closes #225
Closes #226
Closes #227

Refs ADR-018 (`docs/adr/ADR-018-memory-layer-activation.md`)