### PR TITLE
docs: refresh README and wiki for v2.20.2 ops updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Start from **your situation**, not the skill name.
 | Build a new feature from scratch  | `/requirements`                                                                                                                                                                                                     | `/design` → `/breakdown`          | H2: Define done first   |
 | Review code before committing     | `/review-ai`                                                                                                                                                                                                        | `/security-check` if needed       | H4: Never skip review   |
 | Understand an unfamiliar codebase | `/research`                                                                                                                                                                                                         | `/build-brief`                    | H5: Read before writing |
-| Deploy to production              | `/deploy-guide`                                                                                                                                                                                                     | `/monitor-setup`                  | H1: Staging first       |
+| Deploy / provider canary        | `/deploy-guide`                                                                                                                                                                                                     | `/monitor-setup`                  | H1: Stage, rollback, reconcile |
 | Assess overall project health     | `/cross-verify`                                                                                                                                                                                                     | `/whole-person-check`             | All 8 habits            |
 | Classify an operational finding   | `/operational-state`                                                                                                                                                                                                | `/deploy-guide` or `/post-mortem` | H1 + H5 + H8            |
 | Fix a production bug              | `/build-brief`                                                                                                                                                                                                      | Reproduce first                   | H5: Understand first    |
@@ -349,7 +349,7 @@ Both agents use the `sonnet` model for fast, focused analysis.
 │   ├── breakdown/SKILL.md          #   Step 3 → H3 (orchestration classification)
 │   ├── build-brief/SKILL.md        #   Step 4 → H5 (context boundaries)
 │   ├── review-ai/SKILL.md          #   Step 5 → H4 (4-level verdict)
-│   ├── deploy-guide/SKILL.md       #   Step 6 → H1
+│   ├── deploy-guide/SKILL.md       #   Step 6 → H1 (staging, rollback, reconciliation)
 │   ├── monitor-setup/SKILL.md      #   Step 7 → H7
 │   ├── cross-verify/SKILL.md       #   All habits (17Q + dimension summary)
 │   ├── consistency-check/SKILL.md  #   H5+H1: spec + incident/config consistency (v2.20.1)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -78,7 +78,7 @@ Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
 | [`/whole-person-check`](Skills-Reference#whole-person-check) | Body/Mind/Heart/Spirit balance                                 |
 | [`/security-check`](Skills-Reference#security-check)         | OWASP Top 10 focused review                                    |
 | [`/scrutinize`](Skills-Reference#scrutinize)                 | Outsider-perspective review — questions if change should exist |
-| [`/consistency-check`](Skills-Reference#consistency-check)   | Cross-artifact drift detection (PRD ↔ design ↔ tasks)          |
+| [`/consistency-check`](Skills-Reference#consistency-check)   | Spec artifact and incident/config hotfix drift detection       |
 | [`/reflect`](Skills-Reference#reflect)                       | Post-task retrospective with lesson persistence                |
 | [`/workflow`](Skills-Reference#workflow)                     | Interactive guided walkthrough                                 |
 

--- a/docs/wiki/Vibe-Coding-vs-Structured.md
+++ b/docs/wiki/Vibe-Coding-vs-Structured.md
@@ -15,7 +15,7 @@
 | **Task decomposition** | One giant prompt               | `/breakdown` — atomic tasks, Q2 prioritized        |
 | **Before coding**      | Straight to code generation    | `/build-brief` — read existing code first          |
 | **Review**             | "Looks good, commit it"        | `/review-ai` + `/security-check` + `/cross-verify` |
-| **Deploy**             | Push to prod directly          | `/deploy-guide` — staging first, rollback ready    |
+| **Deploy**             | Push to prod directly          | `/deploy-guide` — staging first, rollback planned, provider state reconciled |
 | **After deploy**       | Forget about it                | `/monitor-setup` — observe and learn               |
 | **Reflection**         | None                           | `/reflect` — capture lessons                       |
 

--- a/docs/wiki/Workflow-Overview.md
+++ b/docs/wiki/Workflow-Overview.md
@@ -25,7 +25,7 @@ Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
    [!] 5 · /review-ai       H4 Win-Win       audit before commit
         │
         ▼
-   [H] 6 · /deploy-guide    H1 Proactive     staging first, rollback ready
+   [H] 6 · /deploy-guide    H1 Proactive     staging, rollback, reconcile
         │
         ▼
    [O] 7 · /monitor-setup   H7 Sharpen Saw   observe after deploy
@@ -39,7 +39,7 @@ Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
 | 3    | [`/breakdown`](Step-3-Breakdown)         | H3 First Things First | Atomic task list              | Optional          |
 | 4    | [`/build-brief`](Step-4-Build-Brief)     | H5 Understand First   | Implementation brief per task | Optional          |
 | 5    | [`/review-ai`](Step-5-Review-AI)         | H4 Win-Win            | Code review findings          | **Required**      |
-| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1 Be Proactive       | Deploy plan + rollback        | **Required**      |
+| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1 Be Proactive       | Deploy + rollback + reconciliation | **Required**      |
 | 7    | [`/monitor-setup`](Step-7-Monitor-Setup) | H7 Sharpen the Saw    | Observability config          | Optional          |
 
 ## Handoff Contracts


### PR DESCRIPTION
## Summary\n\nRefreshes README and wiki wording so public docs reflect the v2.20.1/v2.20.2 operational updates.\n\n## Updated\n\n- README use-case table now routes provider canary work through `/deploy-guide`.\n- README architecture tree now describes `/deploy-guide` as staging, rollback, and reconciliation.\n- Wiki Home now describes `/consistency-check` as both spec artifact and incident/config hotfix drift detection.\n- Workflow Overview now describes Step 6 as deploy + rollback + reconciliation.\n- Vibe Coding comparison now calls out provider state reconciliation during deploy.\n\n## Boundary\n\nDocs-only refresh. No skill body changes, no package manifest changes, no version bump, and no release required.\n\n## Validation\n\n- `bash tests/validate-structure.sh` -> 405 PASS / 0 FAIL\n- `bash tests/validate-content.sh` -> 315 PASS / 0 FAIL / 1 WARN (pre-existing research DoD warning)\n- `git diff --check -- README.md docs/wiki/Home.md docs/wiki/Vibe-Coding-vs-Structured.md docs/wiki/Workflow-Overview.md` -> clean