### PR TITLE
fix(tests): anchor Check 12 skill-extraction regex to first table column

### DIFF
--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -272,11 +272,24 @@ done
 # Extract skill names from README table rows matching | `/skill-name`
 README_SKILLS=""
 while IFS= read -r line; do
-  sname=$(echo "$line" | sed -n 's/.*`\/\([a-z0-9-]*\)`.*/\1/p')
+  # Anchor to the first table column (^| `/skill`) — a greedy `.*`\/...` would
+  # match the LAST `/skill` reference in a row that mentions several, picking the
+  # wrong skill name (Issue #214, surfaced via /diagnose dogfood on PR #213).
+  sname=$(echo "$line" | sed -n 's/^| *`\/\([a-z0-9-]*\)`.*/\1/p')
   [ -n "$sname" ] && README_SKILLS="$README_SKILLS $sname"
 done < <(grep '| `/[a-z]' README.md 2>/dev/null)
 # Deduplicate
 README_SKILLS=$(echo "$README_SKILLS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+# Regression fixture for Issue #214: a row mentioning 3 skills must yield the
+# FIRST-column skill, not the last. Fails loudly if the greedy regex regresses.
+_c12_row='| `/firstskill` | H1 | mentions `/secondskill` and `/thirdskill` |'
+_c12_got=$(echo "$_c12_row" | sed -n 's/^| *`\/\([a-z0-9-]*\)`.*/\1/p')
+if [ "$_c12_got" = "firstskill" ]; then
+  pass "Check 12 regex anchored to first column (Issue #214 regression guard)"
+else
+  fail "Check 12 regex regressed (#214): picked '$_c12_got' instead of 'firstskill'"
+fi
 
 XREF_FAIL=0
 # Check: every directory skill is in README


### PR DESCRIPTION
## Summary

Closes #214. `tests/validate-structure.sh` Check 12 used a **greedy** regex to pull skill names from README table rows:

```bash
sed -n 's/.*`\/\([a-z0-9-]*\)`.*/\1/p'   # matches the LAST `/skill` in the row
```

A row that mentions several `/skill` references (first column + prose) silently extracted the **wrong** skill name. It hadn't fired a failure only by luck — the last-mentioned skill always happened to be a real directory. **Anchored to the first table column:**

```bash
sed -n 's/^| *`\/\([a-z0-9-]*\)`.*/\1/p'
```

Adds a regression fixture asserting a 3-skill row yields the **first**-column skill, failing loudly if the greedy form returns.

## Why no version bump

`tests/**` is **contributor-doctrine** per [ADR-019](docs/adr/ADR-019-doctrine-only-scope-refinement.md) — no version bump, no CHANGELOG required. Check 27 passes without a bump.

## Scope note (H1 — traced the sibling)

Check 20 (RESOLVER cross-ref) shares the same `.*` greedy idiom but is **latent-safe**: `skills/RESOLVER.md` is one-skill-per-line (0 rows with 2+ `skills/X/SKILL.md`), so the greedy never bites. Left untouched to keep this PR single-purpose (matching #214's own discipline note). Tracked as an observation if RESOLVER ever gains multi-skill lines.

## Test plan

- [x] Reproduced: greedy picks `thirdskill`; anchored picks `firstskill` (from a 3-skill row)
- [x] Anchored extraction preserves full **23-skill** coverage against the real README
- [x] New regression guard PASSES inside Check 12
- [x] `bash -n` syntax clean
- [x] `validate-structure.sh` + `validate-content.sh` — ALL CHECKS PASSED, 0 fitness breaches
- [ ] CI (validate + linkcheck) green on this PR

Refs #213, ADR-015 (n=1 USE recorded for /diagnose), ADR-019.