### PR TITLE
docs(readme): position 8-habit in the Spec-Driven Development landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ We follow the **"Thin Harness, Fat Skills"** pattern — the session hook is bou
 
 The same principle is documented independently by Garry Tan (President & CEO, Y Combinator) in his 2026 essay [_"Thin Harness, Fat Skills"_](https://github.com/garrytan/gbrain/blob/master/docs/ethos/THIN_HARNESS_FAT_SKILLS.md) and shipped in [gbrain](https://github.com/garrytan/gbrain). We arrived at it from workflow discipline; he arrived at it from building a brain — same conclusion.
 
+The same shift is happening industry-wide under the name **Spec-Driven Development (SDD)**: after "vibe coding" entered the vocabulary in early 2025, tools like GitHub spec-kit, AWS Kiro, and Tessl emerged to generate code from specs. Those are spec-first _tooling_ — this plugin is spec-first _discipline_: tool-agnostic guidance that helps any of them (or none of them) produce better specs in the first place. It adds no enforcement and spawns no role-agents — that is the companion [`claude-governance`](https://github.com/pitimon/claude-governance). We arrived here from workflow discipline; they arrived from building codegen tools — same discipline layer, different delivery.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Add a Design Principle paragraph naming the industry-wide **Spec-Driven Development** shift (spec-kit, Kiro, Tessl) and stating the plugin's honest position: spec-first *discipline* (tool-agnostic guidance), **not** codegen tooling and **not** an enforcement engine — enforcement is the companion `claude-governance`.
- Mirrors the existing Garry Tan/gbrain external-positioning pattern in the same section. No table, no statistics, no version stamp (avoids the staleness the repo already has — e.g. spec-kit star count drift in `guides/ears-notation.md`).
- `docs/INTEGRATION.md` deliberately **untouched** to preserve its companion-plugin SSOT scope. This single-paragraph approach was chosen over an INTEGRATION.md comparison table after an 8-habit cross-verify flagged the table as a scope violation + staleness risk.

## Test plan

- [x] `bash tests/validate-structure.sh` → 359 PASS / 0 FAIL (no version drift)
- [x] `/code-review` → no CRITICAL/HIGH/MEDIUM (docs-only, +2 lines)
- [x] External link `claude-governance` verified live (public repo)
- [x] Plugin boundary honored — paragraph states "no enforcement, no role-agents"
- [x] No stats / star counts (staleness-safe)
- [ ] Maintainer self-merge (sole maintainer; substantive-doc tier)