### PR TITLE
fix(tests): guard validate-content.sh git tag call against non-git env (#233)

### DIFF
--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -651,7 +651,7 @@ else
   # — v2.13.0 footer said Previous: 2.7.1 + per-release list ended at v2.8.0 = 6 silent ships).
   # Source of truth: git tag -l "v2.*" (v1.x predates per-release convention; see CHANGELOG.md note).
   # Dev-env: no tags → WARN+skip (CI sets fetch-tags: true so drift still caught at merge).
-  all_tags=$(git tag -l "v2.*" 2>/dev/null | sort -V)
+  all_tags=$(git tag -l "v2.*" 2>/dev/null | sort -V || echo "")
   if [ -z "$all_tags" ]; then
     warn "git tag history unavailable — skipping SELF-CHECK.md body freshness (sub-checks E + F). CI sets fetch-tags: true."
   else


### PR DESCRIPTION
## Summary

One-line guard fix at `tests/validate-content.sh:654`. Adds `|| echo ""` after the `sort -V` so the `git tag -l` exit 128 in non-git environments can't propagate through `pipefail` and abort the script before the intended WARN-and-skip fallback at lines 655-656.

Closes #233.

## Root cause (verbatim from issue)

`set -euo pipefail` + command substitution + `git tag -l` exit 128 + `pipefail` = script aborts at the assignment, before the `if [ -z "$all_tags" ]` fallback can fire. `2>/dev/null` suppresses stderr but not the exit code.

## Defense-in-depth scan (H1)

Grepped both validators for git command-substitutions:

| File:line | Status |
|---|---|
| `tests/validate-structure.sh:797` `git describe --tags --abbrev=0 ... \|\| echo ""` | ✓ guarded |
| `tests/validate-structure.sh:803` `git diff --name-only ... \|\| echo ""` | ✓ guarded |
| `tests/validate-content.sh:654` `git tag -l ... \| sort -V` | ✗ unguarded — **this PR** |

Line 654 was the only unguarded git command-substitution across both validators. The issue author's claim ("the only git call missing that `\|\| echo ""` guard") verified independently.

## Verification

**Reproduce (pre-fix)** — `cp -R` full repo tree to non-git temp dir, then:

```
$ bash tests/validate-content.sh > out.log 2>&1; echo "exit=$?"
exit=128
$ grep "=== Summary ===" out.log
(no match — script aborted)
```

**Post-fix, same non-git tree**:

```
$ bash tests/validate-content.sh > out.log 2>&1; echo "exit=$?"
exit=0
$ grep -A4 "=== Summary ===" out.log
=== Summary ===
PASS: 267
FAIL: 0
WARN: 2     # 1 pre-existing + 1 new "git tag history unavailable"
```

**In-repo (tagged checkout, regression check)**:

- `tests/validate-content.sh` → 269 PASS / 0 FAIL / 1 WARN (unchanged from v2.18.3)
- `tests/validate-structure.sh` → 358 PASS / 0 FAIL (unchanged)

## Doctrine

`tests/**` is **contributor-doctrine** per [ADR-019](docs/adr/ADR-019-doctrine-only-scope-refinement.md) line 88 — no version bump, no CHANGELOG, no SKILL-EFFECTIVENESS update. Check 27 confirms.

The fix is consumer-affecting in **practice** (consumers running the shipped self-test see exit 128 instead of a clean WARN). The ADR-019 classification is unchanged — the path stays contributor-doctrine because the script is shipped for verification, not runtime, and the WARN message is unambiguous. If this becomes a recurring "tests/** affects consumers" pattern, a future ADR can refine the classification.

## Secondary note (LOW / by-design)

The issue raised a secondary question about `guides/anthropic-engineering-doctrine-audit.md` citing 3 maintainer-local `~/.claude/lessons/...` paths. **This is by-design** — the guide self-describes as a "defensive citation surface" for contributors/maintainers, and the lessons it cites are reflection artifacts that don't ship with the plugin. Each contributor's own `~/.claude/lessons/` accumulates via `/reflect`. No code change needed; addressed in the issue comment.

## Test plan

- [x] Reproduce exit=128 pre-fix in non-git temp dir
- [x] Confirm exit=0 + Summary block post-fix in same non-git tree
- [x] Confirm in-repo behavior unchanged (269 PASS / 0 FAIL / 1 WARN)
- [x] `tests/validate-structure.sh` unchanged (358 PASS / 0 FAIL)
- [x] Grep both validators for any other unguarded git calls — none found
- [ ] CI green