### PR TITLE
docs(wiki): rewrite wiki with professional templates

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,45 +1,35 @@
 # Architecture
 
-The plugin is a **pure-markdown Claude Code plugin** with zero runtime dependencies. No build system, no `npm install` — just structured markdown files that Claude Code loads at runtime to shape its development behavior.
+`8-habit-ai-dev` is a markdown-first plugin. The stable core is the `skills/` directory; runtime-specific files only package or present those skills to Claude Code, Codex, and other markdown-capable agents.
 
 > [!NOTE]
-> Understanding the architecture is optional for using the plugin. This page is for contributors and curious users who want to know how the pieces fit together.
+> This page describes how the documentation and plugin surfaces fit together. It is not required reading for everyday use.
 
-## 4-Layer Loading Model
+## Core Boundary
 
-The plugin loads content in 4 layers, each with different timing and scope:
+The plugin owns workflow discipline:
 
-```
-   Layer 1 · Rules           auto-loaded every session    rules/effective-development.md
-        │
-        ▼
-   Layer 2 · Session Hook    runs at session start        hooks/session-start.sh
-        │
-        ▼
-   Layer 3 · Skills          on-demand, user-invoked      skills/*/SKILL.md
-        │
-        ▼
-   Layer 4 · Agents          cross-verification           8-habit-reviewer
-```
+- skill routing and markdown guidance,
+- human checkpoints,
+- review and verification prompts,
+- release and operational documentation discipline,
+- validation scripts for the plugin content itself.
 
-### Layer 1: Rules (always active)
+The plugin does not own runtime enforcement, irreversible-action authorization, cloud automation, compliance certification, or dynamic orchestration engines.
 
-`rules/effective-development.md` is loaded automatically into every Claude Code session via Claude's rules system. It contains the full 8-Habit playbook with Rules, Anti-patterns, and Checkpoints per habit. This is the foundation — always present in context, shaping Claude's behavior even if no skills are invoked.
+## Loading Model
 
-### Layer 2: Session Hook (session start)
+| Layer | Claude Code | Codex |
+| --- | --- | --- |
+| Entry point | `CLAUDE.md` | `AGENTS.md` |
+| Skills | `skills/*/SKILL.md` | `skills/*/SKILL.md` |
+| Resolver | `skills/RESOLVER.md` | `skills/RESOLVER.md` |
+| Session hooks | `hooks/` | Not executed |
+| Package manifest | `.claude-plugin/` | `.codex-plugin/` and `.agents/plugins/marketplace.json` |
 
-`hooks/session-start.sh` runs once at the start of every session. Budget: **≤300 tokens** (enforced by `test-verbosity-hook.sh`).
+## Skill Shape
 
-Responsibilities:
-
-- Print the 7-step workflow reminder
-- Detect workflow progress (existing PRD/ADR/TASKS artifacts)
-- Read `~/.claude/habit-profile.md` and emit maturity-level adaptation directive
-- Respect `HABIT_QUIET=1` opt-out (ADR-006)
-
-### Layer 3: Skills (on-demand)
-
-24 skills in `skills/*/SKILL.md`, loaded only when the user invokes them (e.g., `/requirements`, `/design`). Each skill has YAML frontmatter:
+Each skill is a markdown file with YAML frontmatter and a consistent body:
 
 ```yaml
 ---
@@ -47,75 +37,44 @@ name: <skill-name>
 description: >
   When to use this skill
 user-invocable: true
-argument-hint: "[arg description]"
-allowed-tools: ["Read", "Glob", "Grep"]
 prev-skill: <predecessor|any|none>
 next-skill: <successor|any|none>
 ---
 ```
 
-**Progressive disclosure** (v2.10.0, ADR-009): Three large skills use a `SKILL.md + reference.md + examples.md` triad. The main SKILL.md loads, then pulls in reference/examples only when needed via `Load ${CLAUDE_PLUGIN_ROOT}/...` directives.
+Workflow skills also define what they expect from the previous step and what they produce for the next step.
 
-### Layer 4: Agents (cross-verification)
+## Workflow Graph
 
-`8-habit-reviewer` — a read-only agent (`Read`, `Glob`, `Grep` tools only, model: `sonnet`) invoked by `/cross-verify`. Performs deep 17-question analysis against all 8 habits independently.
-
-`research-verifier` — validates cited URLs and file paths in research briefs.
-
-## Handoff Contracts
-
-Every workflow skill declares `prev-skill` and `next-skill` in its frontmatter, creating a directed acyclic graph (DAG):
-
-```
-/research → /requirements → /design → /breakdown → /build-brief → /review-ai → /deploy-guide → /monitor-setup
+```text
+/research -> /requirements -> /design -> /breakdown
+    -> /build-brief -> /review-ai -> /deploy-guide -> /monitor-setup
 ```
 
-Each skill documents:
+The graph is validated by repository tests so skill references do not silently drift.
 
-- **Expects from predecessor**: what input it needs
-- **Produces for successor**: what output the next step consumes
+## Validation
 
-> [!IMPORTANT]
-> The DAG is machine-verified. `tests/test-skill-graph.sh` validates: no cycles, no dangling references, symmetric edges, no orphan skills.
+| Script | Purpose |
+| --- | --- |
+| `tests/validate-structure.sh` | Frontmatter, names, version sync, graph fields, packaging surfaces |
+| `tests/validate-content.sh` | Markdown integrity, internal links, ADR shape, doctrine checks |
+| `tests/test-skill-graph.sh` | Handoff graph integrity |
+| `tests/test-verbosity-hook.sh` | Claude hook output and token budget |
 
-## Fitness Functions
+## Documentation Surfaces
 
-4 validators run in CI with **482+ total assertions**:
+| Surface | Role |
+| --- | --- |
+| `README.md` | Repository overview |
+| `AGENTS.md` | Cross-agent operating protocol |
+| `CLAUDE.md` | Claude Code architecture reference |
+| `docs/wiki/` | Source for GitHub Wiki pages |
+| `llms.txt` | Flat map for LLM indexing |
+| `docs/adr/` | Architecture decision records |
 
-| Validator                | What it checks                                                             |
-| ------------------------ | -------------------------------------------------------------------------- |
-| `validate-structure.sh`  | Skill frontmatter, directory structure, version consistency across 4 files |
-| `validate-content.sh`    | Skill complexity (word budget), content depth, cross-reference integrity   |
-| `test-skill-graph.sh`    | DAG integrity — cycles, dangling refs, symmetric edges, orphans            |
-| `test-verbosity-hook.sh` | 12 assertions across all 8 hook branches + HABIT_QUIET + token budget      |
+## See Also
 
-## Architecture Decision Records
-
-Every non-trivial decision is documented in `docs/adr/`:
-
-| ADR                                                                                                                      | Decision                                        |
-| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
-| [001](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-001-orchestration-patterns.md)                    | Orchestration patterns for multi-step workflows |
-| [002](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-002-research-modes.md)                            | Research skill modes and depth levels           |
-| [003](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-003-content-validation.md)                        | Content validation fitness functions            |
-| [004](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-004-wiki-as-artifact.md)                          | Wiki stored as build artifact in source control |
-| [005](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-005-eu-ai-act-toolkit.md)                         | EU AI Act compliance toolkit scope              |
-| [006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-superpowers-deferral.md) | Audience honesty + HABIT_QUIET opt-out          |
-| [007](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-007-agentskills-compatibility-decision.md)        | agentskills.io compatibility (NO-GO)            |
-| [008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md)          | User maturity calibration design                |
-| [009](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-009-skill-split-convention.md)                    | Progressive-disclosure skill split convention   |
-
-## Guides & Templates
-
-The `guides/` directory contains supporting material referenced by skills:
-
-- **Templates**: PRD, task list, review, lesson, interview protocol, ADR
-- **Reference docs**: EARS notation, cross-verification questions, whole-person rubrics
-- **Protocols**: Structured output format, orchestration patterns, verbosity adaptation rules
-- **Cross-verify packs**: Domain-specific question sets (API, frontend, infra, AI/ML, mobile)
-
-## See also
-
-- [Skills Catalog](Skills-Reference)
-- [Maturity Model](Maturity-Model)
-- [Changelog](Changelog)
+- [Installation](Installation)
+- [Skills Reference](Skills-Reference)
+- [Contributing to Wiki](Contributing-to-Wiki)

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -1,509 +1,99 @@
-![Version](https://img.shields.io/badge/latest-v2.20.2-blue)
+![Latest](https://img.shields.io/badge/latest-v2.20.2-blue)
 
 # Changelog
 
-Release history for `8-habit-ai-dev`. This page summarizes notable changes; the authoritative sources are [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md) (v2.3.0+), the [GitHub releases page](https://github.com/pitimon/8-habit-ai-dev/releases), and the [git tag history](https://github.com/pitimon/8-habit-ai-dev/tags).
+This page summarizes recent wiki-relevant releases. The authoritative release history remains the repository [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md), GitHub Releases, and git tags.
 
-> Full detail for v2.3.0 and later lives in the root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md). This wiki page summarizes recent versions and keeps v2.2.0 and earlier for continuity.
+> [!NOTE]
+> Wiki summaries intentionally focus on user-facing documentation changes and workflow boundaries. Use the repository changelog for exact release notes.
 
-## v2.20.2 — Production Canary Reconciliation Gates (June 2026)
+## v2.20.2 · Production Canary Reconciliation Gates
 
-Extends `/deploy-guide` with a production canary / capacity-change template for provider-managed infrastructure where the operator can pick a canary but the cloud provider may mutate a different eligible target. Adds precheck, cordon approval, observation, drain approval, provider-side change approval, reconciliation, and postcheck/evidence closure phases. The reconciliation gate compares planned target vs actual provider-selected target; checks desired/min/max, schedulable capacity, all nodes Ready, no unintended `SchedulingDisabled` nodes, and whether the original canary needs uncordon or follow-up. Evidence wording distinguishes provider scale/update success from canary reconciliation success and routes unresolved state to `/operational-state`. No cloud execution, policy enforcement, Kubernetes/ASG automation, or runtime state engine added. Closes [#250](https://github.com/pitimon/8-habit-ai-dev/issues/250). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+`/deploy-guide` now covers provider-managed production canaries and capacity changes where the requested canary target and the provider-selected target may differ.
 
-## v2.20.1 — Incident/Config Consistency-Lite (June 2026)
+Visible documentation points:
 
-Extends `/consistency-check` with a lightweight incident/config hotfix mode for operational PRs and closure notes that do not have persisted `docs/specs/<slug>/` artifacts. The mode checks symptom, evidence, root cause, actual fix, deploy path, live verification, and drift in one short table; flags overclaiming PR/changelog text, missing evidence, scope mismatch, deploy drift, and unclassified adjacent operational state; and routes unresolved related findings to `/operational-state`. Includes a generic WorkerDown/Alertmanager alert/config hotfix example. No new skill, runtime enforcement, cloud execution, or automatic issue/alert mutation added. Closes [#253](https://github.com/pitimon/8-habit-ai-dev/issues/253). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+- Precheck, cordon, observation, drain, provider-side change, reconciliation, and postcheck phases.
+- Planned target vs actual provider-selected target comparison.
+- Desired/min/max capacity, readiness, schedulable capacity, and unintended `SchedulingDisabled` checks.
+- Unresolved rollout state routes to `/operational-state`.
 
-## v2.20.0 — Operational State Model (June 2026)
+Boundary: no cloud execution, policy enforcement, Kubernetes automation, ASG automation, or runtime state engine.
 
-Adds `/operational-state`, a new read-only skill for classifying operational findings before action. It chooses between `Watch`, `Fix Candidate`, `Active Incident`, `Resolved`, `Handoff`, `Known Accepted Issue`, `False Positive`, and `Self-Resolved`, then maps the state to required evidence, allowed/prohibited actions, approval gates, artifacts, escalation criteria, and closure criteria. Guardrails make the operational semantics explicit: Running is not healthy, recovered is not fixed, source-of-truth drift stays visible, report hygiene is not a production mutation, and adjacent unresolved state must not be hidden. Boundary remains markdown guidance only: no runtime state engine, policy enforcement, cloud execution, alert suppression automation, or automatic production writes. Closes [#251](https://github.com/pitimon/8-habit-ai-dev/issues/251); #250 and #253 remain follow-on work. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+## v2.20.1 · Incident/Config Consistency-Lite
 
-## v2.19.2 — Operational Doctrine Patch from Open Issues (June 2026)
+`/consistency-check` now includes a lightweight mode for incident and config hotfix work that does not have persisted spec artifacts.
 
-Ships a conservative doctrine-only patch from issues #252, #254, #255, and #256 without adding a new operational-state skill. `/deploy-guide` now classifies deploy type before rollout planning and treats runtime-impacting config/template changes as deploy work. `/security-check` now includes alerting/email templates, SMTP, webhooks, notification links, container/orchestrator config, env interpolation, mounted config, rendered config, and source-of-truth drift. `/reflect` keeps six questions but splits Q6 into `most_useful`, `least_or_confusing`, and `missed_skill`, with the lesson template preserving missed-skill signals. `/management-talk` adds a generic WorkerDown/Alertmanager closure example rendered for Slack, standup, email, and meeting talking points. Broader operational-model issues #250, #251, and #253 remain deferred. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Visible documentation points:
 
-## v2.19.1 — Codex Runtime Compatibility Contract (May 2026)
+- Checks symptom, evidence, root cause, actual fix, deploy path, live verification, and drift.
+- Flags overclaiming PR/changelog text, missing evidence, scope mismatch, deploy drift, and unclassified adjacent operational state.
+- Routes unresolved related findings to `/operational-state`.
 
-Clarifies the runtime promise after v2.19.0's native Codex packaging. Codex can install the plugin and load the same 23 markdown skills, but that does not imply Claude hook execution or runtime enforcement inside Codex. New [`docs/compatibility-matrix.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/compatibility-matrix.md) documents the Claude Code / Codex / other-agent boundary; new [`docs/codex-integration.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/codex-integration.md) gives Codex install, verify, routing, release-flow, and adapter guidance. [`ADR-024`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-024-codex-runtime-adapter-boundary.md) records the adapter boundary: future Codex automation may route intents, open skills, run validators, reconcile releases, and write curated memory; policy enforcement, compliance execution, irreversible-action authorization, and orchestration engines stay outside the markdown skill core. `tests/validate-structure.sh` Check 29 pins the compatibility docs and entrypoint links. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Boundary: no runtime enforcement, cloud execution, alert mutation, or automatic issue closure.
 
-## v2.19.0 — Native Codex Plugin Packaging (May 2026)
+## v2.20.0 · Operational State Model
 
-Adds first-class Codex packaging while preserving the existing Claude Code package. New files: `.codex-plugin/plugin.json` points Codex at the existing `skills/` directory with interface metadata; `.agents/plugins/marketplace.json` exposes the repo as marketplace `pitimon-8-habit-ai-dev` so users can run `codex plugin marketplace add pitimon/8-habit-ai-dev` followed by `codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev`. The marketplace points to `./plugin`, a symlink back to the repo root, because Codex ignores root-path marketplace entries. [ADR-023](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-023-codex-native-packaging.md) records the packaging decision and boundary: same read-only markdown skills, no runtime enforcement, Claude hooks remain Claude-only. Codex ingestion compatibility sets `/ai-dev-log` and `/save-spec` `disable-model-invocation` to `false` because Codex rejects `true` and ADR-014 already marked it decorative for Claude plugin skills. `tests/validate-structure.sh` now checks Codex packaging presence, required fields, version alignment, and treats Codex packaging paths as consumer-doctrine for bump enforcement. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Adds `/operational-state`, a read-only classifier for operational findings.
 
-## v2.18.9 — Diagnose Worked-Example Polish (May 2026)
+States:
 
-Craft follow-up to v2.18.8, closing a Heart-dimension gap a `/whole-person-check` flagged. `/diagnose` Phase 4's independent-source verification step gains a copy-pasteable worked example (`docker run <img>` vs `docker exec <ctr>`, compare-and-flag-divergence) plus a one-line generalization — _read the claim twice from sources that can't share the same mistake, and believe it only when they agree_ — so a first-time user internalizes the technique without leaving the skill. Boundary-safe per [ADR-021](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-021-dynamic-workflow-positioning.md): independence-of-source, zero agent-orchestration vocabulary. Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+- Watch
+- Fix Candidate
+- Active Incident
+- Resolved
+- Handoff
+- Known Accepted Issue
+- False Positive
+- Self-Resolved
 
-## v2.18.8 — Independent-Source Verification (May 2026)
+The skill maps each state to evidence, allowed and prohibited actions, approval gates, artifacts, escalation criteria, and closure criteria.
 
-Adds the **discipline** the first real fan-out use exposed (follow-up to [#243](https://github.com/pitimon/8-habit-ai-dev/issues/243), built on #241/ADR-021): catching a _confident-but-wrong root cause_ that survives every author-side gate because each gate reuses the same single contaminated observation. Lived case (memforge) — a version read from `docker exec` survived `advisor`, a review pass, a merged PR, and a `/reflect` lesson, until an independent probe (`docker run` on the image) contradicted it and surfaced a bind-mount overriding the image. New canonical [`guides/independent-source-verification.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/independent-source-verification.md) holds the case study + rule (confirm a root cause from an _independent_ source; reconcile contradictions rather than pick) and is cited by six gap edits to `diagnose`, `cross-verify`, `post-mortem`, `reflect`, `orchestration-patterns.md`, and `advisor-pattern.md`. Boundary-safe per [ADR-021](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-021-dynamic-workflow-positioning.md) — discipline here, fan-out engine in `claude-governance`; `8-habit-reviewer` caught one boundary DRIFT (Pattern 4 re-owning the engine) and confirmed CLEAN after reword. Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Boundary: no runtime state engine, policy enforcement, cloud execution, alert suppression automation, or automatic production write.
 
-## v2.18.7 — Dynamic Workflow Positioning (May 2026)
+## v2.19.2 · Operational Doctrine Patch
 
-Positions the plugin against Opus 4.8's new **dynamic workflow** capability — a deterministic engine that spawns parallel sub-agents — which collides by name and philosophy with the plugin's human-gated `/workflow` skill. A 4-probe repo audit (issue [#241](https://github.com/pitimon/8-habit-ai-dev/issues/241)) settled the layering: the **engine** (runtime + agent-spawn authorization) belongs to `claude-governance`; the fan-out **discipline** belongs here. [`guides/orchestration-patterns.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/orchestration-patterns.md) gains **Pattern 4: Fan-Out Discipline** — a when/when-not-to-fan-out gate keyed to habits (H6 Synergize reinforces; H1/H3/H5/H8 in tension) plus an Article 14 oversight checklist (preserve Understand / Override / Stop), delegating the _how_ to existing Patterns 1-3. [`docs/adr/ADR-021`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-021-dynamic-workflow-positioning.md) disambiguates `/workflow` (discipline) from the engine and quotes the CLAUDE.md boundary rule verbatim. Forward guardrail with zero friction signal; sunset 2026-11-24. Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Ships doctrine-only improvements to existing skills:
 
-## v2.18.6 — Step 4a awk Made Frontmatter-Aware (May 2026)
+- `/deploy-guide` classifies deploy type before rollout planning.
+- `/security-check` covers more infrastructure and configuration surfaces.
+- `/reflect` captures more granular skill-effectiveness feedback.
+- `/management-talk` includes an operational incident closure example.
 
-Fast-follow fix to v2.18.5 (shipped ~1h earlier) closing issue [#239](https://github.com/pitimon/8-habit-ai-dev/issues/239) — a QA pass on v2.18.5 caught that the step 4a body-measure command (`awk '/^---$/{c++; next} c>=2'`) returned `0` for files without YAML frontmatter, contradicting the release's own ADR-017 ~150-line case study. [`skills/requirements/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/requirements/SKILL.md) step 4a step 2 now uses a frontmatter-aware variant (`awk 'NR==1 && $0=="---"{f=1; next} f && $0=="---"{f=0; next} !f'`) that strips frontmatter only when the file actually starts with `---`; otherwise counts the whole body. Verified: ADR-017 → 152, ADR-018 → 145, `cross-verification.md` → 95, `requirements/SKILL.md` → 131. [`tests/validate-content.sh`](https://github.com/pitimon/8-habit-ai-dev/blob/main/tests/validate-content.sh) Check 22 closes the gap #239 explicitly named (_"`tests/**` was untouched"_) — runs the prescribed awk against 4 representative files and asserts body counts match. Establishes the precedent that future `awk`/`grep`/`jq` snippets in skill prose ship with a paired assertion. Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Broader operational model work was intentionally deferred until later releases.
 
-## v2.18.5 — PRD Calibration Checkpoint (May 2026)
+## v2.19.1 · Codex Runtime Compatibility Contract
 
-Adds a `4a. Calibrate numeric ceilings against precedent` sub-step to [`skills/requirements/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/requirements/SKILL.md) Process. When an EARS criterion sets an upper bound on lines/words/characters of a markdown artifact (ADR, guide, skill), the skill now nudges the author to identify the closest precedent (`docs/adr/ADR-0*.md`, `guides/*.md`, or `skills/*/SKILL.md` by artifact type), measure the body excluding YAML frontmatter (`awk '/^---$/{c++; next} c>=2' <file> | wc -l`), and set the ceiling at `precedent_max × 1.20` — because aspirational round numbers contaminate `/consistency-check` runs once the artifact lands at its actual required size. Opt-out preserved when no precedent exists or the cap is set by a different constraint (hook token budget, validator string limit). Closes [#237](https://github.com/pitimon/8-habit-ai-dev/issues/237) — action item from lesson `~/.claude/lessons/2026-05-24-v218-4-skill-authoring-double-rescue.md` §5 catching FR-007 (ADR-020) PRD-vs-reality drift before merge in v2.18.4. Plugin-boundary respected — no validator extension, no PreToolUse hook (runtime enforcement belongs in [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) per memory obs #233270). Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Clarifies that Codex can install the plugin and load the same markdown skills, but does not run Claude hooks or gain runtime enforcement.
 
-## v2.18.4 — Skill Authoring Guide (May 2026)
+Related docs:
 
-Adds [`guides/skill-authoring.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/skill-authoring.md) documenting Ben AI's Pre-Building Preparation pattern + canonical SKILL.md skeleton with a dedicated `## Objective` section + authoring lifecycle (`/research` → reference docs → SKILL.md → `/reflect` → SKILL-EFFECTIVENESS feedback). Closes N1 (no discoverable authoring methodology — 23 skills but only structural template in CONTRIBUTING.md) + P2 (Objective conflated with the Check 25 trigger-rubric `description`). Triggered by 2026-05-24 audit of Vibe Coding Thailand's "คู่มือสร้าง Claude Skills ให้เก่งกว่าคนทั่วไป" article. Cross-verify reconciliation: `@8-habit-reviewer` scored the brief's first "ship nothing" draft 12/17 and identified the same selective-strictness pattern that rescued the [ADR-017](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-017-anthropic-skill-patterns-audit.md) draft four days earlier; revised verdict applies [ADR-014](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-014-external-prior-art-audit.md) "ship with zero friction as forward guardrail" precedent consistently. [ADR-020](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-020-skill-authoring-guide.md) records the Tier 1 ship + Forward-Guardrail Sunset 2026-11-24. CONTRIBUTING.md template diff inserts `## Objective` section in the skill skeleton. Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md). PR closes [#235](https://github.com/pitimon/8-habit-ai-dev/issues/235). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+- [`docs/compatibility-matrix.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/compatibility-matrix.md)
+- [`docs/codex-integration.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/codex-integration.md)
 
-## v2.18.3 — Anthropic Engineering Doctrine Audit Guide (May 2026)
+## v2.19.0 · Native Codex Plugin Packaging
 
-Adds [`guides/anthropic-engineering-doctrine-audit.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/anthropic-engineering-doctrine-audit.md) as a defensive citation surface for the [ADR-018](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-018-memory-layer-activation.md) "Earn each line" doctrine. Catalogues 12 already-adopted patterns from Anthropic / Karpathy / Claude Code engineering blog corpus (Table 1) and 7 evaluated patterns (Table 2). N6 (skill description routing audit) reclassified from T1 → T2 after `@8-habit-reviewer` cross-verify flagged cherry-picking — the cited 2026-04-22 lesson records `skills/RESOLVER.md` as proactive feature (issue #135), not friction patch. H8 modeling deposit: apply friction-first to ourselves the same way we apply it to incoming proposals. Complements [ADR-017](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-017-anthropic-skill-patterns-audit.md) (narrower `github.com/anthropics/skills` 5-pattern audit). Consumer-doctrine bump per [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md) — `guides/**` is consumer-facing reference content. PR closes [#231](https://github.com/pitimon/8-habit-ai-dev/issues/231). Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+Adds Codex packaging through `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json` while preserving the Claude Code package.
 
-## v2.18.2 — ADR-019 Doctrine-Only Scope Refinement + Check 27 (May 2026)
+Install path:
 
-Refines [ADR-017 §C5](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-017-anthropic-skill-patterns-audit.md) doctrine-only rule. [ADR-019](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-019-doctrine-only-scope-refinement.md) splits doctrine-only into **contributor-doctrine** (no bump — `docs/adr/`, `CLAUDE.md`, `CONTRIBUTING.md`, `.github/`, `tests/`, `SELF-CHECK.md`) and **consumer-doctrine** (MUST bump + CHANGELOG — `rules/`, `skills/`, `hooks/`, `habits/`, `guides/`, `agents/`). Closes the silent-shift gap that would have hit `rules/effective-development.md`'s next audit (per [ADR-018](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-018-memory-layer-activation.md) §"Context"). `tests/validate-structure.sh` Check 27 enforces the rule mechanically: detects consumer-doctrine paths changed since last release tag; fails CI if version-4-files unchanged. Bumped electively (PR was contributor-doctrine only) to signal CI behavior change to contributors. Validator state: 358 PASS / 0 FAIL. Forward-Guardrail Sunset 2026-11-24 per ADR-017 convention. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+```bash
+codex plugin marketplace add pitimon/8-habit-ai-dev
+codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
 
-## v2.18.1 — Anthropic Skills 5-Pattern Audit: Tier 1 P3 Ship + Check 26 (May 2026)
+Boundary: same read-only markdown skills, no Claude hook parity, and no runtime enforcement.
 
-User-prompted Deep+Audit `/research` evaluated 23 skills against [github.com/anthropics/skills](https://github.com/anthropics/skills) (`skills/{pdf,pptx,docx}`) 5 SKILL.md patterns. [ADR-017](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-017-anthropic-skill-patterns-audit.md) records Tier 1 P3 ship (Check 26 warning-only validator + `/scrutinize` Operating Rules MUST/NEVER+Why blocks + `/diagnose` Phase 6 MUST re-verify); Pattern 4 (embedded scripts) out-of-scope per plugin charter; Pattern 5 split (T2 bag drop 2026-11-23 + companion [pitimon/claude-governance#37](https://github.com/pitimon/claude-governance/issues/37) for runtime hook). 8-habit-reviewer cross-verify caught selective-strictness asymmetry vs ADR-014 precedent (4 patterns shipped with zero friction 4 days earlier) and forced reconciliation paragraph before PR. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+## Earlier Releases
 
-## v2.18.0 — `/diagnose` Skill: Friction-Driven External Adoption (May 2026)
+For earlier versions, use:
 
-Adds `/diagnose` — 6-phase active bug investigation skill — as a **friction-driven** external prior-art adoption from [mattpocock/skills](https://github.com/mattpocock/skills) SHA `b8be62ff`. Closes the gap between `/research` (too broad) and `/post-mortem` (too late). Phase 1 (build feedback loop) is enforced before hypothesis generation. Hands off to `/post-mortem` once the fix lands. Honest framing in [ADR-015](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-015-diagnose-skill-adoption-and-n1-framing.md): n=1 friction signal (lesson `2026-04-12-compression-worker-420-investigation.md` first-person absent-skill admission), below ADR-014's n≥2 preferred bar but unusually strong. Sets precedent for friction-first external prior-art adoption. Plugin total: 23 skills. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
+- [Repository changelog](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md)
+- [GitHub releases](https://github.com/pitimon/8-habit-ai-dev/releases)
+- [Git tags](https://github.com/pitimon/8-habit-ai-dev/tags)
 
-## v2.17.0 — External Prior-Art Audit: mattpocock/skills Patterns (May 2026)
+## See Also
 
-Adopts 4 patterns from [mattpocock/skills](https://github.com/mattpocock/skills) as forward guardrails: P1 AGENT-BRIEF template, P3 `disable-model-invocation` frontmatter, P4-lite `docs/out-of-scope/` catalog, P5 description rubric (validator Checks 24+25). Honest framing in [ADR-014](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-014-external-prior-art-audit.md): all 4 ship without prior friction-signal evidence — future audits must apply friction-first lens. Full detail in root [`CHANGELOG.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/CHANGELOG.md).
-
-## v2.16.5 — Companion Announcement: devsecops `/workflow` → `/security-workflow` (May 2026)
-
-Docs-only patch closing the paired-announcement promise from `devsecops-ai-team` v10.12.0's CHANGELOG. The cross-plugin `/workflow` naming collision has been resolved by devsecops renaming its skill to `/security-workflow`; this plugin's `/workflow` (the 7-step Covey practice) keeps the generic name. `docs/INTEGRATION.md` peg bumped 10.10.0 → 10.12.0+; `skills/workflow/SKILL.md` gains "See Also" footer pointing scan-orchestration seekers to devsecops; README companion-plugins section refreshed. Pattern captured: companion-announcement step is now part of DoD for any cross-plugin slash-command rename.
-
-## v2.16.4 — `/save-spec` Suite-Positioning Honesty Patch (Adopter #2 third-repo dogfood) (May 2026)
-
-Docs-only patch. Adopter #2's third-repo dogfood (operational VA/PT workspace with `claude-mem` active + 284-line `CLAUDE.md`) surfaced two real overlap cases the `/save-spec` docs didn't acknowledge. P1 + P2 ship; P3 explicitly deferred per adopter recommendation. Closes [#207](https://github.com/pitimon/8-habit-ai-dev/issues/207).
-
-**P1 (docs only) — SKILL.md "When to Skip" + memory-MCP-overlap entry**: Memory-MCP active (`claude-mem`/`memforge`) + short `CLAUDE.md` (<150 lines / scannable in <30s) already solves the post-`/clear` save-point problem the skill was designed for. In that combination, §4 is the only net-value section; writing a short `## Current state` into `CLAUDE.md` is the lower-friction path.
-
-**P2 (docs only) — Suite positioning across 3 files**: SKILL.md gains "Suite positioning (not a workflow step)" section framing the skill as a deployment-mode helper orthogonal to the 7-step workflow, alongside `/calibrate` + `/reflect` as state-write skills (NOT alongside assessment skills). README skill-table row + using-8-habits/reference.md row both reclassified.
-
-**P3 (feature — explicitly deferred)**: `--skip-empty-sections` flag deferred per adopter recommendation pending demand signal.
-
-Pattern: **H8 Conscience applied to marketing copy** — the skill's own H8 Checkpoint admitted "the value depends on the user's habit of updating it"; this release extends that honesty to "When to Skip". Arc-close criterion (v2.16.3: "round 6 deferred unless 3rd adopter surfaces friction") validated — condition triggered within ~2 hours of v2.16.3 release. Pattern continues at n=3 evidence base. Adopter's /cross-verify: 13/15 = 86.7%. Maintainer's /cross-verify on implementation posture: 15/15 = 100%. Validator state: validate-structure.sh 268/268 PASS, validate-content.sh 220+ PASS / 0 FAIL / 1 WARN / 0 fitness breaches.
-
-## v2.16.3 — `/save-spec` Round-5 Arc-Close Polish (Adopter #2 closure pass) (May 2026)
-
-Patch release. Adopter #2 closure pass on the 5-round v2.16.x QA arc surfaced 1 MEDIUM bug + 2 LOW items + an arc-close meta. All 3 fixed; arc closed per Adopter #2 recommendation. Closes [#205](https://github.com/pitimon/8-habit-ai-dev/issues/205).
-
-**R5-3 (MEDIUM bug, fixed)**: Scaffolded SPEC.md §2 markdown table rendered broken on every empty-decisions scaffold because reference.md:30 blank line separated alignment row from `<§2-rows>` substitution. Initial fix (delete blank + add HTML-comment assembly directive) failed because the formatter persistently re-wedged blanks around HTML-blocks AND `<...>` markers. Final fix uses table-row-shaped substitution marker (`| §2-rows-ASSEMBLY-DIRECTIVE | ... |`) so the formatter sees it as a real data row. New validate-content.sh Check 12c.1 regression check added with formatter-padding-tolerant regex.
-
-**R5-1 (LOW-MEDIUM doc, fixed)**: Template assembly markers visually identical to F1-class pre-fix placeholders — risked future-contributor confusion. Fixed by consolidating the assembly-directive intent INTO the marker text with explicit `ASSEMBLY-DIRECTIVE` phrase + "NEVER appears in output" language.
-
-**R5-2 (LOW doc, fixed)**: FR-017 error template used write-failure register for pre-flight path-validation. Added new canonical pre-flight error template ("Directory not found: <target-dir>...") with correct register. FR-017 wired to new template; SKILL.md Process step 1 updated.
-
-Pattern: **formatter-vs-substitution-marker arms race resolved via table-row-shaped marker** — when a marker must be adjacent to a formatter-stable construct, make the marker itself look like that construct. DoD-must-execute self-test caught zero bugs this round (previous round caught F3 BSD-awk regression); convergence is the expected pattern when discipline holds. Validator state: validate-structure.sh 268/268 PASS, validate-content.sh 220+ PASS / 0 FAIL / 1 WARN / 0 fitness breaches. **5-round arc closed** per Adopter #2 recommendation; round 6 deferred unless a third independent adopter surfaces friction.
-
-## v2.16.2 — `/save-spec` Round-3 Polish + Guide Check 2 BSD-awk Fix (Adopter #3 dogfood) (May 2026)
-
-Patch release. Adopter #3 dogfood pass on `/save-spec` (first round from real skill execution rather than docs review) surfaced 1 correctness bug + 1 friction enhancement; pre-PR self-test surfaced 1 additional verification-command bug. All 3 fixed in this PR. Closes [#203](https://github.com/pitimon/8-habit-ai-dev/issues/203).
-
-**F1 (MEDIUM bug, fixed)**: Scaffolded SPEC.md shipped with 6 literal angle-bracket placeholder sites contradicting the read-first-context purpose. Fixed via hybrid approach — §2/§3 skip-stub rows use plain prose italic markers (`_no decisions seeded yet — add the first one when it lands_`); §1 narrative + §4 fill-required sites use `<!-- TODO: … -->` HTML comments (invisible at render, visible to editor). `tests/validate-content.sh` Check 12c whitelist extended to `skills/save-spec/`.
-
-**F2 (LOW-MEDIUM enhancement)**: `/save-spec [project-name] [target-dir]` now accepts an optional second positional argument. Multi-repo portfolio adopters no longer need a per-repo session switch. PRD FR-013 scope-clarified; new FR-017 added.
-
-**F3 (MEDIUM bonus, surfaced by pre-PR self-test)**: `guides/spec-digest-pattern.md` Check 2's `awk '/^## 4\. Current state/,/^## /'` collapses to 1 line on BSD awk (macOS default) because the end-regex `^## ` matches the start line. All macOS adopters running the published verification command had a silently-failing Check 2. Replaced with `sed -n '/^## 4\. Current state/,/^## /p'` (consistent cross-platform). Regression introduced in v2.15.9 (#197 N1 fix migrated from `grep -A1` → `awk`).
-
-**W2 (doc softening)**: N2 timestamp warning reframed — Adopter #3 fresh-session scaffold produced correct Bangkok offset; the `+00:00` fallback is the "documented escape-hatch, not expected outcome in normal use."
-
-**Positive verifications from Adopter #3**: W1 N3 free-text affordance works end-to-end, W2 N2 timestamp correct in real use, W3 refusal-path safety guard works.
-
-Validator state: validate-structure.sh 268/268 PASS, validate-content.sh 219+ PASS / 0 FAIL / 1 WARN / 0 fitness breaches. Pattern: **DoD-must-execute principle empirically validated within 24h of being coined** — the same-day /reflect action item caught F3 (a BSD-awk regression no static review would have surfaced). Lesson loop closed in a single day.
-
-## v2.16.1 — `/save-spec` Phase 1 Polish (Adopter #2 dogfood) (May 2026)
-
-Patch release. Adopter #2 dogfood pass on the v2.16.0 `/save-spec` skill surfaced 1 correctness bug + 3 quality items — all four fixed in this single PR. Closes [#201](https://github.com/pitimon/8-habit-ai-dev/issues/201).
-
-**N1 (MEDIUM bug, fixed)**: §1 empty stub previously used `` `<filename>.md` `` which Check 4's backtick-path grep extracted as `<filename>.md` (literal angle brackets), failing `[ -e ]` and emitting `MISS  <filename>.md`. The Definition of Done's claim that "output passes the 5 verification commands" was provably false on the default scaffold. Fixed by changing the stub to plain prose `_§1 is empty — add project-specific pointers as the repo grows._` with no backticked .md path.
-
-**N2 (LOW, documented)**: Timestamp reliability profile documented in reference.md. The skill (no `Bash` in `allowed-tools`) generates the `**Last updated**` value by substituting Claude's session-injected current-time context; when that injection is absent the output may carry `+00:00` or a wrong offset. Adopter guidance added: verify offset after scaffold, edit manually if wrong. Phase 2 may add `Bash` if feedback shows unreliability.
-
-**N3 (LOW UX, fixed)**: Q2 (§1 pointer confirmation) now accepts an "Other (free-text)" affordance for newline-separated project-specific paths. Motivated by ops/infra repos using non-canonical naming (`server-state.md`, `playbooks/change-management.md`, `runbooks/ops-runbook.md`) that have zero overlap with the 5 canonical glob names. SKILL.md Process step 3 + step 4 parse rule extended; reference.md Example F added to show the parse flow.
-
-**N4 (LOW doc drift, fixed)**: PRD FR-003 deduplicated against `reference.md` Decision-3. FR-003 previously included a paraphrased inline version of the refusal message that diverged from the canonical version in reference.md — future-maintainer drift hazard. FR-003 now references reference.md as the single source of truth.
-
-Validator state: `validate-structure.sh` 268/268 PASS, `validate-content.sh` 219+ PASS / 0 FAIL / 1 WARN / 0 fitness breaches. Sibling closure: [#197](https://github.com/pitimon/8-habit-ai-dev/issues/197) is now closeable — all 5 of its items were addressed in v2.16.0 + #198. Pattern: **patch-release dogfood discipline** — the adopter #2 report surfaced N1 in <2 hours after the v2.16.0 release; correctness fix shipped same day; the dogfood feedback loop is faster than the original promotion-criteria gathering.
-
-## v2.16.0 — `/save-spec` Skill — Phase 1 Minimum Viable (May 2026)
-
-Minor version bump (new skill). Promotes the v2.15.9 spec-digest-pattern guide to a user-invocable skill after all three documented promotion criteria were objectively met. Closes [#199](https://github.com/pitimon/8-habit-ai-dev/issues/199).
-
-New `skills/save-spec/SKILL.md` (~180 lines) — Phase 1 minimum viable user-invoked skill that scaffolds a project-root `SPEC.md` digest. Frontmatter: `allowed-tools: [Read, Write, Glob, AskUserQuestion]`, `prev-skill: any`, `next-skill: any` (standalone). Generator-only — refuses to overwrite an existing `SPEC.md` (Phase 2 `--update` deferred). 8-step Process section is the runtime contract pinned by new validator Check 23 (Decision-7 sticky). Hybrid auto-detect globs 5 canonical pointer-target files (`PLAYBOOK.md`, `CONTRACTS.md`, `LESSONS.md`, `CHANGELOG.md`, `README.md`, case-sensitive) and asks the user to confirm §1 inclusion. 4-prompt interactive flow (project name + §1 multi-select + §2 comma-separated free-text + §3 comma-separated free-text) with skip-sentinels (`skip`, `none`, `nothing`, `n/a`, empty). §4 timestamp uses RFC 3339 strict with local timezone offset. Emits CLAUDE.md auto-update recipe stanza to conversation only — does NOT modify your `CLAUDE.md` (FR-014, FR-015 design invariants).
-
-Companion artifacts: `skills/save-spec/reference.md` (~200 lines) with the verbatim refusal message + 3-line error template + skip-sentinels list + glob set + 5 parse examples + rationale links to issue #199 open-question defaults. New `tests/validate-structure.sh` Check 23 with 8 assertions pinning frontmatter array + 8-step Process count + canonical-phrase presence in reference.md. `skills/RESOLVER.md` gets 3 trigger phrases (`"scaffold a SPEC.md"`, `"save-point file for this repo"`, `"set up a project digest"`). `guides/spec-digest-pattern.md` "Promotion to a skill (deferred)" section rewritten to "Promoted to `/save-spec` in v2.16.0" with the explicit scope-resolution statement (the two deployment modes are disjoint in practice; multi-mode repos out of scope for tooling). `docs/adr/ADR-013-spec-persistence-opt-in.md` receives a 2026-05-17 follow-up note inside the existing addendum (user-invoked write stays outside Alt-4 auto-write-hook rejection — no new ADR required).
-
-Dogfood: the PRD/design/tasks for this skill itself were persisted via `--persist save-spec` (the feature-spec convention — cross-mode dogfooding the project-orientation tooling). `/consistency-check save-spec` ran clean (0 CRITICAL, 0 HIGH, 0 MEDIUM, 4 LOW — accepted as informational per Significance profile avoid-documentation-gold-plating stance).
-
-Promotion criteria status (all three met, the deferred-skill criterion-driven ship pattern):
-
-1. **n=2 independent adoption** — `netbox-sit` (the canonical empirical artifact in v2.15.9) + `claude-all/netbird-sit` (Adopter #2 report via [#197](https://github.com/pitimon/8-habit-ai-dev/issues/197))
-2. **Scope question resolved in writing** — the two-modes-are-disjoint paragraph in `guides/spec-digest-pattern.md`
-3. **Friction lesson captured** — `~/.claude/lessons/2026-05-17-spec-digest-pattern-v2-15-9.md` + #197 adopter friction items 2.1–2.3 + 4
-
-Validator state: validate-structure.sh 266/266 PASS, validate-content.sh 217+ PASS / 0 FAIL / 1 WARN / 0 fitness breaches. Pattern: **promotion via maturity ladder, not aesthetic preference** — the v2.15.9 deferral made the next escalation step falsifiable; v2.16.0 ships only because the criteria were objectively met, with documented evidence per criterion.
-
-## v2.15.9 — Project-Orientation Hub Mode Documentation (May 2026)
-
-Docs-only patch. Closes [#194](https://github.com/pitimon/8-habit-ai-dev/issues/194) via [PR #195](https://github.com/pitimon/8-habit-ai-dev/pull/195).
-
-Documents a second spec-persistence deployment mode (**project-orientation hub**) as complement to v2.15.2's feature-spec mode. No new skill, no hook, no enforcement — pattern documentation only.
-
-New `guides/spec-digest-pattern.md` (~180 lines) documents the project-root `SPEC.md` digest archetype: §1 Architecture (pointer), §2 Decisions snapshot (compact ADR digest table), §3 Live backlog, §4 Current state save point ("Read this section first after `/clear` or `/compact`"). Template paraphrased from a production artifact (`scanopy/netbox-sit/SPEC.md`, 153 lines) that independently arrived at this four-section shape after repeated `/clear`/`/compact` flushing pain. ADR-013 receives an additive 2026-05-17 addendum clarifying its rejections (Alt-1 unified prd+design+tasks merge, Alt-4 always-on auto-write hook, CHANGELOG v2.15.0 `/save-point` skill rejection) cover the **feature-spec mode** specifically; the digest-layer-above-detail-files archetype is a different deployment mode those alternatives did not evaluate. `/save-spec <slug>` skill explicitly deferred pending ≥2 independent project adoption signal per working-with-pitimon "minimal additions, user-demand-driven" stance + PR #111 local-maximum lesson. Cross-links from `guides/persistence-convention.md` (the two modes are complementary) + `README.md` Use Cases row "Survive `/clear` and `/compact`". 8-habit-reviewer pre-commit dispatch caught nested-fence rendering issue (outer ` ```markdown ` collapsed `\`\`\`bash`to literal text); fixed to 4-backtick outer fence. Post-merge CI surfaced`validate-content.sh` Check 12b false-positive: link resolver flagged 8 template-internal placeholder links inside the code block as broken because the regex is not backtick-aware — template rewritten to use backticked filenames (`` `PLAYBOOK.md` ``, `` `CONTRACTS.md` ``, etc) instead of bracket-paren link syntax with a note for the copy-paster. Same fix applied to Decisions table example row. Validator state: validate-structure.sh 256/256 PASS, validate-content.sh 216 PASS / 0 FAIL / 1 WARN / 0 fitness breaches. Pattern: **empirical-evidence-driven discipline addition** — real-world artifact from another session revealed a deployment mode the plugin did not document; plan was revised twice (after reviewer + advisor) to match commitment level to evidence strength; deferred skill criterion makes the next escalation decision data-driven rather than aesthetic.
-
-## v2.15.8 — `/reflect` Auto-Consolidation: One-Command Flow (May 2026)
-
-UX patch. Step 7 of `/reflect` now runs the 4-phase consolidation cycle automatically when `count > 10` — no separate `/reflect consolidate` invocation needed. Closes [#191](https://github.com/pitimon/8-habit-ai-dev/issues/191) via [PR #192](https://github.com/pitimon/8-habit-ai-dev/pull/192).
-
-No merges found → `~/.claude/lessons/INDEX.md` updated automatically + 1-line summary. Deletions proposed → cycle stops for explicit user approval (In-the-Loop per ADR-002 preserved). Explicit `/reflect consolidate` argument retained for verbose output. DoD bullet updated to testable outcome. Pattern: **PC² — H7 applied to H7 itself**. Root cause was threshold 10 that mature repos cross quickly — auto-run is safe for the common case (additive INDEX update), gate preserved for the rare case (irreversible deletions). Validator state: validate-structure.sh 256/256 PASS, validate-content.sh 217 PASS / 0 FAIL / 1 WARN / 0 fitness breaches.
-
-## v2.15.7 — Vendor Portability Discipline for Managed Agent Platforms (May 2026)
-
-Patch release. Doc-only addition responding to the industry move toward managed-agent runtime features (cross-session memory, self-evaluation against outcomes, built-in orchestration) from Claude Managed Agents, OpenAI Assistants, Bedrock Agents. Closes [#188](https://github.com/pitimon/8-habit-ai-dev/issues/188) via [PR #189](https://github.com/pitimon/8-habit-ai-dev/pull/189).
-
-New `guides/vendor-portability.md` (~90 lines) structured around three principles: persist artifacts outside the vendor (repo = source of truth), treat managed memory as cache not source of truth, separate discipline (portable) from runtime (vendor-specific). Selection checklist framed as the `/cross-verify` Q14 "third alternative beyond the obvious options" exercise — managed vs. self-hosted is rarely binary, and hybrid with explicit persistence discipline is often the better answer. Habit mapping: H8 (Voice, architectural autonomy / Spirit) primary anchor, H1 (Proactive, prevent lock-in / Body), H4 (Win-Win, Emotional Bank Account / Heart — canonical framing per `habits/h4-win-win.md`), H7 (Sharpen the Saw, reproducibility = PC over P / Mind) — full Whole Person 4-dimension coverage. `llms.txt` indexed under Philosophy section. Plugin boundary preserved — workflow discipline lives here; enforcement hooks and compliance framework mapping live in `pitimon/claude-governance`. 8-habit-reviewer pre-commit dispatch caught a Commandment #13 violation: initial draft mislabeled Q14 as "External dependencies" but actual text per `guides/cross-verification.md:45` is "third alternative beyond the obvious options" — corrected before merge, demonstrating the integrity discipline applies to its own writing. Pattern: **discipline answer to a runtime trend** — framework responds to vendor convergence not by replicating features but by naming the portability discipline that keeps users vendor-neutral. Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 217 PASS / 0 FAIL / 1 WARN / 0 fitness breaches.
-
-## v2.15.6 — SKILL_OUTPUT Producer + Consumer Doc Sync (May 2026)
-
-Patch release. Doc-only fix closing a pair of same-shape drift gaps in `guides/structured-output-protocol.md`. Both stemmed from `/design`'s `SKILL_OUTPUT:design` block being added without doc sync. Closes [#153](https://github.com/pitimon/8-habit-ai-dev/issues/153) via [PR #186](https://github.com/pitimon/8-habit-ai-dev/pull/186).
-
-Producer entry: `/design` → `SKILL_OUTPUT:design` inserted between `/requirements` and `/breakdown` (workflow Step 2 placement). Schema matches `skills/design/SKILL.md:128-142` exactly with all 7 keys; concrete example values match existing producer style. Consumer entries: Q14 (`decision_count` → third-alternative flag) + Q16 (`sticky_decisions` → WHY-not-captured flag); Q4 extended with design-block cross-check. All 5 SKILL_OUTPUT-consuming questions from `skills/cross-verify/SKILL.md:35-41` now mirrored in the guide. Pattern: **producer + consumer doc-sync-as-a-pair** — strict-scope producer-only fix would have created the "confusion point" the issue cites (H4 + H1). Minimal scope expansion closes both halves in one PR. Originally surfaced by `8-habit-reviewer` cross-verification of PR #152 (#151 attribution implementation). Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 217 PASS / 0 FAIL / 0 fitness breaches.
-
-## v2.15.5 — Repo-Wide Link-Check CI Gate + Real Link-Rot Fixes (May 2026)
-
-Patch release. Adds `.github/workflows/link-check.yml` — repo-wide markdown link validation using lychee. Triggers on PR + push to main when any `**/*.md` changes. Closes [#172](https://github.com/pitimon/8-habit-ai-dev/issues/172) via [PR #184](https://github.com/pitimon/8-habit-ai-dev/pull/184).
-
-Scope: external HTTP/HTTPS URLs across all `*.md` outside `docs/wiki/` (wiki covered by separate workflow). Excludes self-referential `pitimon/8-habit-ai-dev/(blob|tree|raw)/main/` URLs (only resolve post-merge) and private cross-repo refs to `pitimon/memforge` + `pitimon/devsecops-ai-team` (workflow `GITHUB_TOKEN` is scoped to this repo only; cannot authenticate against other private repos). `claude-governance` is public and stays in scope. Internal markdown links remain validated by `tests/validate-content.sh` Check 12b — two-layer design (CI for external, shell for internal) covers full surface without duplication.
-
-First CI run on PR #184 caught 3 real link-rot issues: README.md typo `claud-mem-me` → `memforge` (repo doesn't exist under typo'd name), ADR-005:137 dead EU AI Act Service Desk URL (EC restructured path; ADR-005 is Superseded per ADR-012, preserved as historical reference text with note), and `pitimon/devsecops-ai-team/issues/467` 404 due to private-repo CI token scope (added to exclude pattern with rationale). CONTRIBUTING.md gains "Link check (external URLs)" subsection under Testing Conventions documenting both workflows + the two-layer design. Pattern: **CI gate that immediately proves its own value** — link rot was already happening silently; the gate catches it at PR time vs when users report broken navigation. The 8-habit-reviewer recommendation from the 3-plugin integration audit is now enforced. Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 217 PASS / 0 FAIL / 0 fitness breaches; link-check CI run after fixes: PASS.
-
-## v2.15.4 — Backtick-Aware Ambiguity Pass + Dogfood ID Cleanup (May 2026)
-
-Patch release. First true bug-fix in the v2.15.x line — addresses the CRITICAL false-positive surfaced by v2.15.0's dogfood smoke test 9 days prior. Closes [#167](https://github.com/pitimon/8-habit-ai-dev/issues/167) via [PR #182](https://github.com/pitimon/8-habit-ai-dev/pull/182).
-
-`/consistency-check` Pass 3 (Ambiguity) gains a "Backtick-context filter (required)" subsection — pre-strip backtick-quoted segments from each line before applying the `[NEEDS CLARIFICATION]` / `TBD` / `TODO` / `???` / `XXX` token match. Covers single-backtick inline spans and triple-backtick fenced blocks. Eliminates the `docs/specs/consistency-check/prd.md:45` false-positive where the PRD legitimately mentions the token inside backticks as detection-target documentation. Option A from #167 (backtick-context filter) chosen over Option B (skip-marker comment): fewer escape hatches, principled, generalizes. Aligns analyzer runtime semantics with the validator-side whitelist that already exists for `skills/consistency-check/` content (`tests/validate-content.sh` Check 12c) — the two-tier design (validator whitelist for skill prose + analyzer backtick-filter for spec artifacts) is now internally consistent. Reference.md known-limitation note removed (the limitation was the bug). F2 residual cleaned: `tasks.md:48` `Decision-D5`/`Decision-D9` → canonical `Decision-5`/`Decision-9` per ADR-013, completing PR #169's earlier canonicalization. Validator Check 21 added asserting 3 contract signals — prevents future drift back to plain `grep -nE` semantics. Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 217 PASS / 0 FAIL / 0 fitness breaches. Pattern: bug fix of a feature shipped 9 days ago — distinct from v2.15.1/2/3 (content additions and convention imports).
-
-## v2.15.3 — Integrity Commandment #13: Grep-Verify Quotes Before Pasting (May 2026)
-
-Patch release. Content-only addition to `guides/integrity-principles.md` closing a verification-discipline gap surfaced during the v2.15.2 reflection. Two consecutive PR reviews (#174, #177) showed habit-attribution drift from gestalt pattern-matching, and a quote misattribution (`"Magic" behavior` at ADR-013 Alt-2 line 87 wrongly cited to Alt-4) propagated through 4 artifacts before reviewer catch. Closes [#179](https://github.com/pitimon/8-habit-ai-dev/issues/179) via [PR #180](https://github.com/pitimon/8-habit-ai-dev/pull/180).
-
-New commandment **#13**: _"Never paste a verbatim quote without grep-verifying its source."_ Scope: ADR citations, habit principle claims (H1-H8 attributions), scare-quoted external phrases, observation IDs, prior-conversation paraphrases presented as direct quotes. Title updated 12→13; mapping table row extended `5-7, 13 (Honesty)` → H8 Find Voice / Spirit (conscience); 3 live cross-references synced (README architecture-tree comment, `/review-ai` load directive). Historical entries (v1.9.0 release line, v2.0.0 CHANGELOG delta, SELF-CHECK v1.9.0 improvements section) intentionally preserved as period record — editing them would itself violate commandment #4 (evidence) and #5 (paths). Dogfooding moment: drafting #13 caught its own meta-violation pre-commit — initial `"magic behavior"` (lowercase) self-corrected to `"Magic" behavior` (capitalized) to match ADR-013:87 exactly. Pattern: **commandment growth driven by reflection-detected internal drift across ≥2 sessions** — distinct from v2.15.1 upstream-import and v2.15.2 community-article convention-import. Validator state: `validate-structure.sh` 256/256 PASS.
-
-## v2.15.2 — Current State Save-Point Convention (May 2026)
-
-Patch release. Convention-only addition to `guides/persistence-convention.md` importing a community-article save-point pattern (Thai-language article _"ผมไม่เคยกลัว /clear กับ /compact"_) as a user-owned 4th file. Closes [#176](https://github.com/pitimon/8-habit-ai-dev/issues/176) via [PR #177](https://github.com/pitimon/8-habit-ai-dev/pull/177).
-
-Three new sections in `guides/persistence-convention.md`: **`## Current State File (Optional, User-Owned)`** (recommends `docs/specs/<slug>/current-state.md` with template doing-now / stuck-at / next / last-updated; user-owned, no plugin skill writes; frontmatter-exempt; `/consistency-check` explicitly excluded), **`## Auto-Update Recipe (User-Side, Optional)`** (CLAUDE.md rule template the user adopts — plugin does NOT enforce per ADR-013 Alt-4: no-build philosophy + unintended file artifacts), and **`## Attribution`** (credits the article + #176).
-
-Solves the resume-after-context-loss problem (`/clear`, `/compact`, session crash) at **task level** — complements `hooks/session-start.sh:83-115`'s step-level artifact-detection nudges (Issue #119, v2.7.0). Habit mapping: H5 + H3 for Current State File; H1 for Auto-Update Recipe. Honors PR #111's local-maximum lesson: no new skill, no new agent, no validator change, no DAG change. Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 0 fitness breaches. `@8-habit-reviewer` pre-merge: 17/17 PASS + 2 polish items both addressed in-PR. Pattern: **community-article convention-only import** — distinct shape from v2.15.1's upstream-skill extract; the article has no canonical PR/commit to cite, attribution is paraphrased title + issue link.
-
-## v2.15.1 — Doubt-Driven Techniques Imported (May 2026)
-
-Patch release. Single-guide enhancement to `guides/advisor-pattern.md` importing three techniques from [`addyosmani/agent-skills` — `doubt-driven-development`](https://github.com/addyosmani/agent-skills/blob/main/skills/doubt-driven-development/SKILL.md) (MIT, [PR #139](https://github.com/addyosmani/agent-skills/pull/139), upstream 2026-05-07 — **27 days after** our prior addyosmani audit in PR #111). Closes [#173](https://github.com/pitimon/8-habit-ai-dev/issues/173) via [PR #174](https://github.com/pitimon/8-habit-ai-dev/pull/174).
-
-The new `## Disprove-Mode Disciplines` section adds three labeled subsections: **Anti-CLAIM-bias rule (H5)** (pass `ARTIFACT + CONTRACT` only; hold the CLAIM back so the reviewer independently re-derives it), **Iterative review 3-cycle cap (H3 + H7, conditional)** (bounded loop with user escalation; single-shot pattern unchanged), and **Adversarial prompt template (H1 + H5)** (disprove-only output dispatched to a fresh subagent with no named role and read-only tools — not `@8-habit-reviewer`, whose 17-question process is fixed).
-
-Honors PR #111's local-maximum lesson: no new skill, agent, or validator. Quick Reference table gains a second row for the adversarial pattern; See Also cites the MIT upstream. Rejected in-scope candidates explicit in #173 body: new `/doubt-check` skill, `source-driven-development` import, cross-model CLI escalation, agentskills.io frontmatter migration (ADR-007 NO-GO holds). Validator state: `validate-structure.sh` 256/256 PASS, `validate-content.sh` 214/214 PASS pre-release-meta. Pattern: **post-audit delta** — evaluate upstream methodology innovations in isolation when they publish after a periodic audit.
-
-## v2.15.0 — Cross-Artifact Consistency Analyzer + Opt-In Spec Persistence (May 2026)
-
-Minor release adding `/consistency-check` (the 18th skill) and an opt-in `--persist <slug>` argument to `/requirements`, `/design`, `/breakdown`. Inspired by github/spec-kit `/analyze`, adapted to our discipline-not-enforcement philosophy ([#165](https://github.com/pitimon/8-habit-ai-dev/issues/165)).
-
-The new `/consistency-check` skill reads persisted `docs/specs/<slug>/{prd,design,tasks}.md` files and runs 5 detection passes — Coverage, Drift, Ambiguity, Underspec, Inconsistency — emitting severity-graded findings (CRITICAL/HIGH/MEDIUM/LOW) with file:line citations. Hybrid evaluation: deterministic when artifacts include `FR-NNN`/`Decision-N`/`Task #N` ID markers (recommended), LLM semantic with explicit warning when absent. Read-only by design — emits findings, never blocks. Boundary preserved: enforcement on persisted artifacts still belongs in `pitimon/claude-governance`.
-
-The persistence half is fully backward compatible: without `--persist`, all three modified skills behave byte-identically to v2.14.3. With `--persist <slug>`, they additionally write outputs to `docs/specs/<slug>/{prd,design,tasks}.md` with YAML frontmatter, while preserving conversation `SKILL_OUTPUT` blocks (`/cross-verify` auto-detect unaffected). Conflict policy: AskUserQuestion prompt → fallback to numbered variant in non-interactive contexts. Slug validation regex `^[a-z0-9][a-z0-9-]{1,63}$` prevents path traversal.
-
-Self-applied dogfood: this release's own `prd.md`, `design.md`, `tasks.md`, and ADR-013 live in `docs/specs/consistency-check/`. Run `/consistency-check consistency-check` against the dogfood as smoke test (manual procedure documented in CONTRIBUTING.md). Skills count: 17 → 18. See [ADR-013](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-013-spec-persistence-opt-in.md) for design rationale, 5 alternatives considered, flag-style argument convention attestation, and hybrid pass evaluation strategy.
-
-## v2.14.3 — Post-Migration Cleanup + Validator Self-Discipline (May 2026)
-
-Patch release closing [#163](https://github.com/pitimon/8-habit-ai-dev/issues/163) — three small cleanups left in v2.14.2's wake plus applying the validator's own 800-line rule to itself.
-
-- **ADR-012 metadata closure** — `SELF-CHECK.md` reframed two lines describing the deleted EU AI Act research + mapping files as if they still existed; `docs/adr/ADR-012-eu-ai-act-migration-completion.md` status header upgraded with `**Implementation**:` field naming commit `ed65b97` (v2.14.2 release) and the metadata-closure date
-- **`.gitignore`** — created with `/deep-project/` and `/.claude/` entries to gate against accidental `git add .` of cross-plugin checkouts and Claude Code session artifacts
-- **`tests/validate-content.sh` trim** — 831 → 793 lines via comment consolidation across Check 15 (EU AI Act stub explainer), Check 19 sub-check rationales, F2 + F3 explainers; logic untouched, 10 checks preserved, PASS count = 205
-
-Pattern: validator self-discipline — when a fitness function applies to the rest of the codebase, it applies to the validator too.
-
-## v2.14.2 — EU AI Act Migration Completion (May 2026)
-
-Plugin-boundary correction. The EU AI Act compliance toolkit (skill + reference + research + mapping guide) migrated to [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance) v3.1.0 on 2026-05-02 per memory observation #233270 (2026-04-07): `8-habit-ai-dev` = workflow discipline; `claude-governance` = compliance enforcement + framework mappings. EU AI Act compliance is a framework mapping, not a workflow step. Original placement here was a boundary error.
-
-- **Removed**: `skills/eu-ai-act-check/reference.md`, `docs/research/eu-ai-act-obligations.md`, `guides/eu-ai-act-mapping.md` (now canonical in `claude-governance` v3.1.0)
-- **Stub**: `skills/eu-ai-act-check/SKILL.md` rewritten as a redirect to the canonical location with install + invocation examples; preserves NOT LEGAL ADVICE disclaimer; skill name remains valid in the catalog so existing cross-references resolve
-- **ADR**: ADR-005 marked Superseded by ADR-012 (this migration completion)
-- **Validator**: Check 15 in `tests/validate-content.sh` rewritten to assert post-migration state (stub correctness + deleted-file negative assertions + ADR-012 presence + ADR-005 Superseded marker)
-- **Cross-refs**: reframed in RESOLVER, using-8-habits, design Step 5, ai-dev-log, session-start hook, README skill table
-
-Wiki Architecture/FAQ/Home/Installation/Skills-Reference/Workflow-Overview pages and the README "EU AI Act ready" badge are deferred to a follow-up doc-only PR (precedent: `pitimon/claude-governance` PR #25 + #26 — local Markdown formatter rewrites tables on every Edit, producing 140+ lines of unrelated noise).
-
-Coordination: this is the second half of the migration. The first half shipped in [`pitimon/claude-governance` v3.1.0 PR #26](https://github.com/pitimon/claude-governance/pull/26).
-
-## v2.14.1 — README "What's New" Drift Guard (May 2026)
-
-Patch release closing [#157](https://github.com/pitimon/8-habit-ai-dev/issues/157) — external QA found `validate-content.sh` Check 19A was passing on the README badge URL `releases/tag/v2.14.0` instead of asserting the section header `## What's New in v2.14.0`. Same bug class as [#124](https://github.com/pitimon/8-habit-ai-dev/issues/124) (CHANGELOG pointer-fallback) and [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) (SELF-CHECK.md body drift) — capability-level recurrence on a sibling surface.
-
-- **README.md backfill** — restored missing `## What's New in v2.14.0` block, fixed broken TOC anchor (`#whats-new-in-v220` → `#whats-new-in-v2141`, broken since v2.3.0), backfilled 4 missing skills in the architecture file tree (calibrate, using-8-habits, eu-ai-act-check, ai-dev-log) so the tree matches the declared 17-skill count.
-- **`tests/validate-content.sh` Check 19 sub-check G** — anchored grep `^## What's New in v${current_version}` in README.md. Closes the badge-URL false-positive class permanently. Mirrors the sub-checks E + F mechanism from PR #144.
-- **Check 20 hardening** — pin literal `Find → Fix → Re-Verify` loop name + assert exactly 5 numbered steps in `skills/review-ai/SKILL.md` Verification Phase. Closes the v2.14.0 self-disclosed follow-up (passes-on-3-string-matches risk).
-
-Pattern: same shape as v2.11.1 and v2.13.1 — QA surfaces drift class on a sibling surface → fix is fitness function, not checklist. Check 19 now covers README + CHANGELOG + wiki + SELF-CHECK + README-section-header — five anchored assertions, all co-located.
-
-Fitness receipts: `validate-structure.sh` 246/0, `validate-content.sh` **206/0/1 WARN** (was 203; +3 new assertions), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
-
-External QA report by [@itarunp-apple](https://github.com/itarunp-apple) — ran the plugin's own `8-habit-reviewer` agent against v2.14.0 install per the framework's intended self-discipline workflow.
-
-Closes #157.
-
----
-
-## v2.14.0 — TOH Framework Inspirations (May 2026)
-
-Minor release closing milestone [#15](https://github.com/pitimon/8-habit-ai-dev/milestone/15) — three workflow-discipline imports from Toh Framework (`Nathanphop/Toh-Framework`, now unavailable) (an "AI-Orchestration Driven Development" framework for solo SaaS builders). Cross-pollination filtered through plugin-boundary: workflow discipline here, project-state persistence routed to `claude-governance`.
-
-- **SKILL_OUTPUT attribution lines** ([#151](https://github.com/pitimon/8-habit-ai-dev/issues/151), [PR #152](https://github.com/pitimon/8-habit-ai-dev/pull/152)) — `[/<skill>] COMPLETE SKILL_OUTPUT:<type>` directly above each HTML comment in the 4 emitter skills. Status markers `COMPLETE` / `PARTIAL` / `FAILED` (text-only). New **Check 22** in `validate-structure.sh`; `cross-verify` parser unaffected. Inspired by Toh's Agent Announcement format.
-- **Argument-driven smart-routing for `/using-8-habits`** ([#149](https://github.com/pitimon/8-habit-ai-dev/issues/149), [PR #154](https://github.com/pitimon/8-habit-ai-dev/pull/154)) — `/using-8-habits "<intent>"` returns ≤3 ranked skills + reasoning + alternatives + one direct question, instead of the full narrative tree. Reads `~/.claude/habit-profile.md` for verbosity and recent `~/.claude/lessons/` for context. Activates existing `argument-hint` frontmatter — no new skill file. Inspired by Toh's `/toh` Smart Command (reshape: extend rather than wrap).
-- **`/review-ai` Verification Phase** ([#150](https://github.com/pitimon/8-habit-ai-dev/issues/150), [PR #155](https://github.com/pitimon/8-habit-ai-dev/pull/155)) — Find → Fix → Re-Verify loop: list CRITICAL/HIGH, apply fix, re-run review, cite evidence per finding, refuse to emit `pass: true` unless all CRITICAL closed. Output ends with a Verification Table. **Plugin boundary**: section header reads "guidance only — NOT a hook"; new **Check 20** in `validate-content.sh` enforces three-anchor boundary qualifier. Inspired by Toh's Test → Fix → Loop adapted as discipline guidance, not automated enforcement.
-
-Pattern: external-framework cross-pollination kept tight by the boundary rule — 3 of 10 Toh ideas imported, 7 rejected with reason (multi-agent builders, "vibe" command, design profiles, component registry, multi-IDE adapters, 7-file project memory). Companion proposal in `claude-governance` ([#24](https://github.com/pitimon/claude-governance/issues/24)) for the persistence layer.
-
-Fitness receipts: `validate-structure.sh` **246/0** (+1), `validate-content.sh` **201/0/1 WARN** (+3), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
-
-Closes #149, #150, #151.
-
----
-
-## v2.13.1 — SELF-CHECK.md Body Freshness (April 2026)
-
-Patch release closing the three-PR arc for [#141](https://github.com/pitimon/8-habit-ai-dev/issues/141) — SELF-CHECK.md body drift (header said v2.13.0 but footer said Previous: 2.7.1 and per-release list ended at v2.8.0, skipping 6 releases).
-
-- **One-time catch-up** ([PR #142](https://github.com/pitimon/8-habit-ai-dev/pull/142)) — SELF-CHECK.md footer updated to `Previous: 2.12.0`; added 6 missing rows (v2.9.0 through v2.13.0). Plugin opens with _"H8 Modeling: Follow the process always, no shortcuts when unwatched"_ — contradicted by 6 consecutive silent releases.
-- **Convention correction** ([PR #143](https://github.com/pitimon/8-habit-ai-dev/pull/143)) — CONTRIBUTING.md § Version Bumping "Version lives in **3 files**" → "**4 files**", adds `SELF-CHECK.md` header to the list (convention enforced since [#106](https://github.com/pitimon/8-habit-ai-dev/issues/106) but CONTRIBUTING.md never caught up).
-- **CI invariant** ([PR #144](https://github.com/pitimon/8-habit-ai-dev/pull/144)) — `tests/validate-content.sh` Check 19 sub-checks E + F: footer must match `git tag -l "v2.*" | sort -V` predecessor of `plugin.json.version` (E); every v2.x tag must have a matching `^- v<x.y.z>: ` row in SELF-CHECK.md (F). Prevents recurrence of the drift class.
-- **`.github/workflows/validate.yml`** — `fetch-tags: true` + `fetch-depth: 0` added to `actions/checkout@v4` so CI can read tag history.
-
-Fitness receipts: `validate-structure.sh` 245/0, `validate-content.sh` **198/0/1 WARN** (was 196 + 2 net new pass-able assertions — same hardening shape as v2.11.1 drift guard), `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
-
-Closes #141.
-
----
-
-## v2.13.0 — Cross-Agent Discoverability (April 2026)
-
-Minor release making the plugin discoverable from non-Claude agent platforms — three linked PRs from the 2026-04-22 `/research` session on [`garrytan/gbrain`](https://github.com/garrytan/gbrain). No breaking changes.
-
-- **`skills/RESOLVER.md`** ([#135](https://github.com/pitimon/8-habit-ai-dev/issues/135), [PR #139](https://github.com/pitimon/8-habit-ai-dev/pull/139)) — flat phrase-to-skill dispatcher covering all 17 skills in 3 sections (Workflow / Assessment / Meta), ≤3 triggers each. Fills the phrase→path lookup gap; **Check 20** enforces bidirectional coverage (directory ↔ RESOLVER row).
-- **`llms.txt` + `AGENTS.md`** at repo root ([#136](https://github.com/pitimon/8-habit-ai-dev/issues/136), [PR #140](https://github.com/pitimon/8-habit-ai-dev/pull/140)) — cross-agent entry points for Codex / Cursor / Windsurf / Aider / Continue / LLM-based fetchers. `llms.txt` follows [llmstxt.org](https://llmstxt.org) convention; `AGENTS.md` is the non-Claude operating protocol. **Check 21** enforces both files exist + 4× pointer integrity to `skills/RESOLVER.md` and `CLAUDE.md`.
-- **README "Design Principle" section** ([#137](https://github.com/pitimon/8-habit-ai-dev/issues/137), [PR #138](https://github.com/pitimon/8-habit-ai-dev/pull/138)) — cites Garry Tan's 2026 essay _"Thin Harness, Fat Skills"_ as external validation of the bounded-hook + fat-skills pattern already enforced by `hooks/session-start.sh` (≤300 tokens).
-- **ADR-010** (Flat Skill Dispatcher) and **ADR-011** (Cross-Agent Discoverability) — 6 options considered each; ADR-011 records the design-time empirical finding that `obra/superpowers-skills/.../references/` (cited in #136's issue body) was already HTTP 404 — AGENTS.md cites upstream tool patterns by name only.
-- **Pattern extracted**: "Bidirectional Validator for Canonical Cross-References" — forward + reverse coverage invariants as the unit-test analog for documentation integrity. Check 12 / 20 / 21 share this shape.
-
-Fitness receipts: `validate-structure.sh` 245/0, `validate-content.sh` 196/0/1 WARN, `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0. End-to-end cross-agent chain: `llms.txt → AGENTS.md → skills/RESOLVER.md → individual SKILL.md`.
-
-Closes #135, #136, #137.
-
----
-
-## v2.12.0 — Code-Symbol Grep Evidence (April 2026)
-
-Minor release adding a new Evidence Standard obligation to `/research` and clarifying `research-verifier` scope ([#133](https://github.com/pitimon/8-habit-ai-dev/issues/133)). Guidance-only — no automation, no hook.
-
-- **`/research` Evidence Standard** — code-symbol verdicts matching `/remove|dead|unused|transitional|safe to (drop|remove)/i` must cite a grep-check showing consumer usage across source directories; declaration-site citations (e.g. `package.json:6`) do not establish liveness. Closes a false-positive class surfaced by memforge `neo4j-driver` audit (the canonical Bolt client for Memgraph — brand-name mismatch passed Deep-mode with pristine citations).
-- **`research-verifier` scope** — `description:` rewritten to "citation-integrity verification agent"; new `## Limit of Verification` section defines in-scope (citation accuracy) vs. out-of-scope (semantic correctness of conclusions). Verifier emits `SEMANTIC-EVIDENCE-MISSING` flag on code-symbol verdict rows lacking liveness evidence but does not perform the grep itself.
-- **Trigger regex scope** — `"revisit"` intentionally excluded; over-triggers on follow-up-style verdicts. Hard-removal verdicts are the load-bearing class.
-
-Fitness receipts: `validate-structure.sh`, `validate-content.sh`, `test-skill-graph.sh`, `test-verbosity-hook.sh` all green.
-
-Closes #133.
-
----
-
-## v2.11.1 — CHANGELOG Drift Guard (April 2026)
-
-Patch release hardening `validate-content.sh` Check 19 against recurring CHANGELOG drift ([#124](https://github.com/pitimon/8-habit-ai-dev/issues/124), [PR #131](https://github.com/pitimon/8-habit-ai-dev/pull/131)). Post-v2.11.0 `/cross-verify` exposed the same drift class slipping CI twice (v2.9.0 + v2.11.0) through a pointer-fallback loophole.
-
-- **3 new FAIL-severity assertions** in Check 19: `CHANGELOG.md ^## v<ver>` present, wiki `^## v<ver>` present (no pointer fallback), wiki badge `latest-v<ver>-blue` match.
-- **Backfilled** missing v2.9.0 + v2.11.0 entries in root `CHANGELOG.md` and v2.11.0 in wiki `Changelog.md`.
-
-Fitness receipts: `validate-structure.sh` 243/0, `validate-content.sh` 185/0, `test-skill-graph.sh` 57/0, `test-verbosity-hook.sh` 19/0.
-
-Closes #124.
-
----
-
-## v2.11.0 — Design Pipeline Completion + Wiki Redesign (April 2026)
-
-Close the final gap in the `/requirements` → `/design` → `/breakdown` → `/review-ai` structured-output-block handoff chain, and upgrade 20 wiki pages to a professional template. Both PRs merged within 3 minutes of each other.
-
-- **`SKILL_OUTPUT:design` structured block** ([#128](https://github.com/pitimon/8-habit-ai-dev/issues/128) / [PR #129](https://github.com/pitimon/8-habit-ai-dev/pull/129)) — closes the last cross-skill handoff gap; `/cross-verify` Q4/Q14/Q16 now auto-populate from the design block.
-- **Tech-stack decisions as formal concerns** — `/design` Step 2 + `/research` Step 1 surface language/framework as explicit outputs.
-- **Scope validation via `SKILL_OUTPUT:requirements`** — `/design` consumes the requirements block so scope drift between decisions and success criteria is flaggable.
-- **H8 Whole Person in `/design` checkpoint** — Body/Mind/Heart/Spirit prompts.
-- **Wiki redesign** ([#127](https://github.com/pitimon/8-habit-ai-dev/issues/127) / [PR #130](https://github.com/pitimon/8-habit-ai-dev/pull/130)) — new `Architecture.md` (4-layer plugin design), new `Maturity-Model.md` (4-level adaptive guidance), `Home.md` rewritten as hero landing page, `Skills-Reference.md` expanded 13 → 17 with quick-select matrix, `Workflow-Overview.md` Mermaid diagram, all 8 Step pages with `> [!IMPORTANT]` checkpoints, `_Sidebar.md` reorganized with Concepts section. 18 files, 291 insertions, 53 deletions.
-
-Fitness receipts: `validate-structure.sh` 243/0, `validate-content.sh` 183/0, `test-skill-graph.sh` PASS, `test-verbosity-hook.sh` PASS.
-
----
-
-## v2.10.0 — Progressive-Disclosure SKILL.md Split (April 2026)
-
-Refactor the 3 largest skills into `SKILL.md + reference.md + examples.md` triads per [ADR-009](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-009-skill-split-convention.md). Creates headroom below the F3 word-budget fitness ceiling so future feature additions don't break the validator. Pattern sourced from external research (`shanraisshan/claude-code-best-practice`), filtered through plugin-boundary audit.
-
-- **ADR-009** — codifies Load-directive mechanism (`${CLAUDE_PLUGIN_ROOT}` inline paths), naming convention, and when-to-apply threshold (SKILL >1500 words). Reuses existing Check 8 for sibling existence — no new fitness function needed for that.
-- **F6 (Check 9b)** — soft word-budget warning for `reference.md` / `examples.md` (5000-word soft limit).
-- **`using-8-habits`** split: SKILL 1990 → 1094 words; `reference.md` holds the full 17-skill inventory + cross-plugin composition tables; `examples.md` holds the password-reset onboarding walkthrough.
-- **`eu-ai-act-check`** split: SKILL 1989 → 908 words; `reference.md` holds the full 9-obligation checklist (25 MUST / 27 SHOULD / 8 COULD items) with article/paragraph references. No `examples.md` (pure-reference skill).
-- **`calibrate`** split: SKILL 1774 → 1161 words; `reference.md` holds the scoring rubric + profile-write procedure; `examples.md` holds 4 sample profiles (one per maturity level).
-- **Content validator triad-awareness** — Checks 15 and 18 in `tests/validate-content.sh` now search the SKILL + reference + examples triad as a unit, so content moved to sibling files still satisfies anti-drift and tier-count assertions.
-- **Rejected from this release** — 27-event hook catalog (referred to [`pitimon/claude-governance#22`](https://github.com/pitimon/claude-governance/issues/22)), Idea B (auto-load `user-invocable: false` habits), Idea D (parallel `/cross-verify` dispatch), F3 WARN→FAIL upgrade. Rejection rationale documented in root `CHANGELOG.md`.
-
-Fitness receipts: `validate-structure.sh` 243/0, `test-skill-graph.sh` PASS, `validate-content.sh` 183/0 with 0 fitness breaches. Release shipped via [Issue #125](https://github.com/pitimon/8-habit-ai-dev/issues/125) / [PR #126](https://github.com/pitimon/8-habit-ai-dev/pull/126) in a single clean forward pass.
-
----
-
-## v2.9.0 — Deep-Project Inspired Improvements (April 2026)
-
-Three features inspired by comparison research against `piercelamb/deep-project`. Cross-verified (14/17), advisor-reviewed, 8-habit QA passed (13/17 → 15/17).
-
-- **Interview protocol for `/requirements`** ([#118](https://github.com/pitimon/8-habit-ai-dev/issues/118)) — new `guides/templates/interview-protocol.md` gives structured conversation scaffolding (Quick/Standard/Deep depth) for discovering requirements before EARS criteria. Replaces the "ask the user 5 questions" default with a better-shaped discovery flow.
-- **Workflow step awareness in session-start hook** ([#119](https://github.com/pitimon/8-habit-ai-dev/issues/119)) — `hooks/session-start.sh` now surfaces a workflow step cue so partial chains can resume across sessions without per-skill rework.
-- **Machine-readable structured output blocks** ([#120](https://github.com/pitimon/8-habit-ai-dev/issues/120)) — new `guides/structured-output-protocol.md` defines `<!-- SKILL_OUTPUT:... END_SKILL_OUTPUT -->` HTML comment blocks at the end of `/requirements`, `/breakdown`, and `/review-ai`. Enables `/cross-verify` to auto-check scope alignment (task_count vs ears_count ≤ 3× ratio) and review coverage, reducing manual re-reading of prior-step artifacts.
-
----
-
-## v2.8.0 — Claude Code Architecture Insights (April 2026)
-
-Production patterns from Anthropic's Claude Code internals (reverse-engineered in ["Claude Code from Source"](https://github.com/alejandrobalderas/claude-code-from-source)) adapted into 4 existing skills as workflow guidance.
-
-- **`/build-brief` context compression awareness** ([#114](https://github.com/pitimon/8-habit-ai-dev/issues/114)) — step 6 "Context survival" for briefs that survive the 4-layer compression pipeline
-- **`/design` sticky latch principle** ([#116](https://github.com/pitimon/8-habit-ai-dev/issues/116)) — step 5 "Sticky decisions" with rework-level classification table
-- **`/reflect` lesson consolidation** ([#113](https://github.com/pitimon/8-habit-ai-dev/issues/113)) — Step 7 + `/reflect consolidate` argument with 4-phase dream-inspired cycle
-- **`/breakdown` fork agent pattern** ([#115](https://github.com/pitimon/8-habit-ai-dev/issues/115)) — step 5 "Token-efficient parallel design" with ~90% cache hit guidance
-
-## v2.7.1 — Review Discipline Refinement (April 2026)
-
-Small post-milestone patch adding two disciplines to `/review-ai` after a cost/benefit audit against `addyosmani/agent-skills` (MIT). Scope deliberately minimal — only one of six candidate mechanics was imported.
-
-- **`/review-ai` Performance axis** ([#110](https://github.com/pitimon/8-habit-ai-dev/issues/110), [PR #111](https://github.com/pitimon/8-habit-ai-dev/pull/111)) — fourth review category flagging N+1 queries, unbounded loops, missing pagination, unindexed queries, and memory leaks; same `file:line` evidence standard as the other axes
-- **Review-tests-first directive** — new Process step 2 directs the reviewer to read new/changed tests before judging implementation
-- **Rejections preserved in PR #111 body** — `guides/anti-rationalization.md`, `guides/red-flags.md`, `guides/google-engineering-principles.md`, `/cross-verify` Q18, and a cross-plugin hard-gate spec were all evaluated and rejected as duplicative of existing features or out-of-scope
-
-## v2.7.0 — Reader Adoption (April 2026)
-
-Closes the `/calibrate` feature loop by making skills read `~/.claude/habit-profile.md` via a session-start hook.
-
-- **Hook-based verbosity adaptation** ([#96](https://github.com/pitimon/8-habit-ai-dev/issues/96)) — `hooks/session-start.sh` emits a per-level directive into session context; 16 existing skills auto-adapt with zero file changes
-- **`guides/verbosity-adaptation.md`** — canonical per-level rules with 5 skill-archetype examples
-- **`tests/test-verbosity-hook.sh`** — 12-assertion regression coverage for all 8 hook branches + HABIT_QUIET opt-out + ≤300-token budget check
-- **4 validators in CI, 482 total assertions** (up from 3 / 470)
-- **Milestone v2.7.0 CLOSED** — Hermes-inspired feature loop (v2.6.0 + v2.7.0) complete
-
-## v2.6.1 — Skill Effectiveness Tracking (April 2026)
-
-- **`/reflect` Q6 Skill Effectiveness signal** ([#92](https://github.com/pitimon/8-habit-ai-dev/issues/92)) — 6th retro question captures "most useful" and "least useful/confusing" skill
-- **`SKILL-EFFECTIVENESS.md`** (repo root) — maintainer-curated trend tracker; H7 applied to the plugin itself
-- **`guides/templates/lesson-template.md`** — new `## Skill effectiveness` section for consistent Q6 capture
-- **Fix**: SIGPIPE flake in `validate-content.sh` F3 extractor — replaced `sed | head` with pipe-safe awk
-
-## v2.6.0 — Hermes-Inspired Improvements (April 2026)
-
-- **`/calibrate` skill + habit-profile schema v1** ([#90](https://github.com/pitimon/8-habit-ai-dev/issues/90), [ADR-008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md)) — 5-7 question self-assessment writing `~/.claude/habit-profile.md` with dominant-level scoring
-- **`guides/habit-profile-schema.md`** — public schema contract (YAML + markdown body, versioned via `schema-version`)
-- **Persistent reflection artifacts** ([#88](https://github.com/pitimon/8-habit-ai-dev/issues/88)) — `/reflect` writes lessons to `~/.claude/lessons/`; `/research` and `/build-brief` read them before starting work
-- **`guides/habit-nudges.md`** + **ADR-007** — nudge spec (hook delegated to claude-governance) + agentskills.io NO-GO decision
-- **Skill count: 16 → 17** (`/calibrate` added)
-
-## v2.5.0 — Testing & Discoverability (April 2026)
-
-- **`tests/test-skill-graph.sh`** — DAG validator for `prev-skill` / `next-skill` chains (#79): cycles, dangling refs, symmetric edges, orphans
-- **`hooks/pre-commit.sh.example`** — template running `/review-ai` on staged files (opt-in, not auto-installed)
-- **Bidirectional wiki ↔ skills linking** (#81) — each workflow skill has a `## Further Reading` section linking to its wiki page
-- CI now runs 3 validators; 443 total assertions
-
-## v2.4.1 — Honest Correction (April 2026)
-
-Same-day correction after comparing `/brainstorm` to `superpowers:brainstorming`.
-
-- **Removed `/brainstorm` skill** (breaking) — superpowers' 500+ line hard-gate discipline suite is a better fit; `/research` now references it for fuzzy problem statements
-- **`HABIT_QUIET=1` opt-out** for `hooks/session-start.sh` — users who internalize the workflow can silence the reminder
-- **"Core 5" tier** in `/using-8-habits` — 80/20 reality acknowledgment
-- [ADR-006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-opt-out.md) — audience-honesty + opt-out + "check peer plugins before building parity" lesson
-
-## v2.4.0 — Workflow Completions (April 2026)
-
-- **`/brainstorm`** (Step 0a, later removed in v2.4.1) — 5 Whys, alternative framings, hidden assumptions
-- **EARS-notation in `/requirements`** — 5 structured acceptance criteria templates from Rolls-Royce (Mavin et al. 2009)
-- **`/using-8-habits`** — onboarding meta-skill with decision tree and complete walkthrough example
-- Validators: +52 assertions, anti-drift check ensures meta-skill references every directory skill
-- Fix: `validate-structure.sh` regex allowing digits in skill names
-
-## v2.3.0 — EU AI Act Compliance Toolkit (April 2026)
-
-Flagship blue-ocean feature: first Claude Code plugin with explicit EU AI Act compliance toolkit, shipped ~4 months before 2 August 2026 enforcement.
-
-- **`/eu-ai-act-check`** — 9-obligation tiered checklist (25 MUST + 27 SHOULD + 8 COULD) covering Articles 9-15
-- **`/ai-dev-log`** + **`scripts/generate-ai-dev-log.sh`** — AI-assisted development log from `git log` + Co-Authored-By trailers (4 modes: markdown/json/summary/out)
-- **`/design` Step 5** — Article 14 human-oversight 5-capability checkpoint (Understand / Automation bias / Interpret / Override / Stop button)
-- **`docs/research/eu-ai-act-obligations.md`** — primary-source research with Verified Quotes for all 7 articles
-- **[ADR-005](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-005-eu-ai-act-toolkit.md)** + **Plugin Boundary section** in `CLAUDE.md` — documents complementary relationship with [`pitimon/claude-governance`](https://github.com/pitimon/claude-governance)
-- Version file convention corrected to **4 files** (added `SELF-CHECK.md`)
-- Fix: `validate-structure.sh` SIGPIPE race replaced `sed | head` with awk
-
-## v2.2.0 — April 2026
-
-- README overhauled with a professional 8-Habit aligned template
-- Hero tagline reframed around pain-point + benefit
-- Quick Start split into install + use blocks
-- 7-Step Workflow diagram simplified
-- GitHub repo description and topics updated
-- Wiki infrastructure introduced (`docs/wiki/`, sync Action, link check) — see [ADR-004](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-004-wiki-as-artifact.md)
-
-## v2.1.0
-
-- Smart QA integration with 8-Habit framework
-- README internal link and skill cross-reference validation
-- `validate-content.sh` fitness function improvements
-
-## v2.0.0
-
-- Three accepted ADRs drive architecture:
-  - [ADR-001 Orchestration Patterns](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-001-orchestration-patterns.md)
-  - [ADR-002 Research Modes](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-002-research-modes.md)
-  - [ADR-003 Content Validation](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-003-content-validation.md)
-- Three architecture fitness functions (skill complexity, content depth, cross-reference integrity)
-- `validate-content.sh` added alongside `validate-structure.sh`
-
-## v1.x
-
-- Initial 7-step workflow and 8-habit skill set
-- Cross-verify agent (`8-habit-reviewer`)
-- External QA review v1.0.0 scored 9.5/10 (EXCELLENT) — [Issue #1](https://github.com/pitimon/8-habit-ai-dev/issues/1)
-
-## Versioning policy
-
-This plugin follows [semantic versioning](https://semver.org/):
-
-- **Major** — breaking change to skill interfaces, skill removal, or workflow restructuring
-- **Minor** — new skills, new habits content, backward-compatible additions
-- **Patch** — documentation fixes, typo corrections, clarifications
-
-Version is tracked in five files that must bump together (enforced by `tests/validate-structure.sh`):
-
-- `.claude-plugin/plugin.json`
-- `.claude-plugin/marketplace.json`
-- `.codex-plugin/plugin.json`
-- `README.md` (badge + footer)
-- `SELF-CHECK.md` header
-
-## Full history
-
-- **Releases**: [github.com/pitimon/8-habit-ai-dev/releases](https://github.com/pitimon/8-habit-ai-dev/releases)
-- **Tags**: [github.com/pitimon/8-habit-ai-dev/tags](https://github.com/pitimon/8-habit-ai-dev/tags)
-- **Commits**: [github.com/pitimon/8-habit-ai-dev/commits/main](https://github.com/pitimon/8-habit-ai-dev/commits/main)
+- [Home](Home)
+- [Skills Reference](Skills-Reference)
+- [Architecture](Architecture)

--- a/docs/wiki/Contributing-to-Wiki.md
+++ b/docs/wiki/Contributing-to-Wiki.md
@@ -1,153 +1,55 @@
-# Contributing to Wiki
+# Contributing To Wiki
 
-The wiki is a **build artifact**. Source of truth lives in [`docs/wiki/`](https://github.com/pitimon/8-habit-ai-dev/tree/main/docs/wiki) in the main repository. Edits made via the GitHub Wiki web UI are **overwritten** on the next sync. This page explains how to contribute correctly.
+The public wiki is generated from `docs/wiki/` in the repository. Treat wiki changes like code changes: edit source files, validate locally, and open a PR.
 
-See [ADR-004](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-004-wiki-as-artifact.md) for the rationale.
+## Workflow
 
-## TL;DR
+1. Create a docs branch.
+2. Edit files under `docs/wiki/`.
+3. Preserve existing page filenames unless a redirect plan exists.
+4. Run validation.
+5. Open a PR for review.
+6. After merge, verify the wiki sync workflow and inspect the published page.
 
-```bash
-git clone https://github.com/pitimon/8-habit-ai-dev
-cd 8-habit-ai-dev
-git checkout -b docs/my-wiki-fix
-# edit docs/wiki/<page>.md
-git add docs/wiki/<page>.md
-git commit -m "docs(wiki): fix typo in Getting Started"
-git push -u origin docs/my-wiki-fix
-gh pr create
-```
+## Style
 
-Merge → GitHub Action syncs → wiki updates automatically.
+- Start every page with a clear H1 and short lead paragraph.
+- Prefer precise capability wording over marketing claims.
+- Say "guidance" or "workflow discipline" when that is what the plugin provides.
+- Do not claim runtime enforcement, cloud automation, legal advice, or compliance certification.
+- Keep links wiki-relative for wiki pages, for example `[Installation](Installation)`.
+- Use GitHub alert callouts only for important boundaries or warnings.
 
-## Step-by-step
+## Content Boundaries
 
-### 1. Fork and clone
+Do not add:
 
-```bash
-gh repo fork pitimon/8-habit-ai-dev --clone
-cd 8-habit-ai-dev
-```
+- secrets, tokens, credentials, customer-sensitive raw data, or private incident evidence,
+- platform-specific syntax across all skills without an accepted ADR,
+- new behavior claims that are not present in source skills,
+- release notes that conflict with `CHANGELOG.md` or GitHub Releases.
 
-### 2. Create a branch
-
-```bash
-git checkout -b docs/describe-change
-```
-
-Branch naming: use `docs/` prefix for wiki-only changes.
-
-### 3. Edit `docs/wiki/<page>.md`
-
-- Use sentence-case headings
-- Keep paragraphs short (3–5 lines)
-- Link with wiki-relative names: `[Step 2 · Design](Step-2-Design)` — no `.md` suffix
-- Add your page to `_Sidebar.md` if it is brand new
-- Do **not** edit `docs/wiki/Habits-Reference.md` — it is auto-generated from [`habits/h*.md`](https://github.com/pitimon/8-habit-ai-dev/tree/main/habits); edit the source instead
-
-### 4. Preview locally
+## Validation
 
 ```bash
-bash scripts/gen-habits-reference.sh   # if you touched habits/
-bash tests/validate-structure.sh        # verifies wiki skeleton
-bash tests/validate-content.sh          # fitness functions
+git diff --check
+bash tests/validate-structure.sh
+bash tests/validate-content.sh
 ```
 
-### 5. Commit with conventional message
+For link validation, rely on the wiki link-check workflow or run the same tool locally if available.
 
-```bash
-git commit -m "docs(wiki): add troubleshooting section for wiki sync"
-```
+## PR Checklist
 
-Types for wiki work: `docs(wiki): ...`.
+- Existing filenames and major links are preserved.
+- No empty links or empty code fences.
+- No unbalanced code fences.
+- No overclaiming language.
+- Operational updates remain visible when relevant.
+- The PR states that the change is docs-only if no package behavior changed.
 
-### 6. Open a PR
+## See Also
 
-```bash
-gh pr create --title "docs(wiki): ..." --body "..."
-```
-
-The `wiki-linkcheck.yml` Action runs automatically — fix any broken links it flags.
-
-### 7. After merge
-
-The `wiki-sync.yml` Action publishes to `<repo>.wiki.git` within seconds of the merge. Verify at [github.com/pitimon/8-habit-ai-dev/wiki](https://github.com/pitimon/8-habit-ai-dev/wiki).
-
-## Adding a new page
-
-1. Create `docs/wiki/Your-Page.md` with an H1 title
-2. Add an entry to `docs/wiki/_Sidebar.md` in the appropriate section
-3. Add at least one inbound link from another page (Home, Workflow Overview, etc.)
-4. Open the PR as above
-
-## Renaming or deleting a page
-
-- Renaming a page **breaks existing wiki URLs** — avoid if possible, or add a redirect note on the old page
-- Deletion: remove the file, remove the sidebar entry, grep for inbound links (`grep -rn "Your-Page" docs/wiki/`) and update them
-
-## Style guide
-
-- **Voice**: direct, helpful, no marketing language
-- **Length**: one screenful per page when possible; deep-dives get their own page
-- **Code blocks**: fenced with language tag (` ```bash `, ` ```yaml `)
-- **Tables**: use sparingly; convert to lists if the table has only 2 columns
-- **Emoji**: only if it adds clarity (warning, success, info). Do not put emoji in H1/H2 — they break anchor generation
-- **Bilingual**: English only for now; Thai translation is planned as a phase 2
-
-## Visual patterns
-
-The wiki uses consistent visual patterns. Follow these when editing or adding pages.
-
-### Alert boxes
-
-Use [GitHub alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) for callouts:
-
-| Type             | When to use                            | Example                                    |
-| ---------------- | -------------------------------------- | ------------------------------------------ |
-| `> [!NOTE]`      | Background context, FYI                | Architecture details, optional information |
-| `> [!TIP]`       | Helpful shortcuts, quick wins          | "New here? Start with..."                  |
-| `> [!IMPORTANT]` | Habit checkpoints, key principles      | Checkpoint questions on every step page    |
-| `> [!WARNING]`   | Process rules that must not be skipped | "Never skip `/review-ai`"                  |
-| `> [!CAUTION]`   | Real-world consequences, risk warnings | "These are not hypothetical..."            |
-
-### Mermaid diagrams
-
-Use `flowchart LR` for workflow pipelines. Color coding convention:
-
-```
-classDef optional fill:#e8f5e9,stroke:#4caf50     <!-- green: optional -->
-classDef human fill:#fce4ec,stroke:#e91e63         <!-- pink: human checkpoint -->
-classDef never_skip fill:#fff3e0,stroke:#ff9800    <!-- orange: never skip -->
-```
-
-Always add a legend line below the diagram: `> Green = optional · Pink = human checkpoint · Orange = **never skip**`
-
-### Badge row
-
-Use shields.io badges at the top of landing pages (Home, Changelog):
-
-```markdown
-![Version](https://img.shields.io/badge/version-X.Y.Z-blue)
-![Skills](https://img.shields.io/badge/skills-17-green)
-![License](https://img.shields.io/badge/license-MIT-brightgreen)
-```
-
-### Checkpoint pattern
-
-Every Step-N page ends with a checkpoint section using this exact format:
-
-```markdown
-## HN Checkpoint
-
-> [!IMPORTANT]
-> _"The checkpoint question here?"_
-```
-
-## What not to contribute (yet)
-
-- Per-project tutorials (put those in your own repo)
-- Translated pages (Thai EN-bilingual structure is planned — do not start yet)
-- Videos or heavy images (keep the wiki git-friendly)
-
-## Questions
-
-[Open an issue](https://github.com/pitimon/8-habit-ai-dev/issues) with the `wiki` label.
+- [Architecture](Architecture)
+- [Changelog](Changelog)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,81 +1,52 @@
 # FAQ
 
-## Is this a framework or a runnable app?
+This page answers common questions about what `8-habit-ai-dev` does, where its boundaries are, and how to choose the right workflow depth.
 
-Neither. It is a **Claude Code plugin** — structured markdown files that Claude Code loads at runtime. There is no build system, no dependencies, nothing to install beyond `claude plugin install`.
+## What Is This Plugin?
 
-## Do I have to run all 7 steps every time?
+It is a markdown guidance plugin for AI-assisted development. It provides 24 skills, a 7-step workflow, and review habits for Claude Code and Codex.
 
-No. See [Workflow Overview → When to Skip](Workflow-Overview#when-to-skip). Small changes skip most steps; the only step you should **never** skip is `/review-ai` (Step 5).
+## Does It Enforce Policy?
 
-## Why not just let Claude decide architecture?
+No. It gives prompts, checklists, handoffs, and review structure. Runtime enforcement, irreversible-action authorization, compliance frameworks, and dynamic orchestration engines belong in companion tooling such as `claude-governance`.
 
-Architecture decisions are hard to reverse and often require context that lives in people's heads — org priorities, team skills, operational constraints, past incidents. AI can propose options well, but the judgment call should belong to a human who will live with the consequences. See [H8 Find Your Voice](Habits-Reference#habit-8-find-your-voice-and-inspire-others).
+## Does Codex Run The Claude Hooks?
 
-## How is this different from just using `CLAUDE.md`?
+No. Codex can install the plugin and load the same markdown skills, but Claude hooks in `hooks/` are Claude Code-specific.
 
-`CLAUDE.md` is static guidance. This plugin adds:
+## Which Skill Should I Start With?
 
-- **Skills** — on-demand, step-specific playbooks loaded only when invoked
-- **Session hook** — a lean workflow reminder injected at session start
-- **Cross-verify agent** — independent 17-question checklist
-- **Handoff contracts** — each skill declares what it expects and produces
+| Situation | Skill |
+| --- | --- |
+| New feature | `/requirements` |
+| Unclear domain | `/research` |
+| Architecture choice | `/design` |
+| Before commit | `/review-ai` |
+| Production deploy | `/deploy-guide` |
+| Operational finding | `/operational-state` |
+| Bug investigation | `/diagnose` |
 
-You can (and should) combine the two: put project-specific context in `CLAUDE.md`, and use this plugin for workflow discipline.
+For a guided route, use `/using-8-habits`.
 
-## Does this replace code review by a human?
+## Do I Need All Seven Steps Every Time?
 
-**No.** `/review-ai` is an AI-driven audit that catches low-hanging issues (hallucinations, missing error handling, scope creep). A human reviewer catches things an AI cannot: intent mismatch, team conventions, strategic alignment. Use both.
+No. Use the workflow proportionally. Trivial fixes often need only review. Production-impacting changes need deployment planning. Unclear or architectural work should use the full path.
 
-## Can I use this in a language that isn't English?
+## Is `/review-ai` Optional?
 
-The skills themselves are in English. Bilingual Thai+English is the project's long-term goal — see [Contributing to Wiki](Contributing-to-Wiki) if you want to help translate.
+Not for AI-generated work. It is the baseline quality step before commit.
 
-## What's the difference between `/cross-verify` and `/review-ai`?
+## Is This An EU AI Act Compliance Toolkit?
 
-- `/review-ai` is **code-focused** — audits the diff for bugs, security, scope creep
-- `/cross-verify` is **process-focused** — 17 questions spanning all 8 habits, run **before** implementation starts
+No. This plugin includes a redirect stub for `/eu-ai-act-check`; the canonical compliance checklist lives in `pitimon/claude-governance`. This plugin can help produce reviewable engineering artifacts, but it does not certify compliance.
 
-Run `/cross-verify` on your plan before coding; run `/review-ai` on your code before committing.
+## Why Does The Wiki Say It Is Generated?
 
-## Do I need GitHub, or can I use GitLab/Bitbucket?
+The published GitHub Wiki is synced from `docs/wiki/`. Edit the repository files and open a PR; web edits to the GitHub Wiki can be overwritten by the sync workflow.
 
-The plugin itself is git-host-agnostic. Only the wiki sync (this documentation) depends on GitHub Actions. Everything else works anywhere.
+## See Also
 
-## Can I use this with other Claude Code plugins?
-
-Yes. This plugin is complementary with governance, security, and DevSecOps plugins. There are no hard conflicts — just different scopes.
-
-## How does this interact with `claude-governance`?
-
-They complement each other:
-
-- **8-habit-ai-dev** = workflow discipline (7 steps, 8 habits, cross-verification)
-- **claude-governance** = fitness functions and guardrails (secret scanning, commit conventions, ADRs)
-
-Use both for maximum coverage. See the note in [Base Camp](Home) for more.
-
-## Where are the habits actually defined?
-
-In [`habits/h1-...md` through `habits/h8-...md`](https://github.com/pitimon/8-habit-ai-dev/tree/main/habits). The [Habits Reference](Habits-Reference) page in this wiki is auto-generated from those files.
-
-## What is `/calibrate` and do I need it?
-
-`/calibrate` is a self-assessment skill that determines your maturity level (Dependence → Independence → Interdependence → Significance) and writes a profile to `~/.claude/habit-profile.md`. Other skills read this profile to adapt their verbosity — beginners get full guidance, experts get minimal prompts.
-
-You don't need it to use the plugin — the default is Independence level. Calibrate when guidance feels too detailed or too sparse. See [Maturity Model](Maturity-Model) for the full picture.
-
-## Does this plugin help with EU AI Act compliance?
-
-Yes. `/eu-ai-act-check` provides a 9-obligation checklist covering Articles 9-15 of EU AI Act Regulation 2024/1689, with **25 MUST + 27 SHOULD + 8 COULD** items. It includes a scope-check pre-flight so you can quickly skip if your system is not high-risk or not EU-targeted.
-
-The enforcement date is **2 August 2026**. This is believed to be the first Claude Code plugin with explicit EU AI Act compliance tooling. See [Skills Catalog → `/eu-ai-act-check`](Skills-Reference#eu-ai-act-check).
-
-## I found a bug or want to suggest a feature
-
-Open an issue: [github.com/pitimon/8-habit-ai-dev/issues](https://github.com/pitimon/8-habit-ai-dev/issues).
-
-## See also
-
-- **[Troubleshooting](Troubleshooting)**
-- **[Contributing to Wiki](Contributing-to-Wiki)**
+- [Installation](Installation)
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,98 +1,83 @@
 # Getting Started
 
+This walkthrough shows the smallest useful way to use `8-habit-ai-dev`: define the work, make the architecture decision explicit, implement with context, review before commit, and plan deployment before production.
+
 > [!TIP]
-> This walkthrough takes **~10 minutes**. Have a small feature from your backlog ready — a real one works best.
+> Use a real small feature. The workflow is clearer when the output matters.
 
-Your first structured feature. This walkthrough shows how the 7-step workflow replaces "just ask Claude to build X."
+## 1. Define The Work
 
-## Before you start
-
-- [Install the plugin](Installation)
-- Have a small feature idea in mind (a real one from your backlog is best)
-
-## The walkthrough
-
-### 1 · State your intent
-
-Open Claude Code in your project and describe what you want:
-
-```
+```text
 /requirements I need to add a rate limiter to our /api/search endpoint
 ```
 
-Claude produces a PRD summary: **What · Why · Who · In scope · Out of scope · Success criteria · Definition of Done**. Review and correct anything that does not match your intent — this is your first human checkpoint.
+Expected output: a short PRD with purpose, users, scope, out-of-scope items, success criteria, and Definition of Done.
 
-> [!TIP]
-> If the problem space is unclear, start with `/research` (Step 0) instead.
+Human checkpoint: correct the intent before any code is written.
 
-### 2 · Decide architecture
+## 2. Decide Architecture
 
-```
+```text
 /design
 ```
 
-Claude presents **at least 2 options with trade-offs** for each key decision (algorithm, storage, failure mode). **You decide** — AI proposes, human disposes. For decisions affecting >3 files or changing public API, an ADR is recorded.
+Expected output: at least two viable options with trade-offs for important decisions. The AI proposes; the human chooses.
 
-### 3 · Break the work down
+Use an ADR when the decision affects architecture, public API, persistent data, security, or more than a small local change.
 
-```
+## 3. Break The Work Down
+
+```text
 /breakdown
 ```
 
-Claude produces an atomic task list: each task is 1 sentence, touches ≤5 files, with explicit dependencies and priority (Covey's Quadrants Q1–Q4). Q4 tasks are eliminated. Parallel-safe tasks are marked.
+Expected output: atomic tasks with dependencies, priorities, and scope boundaries. Tasks should be small enough to review and test independently.
 
-### 4 · Brief each task before coding
+## 4. Build With Context
 
-```
+```text
 /build-brief
 ```
 
-For each task, Claude **reads existing code first** (H5 — Seek First to Understand), then produces an implementation brief: files to touch, patterns to follow, edge cases to handle. Only now does implementation begin.
+Expected output: a task brief based on existing code, local patterns, edge cases, and files likely to change.
 
-### 5 · Review before commit
+Only implement after the agent has read the relevant code.
 
-```
+## 5. Review Before Commit
+
+```text
 /review-ai
 ```
 
-Claude audits the generated code for security, completeness, and adherence to the brief. **Never commit without this step** — it is your last chance to catch AI hallucinations, missing error handling, and scope creep.
+Expected output: findings ordered by severity, with concrete fixes. This is the default review step for AI-generated work.
 
-Optional deeper lenses:
+Add focused checks when needed:
 
-- `/security-check` — focused OWASP Top 10 review
-- `/cross-verify` — full 17-question 8-Habit checklist
-- `/whole-person-check` — Body/Mind/Heart/Spirit balance
+- `/security-check` for auth, secrets, user input, dependencies, config, or infrastructure changes.
+- `/cross-verify` for larger plans or pre-PR confidence.
+- `/scrutinize` when the question is whether the change should exist at all.
 
-### 6 · Deploy with rollback
+## 6. Plan Deployment
 
+```text
+/deploy-guide production
 ```
-/deploy-guide
-```
 
-Staging first, always. Claude produces a step-by-step deploy plan with verification commands and a rollback procedure ready to paste.
+Expected output: staging steps, production steps, rollback commands, verification, and post-deploy checks.
 
-### 7 · Observe after deploy
+For provider-managed canaries or capacity changes, the guide also asks you to reconcile the planned target with the provider-selected target before calling the change complete.
 
-```
+## 7. Observe And Reflect
+
+```text
 /monitor-setup
-```
-
-Set up error tracking, alerts, and health checks. H7 — Sharpen the Saw: invest in observability so you learn from production.
-
-### 8 · Reflect
-
-```
 /reflect
 ```
 
-5 questions, 5 minutes. What worked? What surprised you? What would you do differently? Capture the lesson before the context evaporates.
+Expected output: monitoring gaps closed, runbook updates identified, and a short lesson captured for future work.
 
-## When to skip steps
+## When To Use Less
 
-Not every change needs all 7 steps. See [Workflow Overview → When to Skip](Workflow-Overview#when-to-skip). Single-line bug fixes, formatting, and dependency bumps typically skip Steps 0–4 and go straight to `/review-ai`.
+Small, obvious fixes usually do not need every step. They still need `/review-ai`, and production-impacting changes still need `/deploy-guide`.
 
-## Next
-
-- **[Workflow Overview](Workflow-Overview)** — the full picture
-- **[8 Habits Reference](Habits-Reference)** — the principles behind each step
-- **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)** — why this matters
+See [Workflow Overview](Workflow-Overview) for skip guidance.

--- a/docs/wiki/Habits-Reference.md
+++ b/docs/wiki/Habits-Reference.md
@@ -1,782 +1,102 @@
-# 8 Habits Reference
+# Habits Reference
 
-> Auto-generated from [`habits/`](https://github.com/pitimon/8-habit-ai-dev/tree/main/habits) — **do not edit this page directly**. Edit the source files and submit a PR.
+The plugin adapts Covey's 8 Habits into concrete engineering behaviors for AI-assisted development. The habits explain why each workflow step exists.
 
-Based on Stephen Covey's *7 Habits of Highly Effective People* + *The 8th Habit*, adapted for AI-assisted development.
+## Summary
 
-## Table of Contents
+| Habit | Engineering behavior | Primary skills |
+| --- | --- | --- |
+| H1 Be Proactive | Prevent incidents before they happen | `/deploy-guide`, `/security-check`, `/operational-state` |
+| H2 Begin with End in Mind | Define done before building | `/requirements`, `/save-spec` |
+| H3 Put First Things First | Prioritize important work over interesting work | `/breakdown` |
+| H4 Think Win-Win | Leave the next person better informed | `/review-ai`, `/management-talk`, `/ai-dev-log` |
+| H5 Seek First to Understand | Read, reproduce, and investigate before changing | `/research`, `/build-brief`, `/diagnose`, `/consistency-check` |
+| H6 Synergize | Use human judgment and agent execution together | `/management-talk`, review workflows |
+| H7 Sharpen the Saw | Improve the system after each cycle | `/monitor-setup`, `/reflect`, `/post-mortem` |
+| H8 Find Your Voice | Keep judgment, conscience, and architecture human-led | `/design`, `/whole-person-check`, `/calibrate` |
 
-- [Habit 1: Be Proactive](#habit-1-be-proactive)
-- [Habit 2: Begin with the End in Mind](#habit-2-begin-with-the-end-in-mind)
-- [Habit 3: Put First Things First](#habit-3-put-first-things-first)
-- [Habit 4: Think Win-Win](#habit-4-think-win-win)
-- [Habit 5: Seek First to Understand](#habit-5-seek-first-to-understand)
-- [Habit 6: Synergize](#habit-6-synergize)
-- [Habit 7: Sharpen the Saw](#habit-7-sharpen-the-saw)
-- [Habit 8: Find Your Voice and Inspire Others](#habit-8-find-your-voice-and-inspire-others)
+## Habit 1 · Be Proactive {#habit-1-be-proactive}
 
----
+Act on what you can control before a problem becomes an incident.
 
-# Habit 1: Be Proactive
+In practice:
 
-**Focus on your Circle of Influence — act on what you can control, not what you can't.**
+- Plan rollback before deploy.
+- Verify runtime state before declaring success.
+- Classify operational findings before mutation or closure.
 
-In AI-assisted development, your Circle of Influence is larger than you think. You can't control whether the AI generates perfect code, but you _can_ control how thoroughly you verify it, how many edge cases you consider, and whether you trace the impact of every change.
+## Habit 2 · Begin With End In Mind {#habit-2-begin-with-end-in-mind}
 
-## The Principle
+Define the desired outcome and success criteria before asking the model to build.
 
-Reactive developers fix the bug that was reported. Proactive developers fix the bug, check every caller of the affected function, add edge case handling, and update the docs — all in the same session.
+In practice:
 
-With AI assistance, being proactive costs almost nothing. An AI agent can trace all callers of a function in seconds. The question isn't capability — it's habit.
+- Write scope and non-scope.
+- Make acceptance criteria observable.
+- Keep Definition of Done tied to validation.
 
-## Rules
+## Habit 3 · Put First Things First {#habit-3-put-first-things-first}
 
-**1. Every bug fix: trace ALL callers, not just the reported path.**
+Sequence work by importance and dependency, not by what is most interesting to generate.
 
-When you fix a function, ask: "What else calls this?" A bug in `parseDate()` might affect 12 callers, not just the one in the bug report. Defense-in-depth means fixing the root cause everywhere.
+In practice:
 
-**2. Every new function: consider null input, missing file, permission denied, corrupt data.**
+- Split tasks small enough to review.
+- Make dependencies explicit.
+- Remove optional work from the current slice.
 
-Before marking a function complete, mentally walk through the failure modes. AI assistants are optimistic — they write the happy path. You provide the paranoia.
+## Habit 4 · Think Win-Win {#habit-4-think-win-win}
 
-**3. Update docs DURING feature work, not after release.**
+Make every artifact useful to the next human who reads it.
 
-"I'll document it later" is the most common lie in software. When the AI implements a feature, have it update the relevant docs in the same session. The context is fresh, the cost is low.
+In practice:
 
-**4. Surface improvements proactively — don't wait to be asked.**
+- Lead review comments with concrete findings.
+- Explain incident closure with evidence.
+- Write status updates for the audience receiving them.
 
-When working on area X and you notice area Y could benefit from the same fix, flag it. Even if it's out of scope, a comment like "FYI: the same date parsing issue exists in the export module" prevents future bugs.
+## Habit 5 · Seek First To Understand {#habit-5-seek-first-to-understand}
 
-### Before/After: Reactive vs Proactive Fix
+Investigate before deciding and read before editing.
 
-```javascript
-// REACTIVE: fix only the reported path
-function parseDate(input) {
-  return new Date(input); // "fixed" here, but 11 other callers still break
-}
+In practice:
 
-// PROACTIVE: fix the function AND verify all callers
-function parseDate(input) {
-  if (!input || typeof input !== "string") return null;
-  const parsed = new Date(input);
-  return isNaN(parsed.getTime()) ? null : parsed;
-}
-// Then: grep -r "parseDate(" src/ to verify all 12 callers handle null
-```
+- Inspect the existing code path.
+- Reproduce bugs before hypothesizing.
+- Confirm claims from evidence, not confidence.
 
-## Anti-Patterns
+## Habit 6 · Synergize {#habit-6-synergize}
 
-- **Fix-the-line syndrome**: Changing only the exact line mentioned in the bug report without checking related code paths. The AI will happily do this — you need to ask for more.
-- **Silent error suppression**: Wrapping code in try-catch with an empty catch block. The error didn't go away — you just hid it.
-- **"Document later"**: Completing a feature without updating any docs. Later never comes, and the next developer (or your future self) pays the cost.
+Combine human judgment and AI speed without confusing their responsibilities.
 
-## Real Example
+In practice:
 
-While running a standardized benchmark against an AI memory system, the team proactively tested not just the benchmark scenarios but also edge cases around retrieval pipeline behavior. This uncovered 2 production bugs that no user had reported — a date parser that silently returned wrong results for relative time expressions, and a search scoring function that over-weighted recency. Both would have caused subtle data quality issues. The benchmark was about measuring accuracy; the bugs were found because the team looked beyond what was asked.
+- Let agents gather, draft, and check.
+- Keep architecture and irreversible decisions human-owned.
+- Use independent review when confidence is high but evidence is thin.
 
-## Quick Reference
+## Habit 7 · Sharpen The Saw {#habit-7-sharpen-the-saw}
 
-| Do                                           | Don't                        | Why                                        |
-| -------------------------------------------- | ---------------------------- | ------------------------------------------ |
-| Trace ALL callers of a bug fix               | Fix only the reported line   | Root cause may affect 12 callers           |
-| Handle null, missing file, permission denied | Write only happy path        | AI skews optimistic                        |
-| Update docs DURING feature work              | "Document it later"          | Later never comes                          |
-| Surface improvements proactively             | Wait to be asked             | A comment today prevents a bug tomorrow    |
-| Consider edge cases before marking done      | Assume AI covered everything | AI-generated code skews toward happy paths |
+Invest in the system's future capability, not only the current output.
 
-## Checkpoint
+In practice:
 
-> "Have I checked what else this change affects? Am I reacting or preventing?"
+- Add monitoring after deploy.
+- Capture lessons after meaningful work.
+- Turn repeated failures into runbook or test improvements.
 
-If you're only fixing what was reported, you're reactive. If you're preventing the next 3 bugs while fixing this one, you're proactive.
+## Habit 8 · Find Your Voice {#habit-8-find-your-voice}
 
----
+Keep conscience, judgment, and purpose visible in AI-assisted work.
 
-_Next: [Habit 2 — Begin with the End in Mind](#habit-2-begin-with-the-end-in-mind)_
+In practice:
 
----
+- Make architecture decisions explicit.
+- Challenge changes that are technically possible but strategically wrong.
+- Adjust guidance to the user's maturity and context.
 
-# Habit 2: Begin with the End in Mind
+## See Also
 
-**Define "done" before writing a single line of code.**
-
-AI coding assistants will eagerly start generating code the moment you describe a feature. That speed is a trap if you haven't defined what success looks like. Without clear acceptance criteria, you'll iterate endlessly — not because the AI is bad, but because you never specified the target.
-
-## The Principle
-
-Every meaningful task needs a Definition of Done that is specific enough to verify. "It works" is not a definition. "The API returns 200 with valid JSON, handles missing fields with 400, and rejects unauthenticated requests with 401" — that's a definition.
-
-The best acceptance criteria are **grep-checkable** — you can search the codebase to verify they're met.
-
-## Rules
-
-**1. Plan files MUST have "Success Criteria" and "Definition of Done".**
-
-Before any multi-file change, write down what success looks like. Not a vague description — concrete, verifiable statements:
-
-```markdown
-## Success Criteria
-
-- [ ] GET /api/search returns results sorted by relevance score
-- [ ] Response time < 200ms for queries under 50 characters
-- [ ] Empty queries return 400 with descriptive error message
-- [ ] All endpoints require authentication
-```
-
-**2. PR body MUST have "Test Plan" with verification steps.**
-
-A PR without a test plan is a PR that "works on my machine." Every PR body should answer: "How can a reviewer verify this works?"
-
-```markdown
-## Test Plan
-
-- [ ] Run `curl -H "X-API-Key: test" /api/search?q=hello` — expect 200
-- [ ] Run `curl /api/search?q=hello` (no auth) — expect 401
-- [ ] Run `curl -H "X-API-Key: test" /api/search` (no query) — expect 400
-```
-
-### Before/After: Commit Messages
-
-```
-# BEFORE (withdrawal — reader learns nothing):
-git commit -m "fix: update parser"
-
-# AFTER (deposit — reader understands WHY):
-git commit -m "fix(search): handle relative dates — 'yesterday' queries
-returned future dates due to timezone offset in parseRelativeDate()"
-```
-
-**3. Before coding: "What does done look like? How will we verify it?"**
-
-Ask this question every time. If you can't answer it, you're not ready to code. This applies doubly with AI assistants — they'll produce something, but without a target, you won't know if it's right.
-
-**4. Commit messages explain WHY, not just WHAT.**
-
-`fix: update parser` tells you nothing. `fix(search): handle relative dates to prevent wrong results for "yesterday" queries` tells the next developer everything they need.
-
-## Anti-Patterns
-
-- **Starting without criteria**: "Build me a search endpoint" -> AI generates code -> endless revision. Better: define inputs, outputs, error cases, and performance bounds first.
-- **"It works on my machine" PRs**: No test plan, no verification steps. The reviewer has no way to validate the change without reverse-engineering your intent.
-- **Scope creep from undefined boundaries**: Without a Definition of Done, every review comment becomes "while you're at it, could you also..." The scope grows until nothing ships.
-
-## Real Example
-
-On a production AI memory system project, every planning document followed a strict template that included "Success Criteria" and "Definition of Done" sections. When implementing a new search algorithm, the plan specified: "F1 score >= 0.65 on the standard benchmark, response time < 500ms p95, zero regression on existing query types." This made the AI's work measurable. Three iterations of generated code were rejected not because they were bad, but because they didn't meet the pre-defined threshold. The fourth iteration passed — and everyone knew it was done.
-
-## Quick Reference
-
-| Do                                         | Don't                                  | Why                                             |
-| ------------------------------------------ | -------------------------------------- | ----------------------------------------------- |
-| Define 3-5 success criteria before coding  | Start coding without "done" definition | Without a target, you can't verify AI output    |
-| Include test plan in every PR              | "It works on my machine"               | Reviewers need verification steps               |
-| Commit messages explain WHY                | `git commit -m "fix: update parser"`   | Future readers need context, not a diff summary |
-| Ask "what does done look like?" every time | Jump into implementation               | AI produces something, but is it right?         |
-| Document constraints and non-goals         | Leave scope boundaries implicit        | Scope creep starts when boundaries are unclear  |
-
-## Checkpoint
-
-> "Can I describe what success looks like before writing code?"
-
-If you can't write 3-5 concrete, verifiable success criteria, you're not ready to start. Go back and think about the end.
-
----
-
-_Next: [Habit 3 — Put First Things First](#habit-3-put-first-things-first)_
-
----
-
-# Habit 3: Put First Things First
-
-**Invest in what's important before it becomes urgent.**
-
-AI assistants make it tempting to skip the boring stuff — tests, code review, CI checks — because generating new code is fast and exciting. But every shortcut today becomes a crisis tomorrow.
-
-## The Principle
-
-Covey's Time Management Matrix divides work into four quadrants:
-
-|                   | Urgent                                                 | Not Urgent                                        |
-| ----------------- | ------------------------------------------------------ | ------------------------------------------------- |
-| **Important**     | Q1: Crisis (production down, security breach)          | Q2: Prevention (tests, CI, reviews, architecture) |
-| **Not Important** | Q3: Interruptions (trivial requests, context-switches) | Q4: Waste (gold-plating, premature optimization)  |
-
-The key insight: **Quadrant II work prevents Quadrant I crises.** Writing tests today prevents debugging production tomorrow. Setting up CI now prevents shipping broken builds next week.
-
-AI assistants make Q4 seductively easy. "While you're at it, add dark mode" takes 30 seconds to ask and 2 hours to properly implement. Stay disciplined.
-
-## Rules
-
-**1. NEVER skip: PR creation, CI checks, test verification.**
-
-These are Q2 activities. They feel unnecessary when everything works. But they're the firewall between "it works locally" and "it works in production." AI-generated code needs _more_ review, not less.
-
-**2. Before unplanned work: "Is this in scope?"**
-
-When an AI suggests an improvement, or a teammate asks for a quick addition, ask: Is this Quadrant II (important, prevents future problems) or Quadrant IV (nice-to-have, doesn't serve the goal)?
-
-**3. Prioritize process improvements over firefighting.**
-
-If you spend every week fixing the same class of bug, the fix isn't another patch — it's a linter rule, a test suite, or an architectural change. Invest in the system, not the symptoms.
-
-**4. One task at a time — finish before starting new ones.**
-
-Context-switching kills quality. An AI assistant that's halfway through implementing feature A and gets redirected to feature B will produce poor results on both. Finish A, commit, then start B.
-
-### Before/After: Q1 Firefighting vs Q2 Prevention
-
-```yaml
-# BEFORE — Q1 reactive firefighting every sprint:
-sprint-12: "fix: search timeout in production (again)"
-sprint-13: "fix: search timeout different endpoint (again)"
-sprint-14: "fix: search timeout under load (again)"
-
-# AFTER — Q2 proactive investment:
-sprint-12: "feat: add circuit breaker + configurable timeout for all search endpoints"
-sprint-12: "feat: add search latency dashboard with P95 alerting"
-# Result: zero search timeout incidents in sprints 13-20
-```
-
-## Anti-Patterns
-
-- **Gold-plating**: Adding features nobody asked for because the AI makes it easy. "Let me also add pagination, sorting, and full-text search" when the ticket says "add a list endpoint." Ship the requirement, then enhance.
-- **"Just this once" skipping**: Skipping tests "because this change is trivial." Trivial changes break production more often than complex ones — precisely because nobody reviews them carefully.
-- **Context-switching**: Jumping between 3 features in one session. Each switch costs re-reading context, losing state, and introducing inconsistencies. AI assistants lose context too.
-
-## Real Example
-
-When implementing a benchmark evaluation for an AI memory system, the team faced a choice: spend time building proper benchmark infrastructure (test harness, data loading, scoring pipeline) or manually run a few queries and eyeball the results. They chose the infrastructure — a Q2 investment that felt slow at first. But when the benchmark needed to run 7 times over 3 weeks of optimization, the infrastructure paid for itself many times over. Teams that skip Q2 would have spent hours on each manual run, or worse, drawn wrong conclusions from inconsistent manual testing.
-
-## Quick Reference
-
-| Do                                                   | Don't                               | Why                                          |
-| ---------------------------------------------------- | ----------------------------------- | -------------------------------------------- |
-| Never skip PR creation, CI checks, test verification | "Just this once" shortcuts          | Skipping Q2 creates Q1 crises later          |
-| Ask "is this in scope?" before unplanned work        | Gold-plate with unasked features    | Nice-to-have steals time from critical       |
-| Invest in process improvements (Q2)                  | Firefight the same bug every sprint | Fix the system, not the symptom              |
-| Finish current task before starting new one          | Context-switch between tasks        | Half-done tasks produce poor results on both |
-| Prioritize by importance, not interest               | Work on what's fun or easy          | Important work prevents future problems      |
-
-## Checkpoint
-
-> "Am I doing what's important, or what's urgent? Will this prevent future problems?"
-
-If you're firefighting the same issues repeatedly, you're stuck in Q1. Step back and invest in Q2.
-
----
-
-_Next: [Habit 4 — Think Win-Win](#habit-4-think-win-win)_
-
----
-
-# Habit 4: Think Win-Win
-
-**Every interaction is a deposit or withdrawal from the Emotional Bank Account.**
-
-In AI-assisted development, your "interactions" include code, commits, issue comments, error messages, and documentation. Each one either helps the next person (deposit) or makes their life harder (withdrawal).
-
-## The Principle
-
-Covey's Emotional Bank Account applies to codebases too. Every artifact you produce is a transaction:
-
-| Deposit                                                         | Withdrawal                |
-| --------------------------------------------------------------- | ------------------------- |
-| Closing an issue with rationale, what was tried, and next steps | Closing with just "fixed" |
-| Error messages that explain what went wrong AND how to fix it   | `Error: failed`           |
-| Commit messages that explain why the change was made            | `fix: stuff`              |
-| Documentation updated alongside the code                        | Code ships, docs rot      |
-| PR descriptions with test plans                                 | PRs with "see commits"    |
-
-## Rules
-
-**1. Close issues with detailed rationale and next steps.**
-
-When closing a GitHub issue, explain: what was the root cause, what was the fix, what was considered but rejected, and what to watch for. This is a deposit for the developer who hits the same problem in 6 months.
-
-**2. Error messages should help the next developer understand AND fix the problem.**
-
-```
-// Withdrawal
-throw new Error('Database connection failed')
-
-// Deposit
-throw new Error(
-  'Database connection failed: host "db.internal" unreachable. ' +
-  'Check DATABASE_URL in .env and verify the database is running.'
-)
-```
-
-**3. When disagreeing, propose alternatives that serve both sides.**
-
-"That won't work" is a withdrawal. "That approach has a performance issue at scale — what if we use a queue instead? It handles both the immediate need and future growth" is a deposit.
-
-**4. AI-generated code should be reviewed for Win-Win quality.**
-
-AI assistants often generate correct but unhelpful error messages, vague variable names, and no comments. Review generated code not just for correctness, but for whether it helps the next person who reads it.
-
-## Anti-Patterns
-
-- **"Fixed" issue closures**: Zero context for future reference. When someone Googles the same problem and finds your closed issue, they learn nothing.
-- **Opaque error messages**: `Error code 42` with no documentation. The person debugging at 2 AM deserves better.
-- **Win-Lose reviews**: Code review comments that prove you're smart instead of helping the author improve. "Obviously this should use a factory pattern" vs "A factory pattern here would let us add new providers without modifying this file."
-
-## Real Example
-
-On a production project, the team adopted a policy: every issue must be closed with a comment summarizing root cause, solution, and what to watch for. Six months later, when a similar issue appeared, a developer searched closed issues, found the detailed closure comment, and resolved the new issue in 20 minutes instead of 2 hours. That single deposit paid dividends across the team.
-
-## Quick Reference
-
-| Do                                                              | Don't                                               | Why                                         |
-| --------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------- |
-| Close issues with detailed rationale                            | Close with just "fixed"                             | Future devs need context for similar issues |
-| Error messages: what went wrong + how to fix                    | Error messages that just say "failed"               | Opaque errors cost hours downstream         |
-| Review for Win-Win: help author improve                         | Review to find flaws and point blame                | Win-Lose reviews destroy collaboration      |
-| Propose alternatives when disagreeing                           | Force your solution without considering constraints | Both sides should walk away better off      |
-| AI-generated code: review for helpfulness, not just correctness | Ship AI output without reading it                   | Correct but unhelpful code is a withdrawal  |
-
-## Checkpoint
-
-> "Does this interaction leave the other party better informed and more capable?"
-
-If your commit message, error message, or issue comment doesn't help the next person, rewrite it.
-
----
-
-_Next: [Habit 5 — Seek First to Understand](#habit-5-seek-first-to-understand)_
-
----
-
-# Habit 5: Seek First to Understand
-
-**Read existing code before writing new code. Reproduce bugs before fixing them.**
-
-AI coding assistants have a bias toward action — they generate solutions immediately. But the most common source of bugs in AI-assisted development isn't wrong code; it's code that's correct in isolation but wrong in context. The context comes from understanding first.
-
-## The Principle
-
-Empathic listening in development means truly understanding the codebase, the problem, and the constraints before proposing a solution. This is harder with AI assistants because they're so fast that skipping the understanding phase feels like efficiency. It isn't.
-
-## Rules
-
-**1. Read existing code before writing new code.**
-
-Before asking an AI to implement a feature, read the module it will live in. Understand the patterns, conventions, and existing utilities. Otherwise the AI will reinvent something that already exists, or use a different pattern than the rest of the codebase.
-
-```
-// Common failure mode:
-// AI generates a new date parser
-// The project already has a date utility module with 15 edge cases handled
-// Now there are two date parsers, and only one handles edge cases
-```
-
-**2. Reproduce bugs before fixing them.**
-
-If you can't reproduce a bug, you can't verify the fix. AI assistants will happily generate a "fix" for a bug description, but without reproduction steps, you're guessing. The fix might suppress the symptom while leaving the root cause intact.
-
-**3. Read ALL feedback; identify patterns, not just individual items.**
-
-When reviewing test failures, error logs, or code review comments, look for patterns. Three different review comments about error handling aren't three separate issues — they're a systemic gap in how errors are handled across the codebase.
-
-**4. Ask clarifying questions when scope is ambiguous — don't assume.**
-
-"Add caching" could mean: add Redis, add in-memory cache, add HTTP cache headers, or add browser cache. Each is a different week of work. Ask before building.
-
-### Before/After: Write-First vs Understand-First
-
-```python
-# BEFORE — write-first: AI generates a brand new date parser (120 lines)
-def parse_date(text):
-    """Parse date string to datetime."""
-    formats = ["%Y-%m-%d", "%m/%d/%Y", "%d %b %Y"]
-    for fmt in formats:
-        try: return datetime.strptime(text, fmt)
-        except ValueError: continue
-    return None
-
-# AFTER — understand-first: read existing code, discover it already exists
-from app.utils.dates import parse_date  # handles 15 formats + relative dates
-# No new code needed. 120 lines saved. Zero new bugs introduced.
-```
-
-## Anti-Patterns
-
-- **Write-first, read-later**: Generating code immediately without reading the existing module. Results in duplicated utilities, inconsistent patterns, and style clashes.
-- **Fix without reproduce**: "The bug report says X, so the fix must be Y." Without reproduction, you might fix a symptom while the root cause persists — or fix the wrong thing entirely.
-- **Answering the wrong question**: The user asks "how do I speed up this query?" The real problem is that the query runs on every page load instead of being cached. Understanding the context reveals the real solution.
-
-## Real Example
-
-While optimizing a search retrieval pipeline for an AI memory system, the team went through 7 iterations of benchmark testing. Each iteration revealed something new about how the pipeline actually behaved versus how it was assumed to behave. The first attempt improved scoring by tweaking weights — a "write-first" approach that barely moved the needle. The breakthrough came in iteration 4, when the team stopped tweaking and instead instrumented the pipeline to understand _why_ certain queries failed. They discovered that the search wasn't missing relevant results — it was finding them but scoring them wrong due to a normalization bug. Understanding the actual behavior led to a targeted fix that improved accuracy by 12 points. The first 3 iterations were wasted because they skipped understanding.
-
-## The Understanding Sequence
-
-For any non-trivial task, follow this sequence:
-
-1. **Read** — What code already exists in this area?
-2. **Reproduce** — Can I trigger the current behavior?
-3. **Understand** — Why does it behave this way?
-4. **Propose** — What change would fix/improve it?
-5. **Verify** — Does the change work without side effects?
-
-AI assistants are great at steps 4-5. You need to ensure steps 1-3 happen first.
-
-## Quick Reference
-
-| Do                                                           | Don't                                            | Why                                                   |
-| ------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------------------- |
-| Read existing code before writing new code                   | Generate new code without checking what exists   | 120 lines of new parser vs 1-line import              |
-| Reproduce bugs before fixing them                            | Apply fix without verifying the bug              | Fix might suppress symptom, not root cause            |
-| Identify patterns across feedback, not just individual items | Treat each review comment as isolated            | Three error-handling comments = systemic gap          |
-| Ask clarifying questions when scope is ambiguous             | Assume "add caching" means one specific approach | Could mean Redis, in-memory, HTTP headers, or browser |
-| Read ALL feedback before responding                          | Cherry-pick the easy comments                    | Patterns emerge from the full picture                 |
-
-## Checkpoint
-
-> "Have I fully understood the problem before proposing a solution?"
-
-If you're generating code based on a title alone, stop. Read the code, reproduce the issue, understand the context.
-
----
-
-_Next: [Habit 6 — Synergize](#habit-6-synergize)_
-
----
-
-# Habit 6: Synergize
-
-**Human judgment + AI execution is greater than either alone.**
-
-Synergy isn't about the AI doing more or the human doing less. It's about each contributing what they do best — simultaneously, in complementary ways — to produce something neither could alone.
-
-## The Principle
-
-True synergy means 1+1=3. In AI-assisted development:
-
-- **Human strengths**: Judgment, context, taste, "does this feel right?", understanding users, architectural decisions
-- **AI strengths**: Speed, consistency, parallel execution, pattern matching, tireless iteration, exhaustive search
-
-The magic happens when you combine both in the right way. Not AI-first or human-first — together.
-
-## Rules
-
-**1. Use parallel agents for independent tasks.**
-
-When three modules need updating and they don't depend on each other, run three parallel AI agents instead of working sequentially. A task that takes 3 hours sequentially can finish in 1 hour with parallelization.
-
-**2. Wave-based execution for dependent work.**
-
-When tasks have dependencies, organize them in waves:
-
-```
-Wave 1 (parallel): Create database schema, design API contract, write test fixtures
-Wave 2 (parallel): Implement routes, write integration tests (uses Wave 1 outputs)
-Wave 3 (sequential): Integration testing, documentation update
-```
-
-Each wave can run in parallel internally, but waves execute in sequence.
-
-### Before/After: Sequential vs Parallel
-
-```
-# BEFORE — sequential execution (40 min total):
-  research (10m) → design (10m) → implement (15m) → test (5m)
-
-# AFTER — parallel where independent (25 min total):
-  research (10m) → design (10m) ──→ implement (15m) → test
-                 └→ test fixtures ─┘  (parallel — no dependency)
-  Saved: 15 min (37%) by identifying independent work
-```
-
-**3. Apply the Lazy Parallelism Gate before spawning agents.**
-
-Not every multi-part task benefits from parallelization. Before launching parallel agents, ask: "Can I do this sequentially in ≤5 tool calls?" If yes, the sequential path is cheaper — no context loading, no coordination, no result merging. Only parallelize when tasks are meaningfully disjoint: different files, different concerns, substantial enough to justify the overhead.
-
-### Before/After: Premature vs Lazy Parallelism
-
-```
-# BEFORE — premature parallelism (3 agents for trivial work):
-  Agent 1: Read config.ts (1 tool call)
-  Agent 2: Read schema.ts (1 tool call)
-  Agent 3: Read types.ts (1 tool call)
-  → 3 agents launched, 3 contexts loaded, results merged
-  → Total overhead: ~30s setup for 3s of actual work
-
-# AFTER — lazy parallelism (sequential, 3 tool calls):
-  Read config.ts → Read schema.ts → Read types.ts
-  → Same result, zero coordination overhead
-  → Reserve parallelism for substantial independent work
-```
-
-**4. Seek third alternatives — not just option A or B.**
-
-AI assistants often present binary choices: "Should we use Redis or Memcached?" But the third alternative might be better: "Use in-memory cache with Redis fallback for shared state." Always ask: "Is there a creative option C?"
-
-**5. Combine strengths deliberately.**
-
-| Task                      | Who Does It Best | Why                 |
-| ------------------------- | ---------------- | ------------------- |
-| Write implementation code | AI               | Speed, consistency  |
-| Review generated code     | Human            | Judgment, context   |
-| Run tests exhaustively    | AI               | Tireless, thorough  |
-| Decide what to test       | Human            | Risk assessment     |
-| Refactor for patterns     | AI               | Pattern matching    |
-| Choose the pattern        | Human            | Architecture vision |
-| Search for related issues | AI               | Exhaustive search   |
-| Decide priority           | Human            | Business context    |
-
-## Anti-Patterns
-
-- **Sequential when parallel is possible**: Working on files one at a time when they're independent. Ask: "Can any of these run simultaneously?"
-- **"Not my problem" blinders**: Fixing a bug in module A without noticing that module B (open in the same session) has the same issue. When you touch area X, look around: "What else here benefits from improvement?"
-- **Compromise instead of synergy**: Compromise means both sides give something up (lose-lose). Synergy means finding a solution where both sides get what they need (win-win). "Let's use half Redis and half Memcached" is compromise. "Let's use Redis for pub/sub and in-memory for hot cache" is synergy.
-
-## Real Example
-
-When documenting architectural patterns for an AI memory system, the team needed to produce 11 pattern files covering search, data architecture, AI infrastructure, and operations. Instead of writing them sequentially (which would have taken a full day), they launched 3 parallel AI agents — one for search patterns, one for data patterns, one for infrastructure patterns. Each agent had its own context and didn't depend on the others. All 11 files were drafted in under 2 hours. The human then reviewed all files in a single pass, catching 4 consistency issues across patterns that no single agent could have seen. Total time: 3 hours instead of 8+. Quality: higher, because the human review caught cross-cutting concerns.
-
-## The Synergy Checklist
-
-Before starting any multi-part task, ask:
-
-1. Which parts are independent? (parallelize these)
-2. Which parts depend on others? (sequence these in waves)
-3. What does the human do best here? (judgment, decisions, review)
-4. What does the AI do best here? (execution, search, iteration)
-5. Is there a third alternative we haven't considered?
-
-## Quick Reference
-
-| Do                                               | Don't                                                | Why                                                  |
-| ------------------------------------------------ | ---------------------------------------------------- | ---------------------------------------------------- |
-| Run independent tasks in parallel                | Sequential execution when parallel is possible       | 37% time saved by identifying independent work       |
-| Apply Lazy Parallelism Gate before spawning      | Launch agents for trivial 1-2 tool call tasks        | Overhead of context loading exceeds time saved       |
-| Seek a third alternative beyond A or B           | Accept binary choices at face value                  | "Redis vs Memcached?" maybe in-memory + fallback     |
-| Combine strengths: human judgment + AI execution | Try to do everything yourself or delegate everything | Neither alone matches the combination                |
-| Use wave-based execution for dependent tasks     | Mix dependent and independent work randomly          | Waves = parallel within, sequential between          |
-| When touching area X, check what else benefits   | "Not my problem" mindset                             | Nearby improvements are cheap while context is fresh |
-
-## Checkpoint
-
-> "Am I leveraging all available capabilities? Is there a third alternative?"
-
-If you're working sequentially on independent tasks, or if you're choosing between two options without looking for a creative third, you're leaving synergy on the table.
-
----
-
-_Next: [Habit 7 — Sharpen the Saw](#habit-7-sharpen-the-saw)_
-
----
-
-# Habit 7: Sharpen the Saw
-
-**Invest in Production Capability, not just Production output.**
-
-AI assistants make it dangerously easy to keep producing — shipping features, fixing bugs, writing more code. But a saw that never gets sharpened eventually can't cut. The same applies to your development process, infrastructure, and knowledge.
-
-## The Principle
-
-Covey's P/PC Balance: **P** is Production (output), **PC** is Production Capability (the ability to produce). If you focus only on P, PC degrades until you can't produce at all.
-
-In AI-assisted development, PC includes: your CI pipeline, your test suite, your deployment process, your monitoring, your understanding of the codebase, and the AI's ability to work effectively within your system.
-
-## Rules
-
-**1. Track tech debt explicitly — don't let it accumulate silently.**
-
-Every "TODO: fix later" should be a tracked issue with a severity tag. AI assistants generate TODOs liberally. If you don't track them, they become invisible rot.
-
-**2. After completing a task: "What did we learn? What could be automated?"**
-
-Every session produces knowledge. If you fixed a deployment issue, write down what went wrong and how to prevent it. If you repeated the same 5 steps, write a script. If the AI made a mistake, add a guardrail.
-
-**3. Periodic review: frameworks, dependencies, security posture.**
-
-Schedule time to update dependencies, review security advisories, and assess whether your tools are still the right choice. This is Q2 work (Habit 3) that prevents Q1 crises.
-
-**4. Invest in AI collaboration infrastructure.**
-
-The more context your AI assistant has (project docs, coding standards, architectural decisions), the better its output. Maintaining a clear CLAUDE.md, keeping docs current, and writing good commit messages are all PC investments — they make every future AI session more productive.
-
-**5. Invest in the meta-system — the system that builds the system.**
-
-When AI agents can rebuild a codebase in hours, the bottleneck shifts from coding speed to orchestration quality. The plugin you configure, the workflow you follow, the decomposition patterns you use — these are the meta-system. Improving the meta-system compounds: every future task benefits from better orchestration, clearer boundaries, and smarter decomposition.
-
-> "If you're only looking at the files created in this repository, you're looking at the wrong layer. What you should study is the system that built it." — UltraWorkers philosophy
-
-### Before/After: All Output vs Capability Investment
-
-```bash
-# BEFORE — manual deploy every time (P only, no PC):
-ssh server "cd /app && git pull && npm install && pm2 restart"
-# 60 min per deploy, error-prone, no rollback, repeated every release
-
-# AFTER — invested in CI/CD (10 min PC investment, 2 min deploys forever):
-git push origin main
-# GitHub Actions: build → test → staging → health check → production
-# Rollback: git revert + push. Total: 2 min. Repeatable. Safe.
-```
-
-## Anti-Patterns
-
-- **All output, no capability**: Shipping features every sprint but never improving the build process that takes 20 minutes. Eventually the slow build costs more than all the features combined.
-- **"It works" tech debt denial**: Ignoring known issues because the system runs. Until the day it doesn't, and the accumulated debt demands payment all at once.
-- **No post-task reflection**: Completing a task and immediately starting the next one. The lessons learned evaporate, and the same mistakes recur.
-
-## Real Example
-
-After running a retrieval benchmark on an AI memory system, the team could have just recorded the scores and moved on. Instead, they invested time in building reusable benchmark infrastructure — data loaders, automated scoring, comparison reports. This was pure PC investment with no immediate production value. But when optimization required 7 benchmark runs over 3 weeks, the infrastructure turned each run from a half-day manual effort into a 15-minute automated process. The PC investment saved 10x its cost within the same project.
-
-## Quick Reference
-
-| Do                                                            | Don't                                                     | Why                                                         |
-| ------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
-| Track tech debt explicitly                                    | "It works, don't touch it"                                | Accumulated debt demands payment all at once                |
-| After each task: "what did I learn?"                          | Complete task, immediately start next                     | Lessons evaporate, same mistakes recur                      |
-| Invest in CI/CD, monitoring, automation (PC)                  | Only ship features (P)                                    | Eventually the saw is too dull to cut                       |
-| Periodically review frameworks and dependencies               | Assume tools are still the right choice                   | Security advisories and better alternatives emerge          |
-| Maintain CLAUDE.md and commit messages                        | Let AI context degrade over time                          | Better context = better AI output every session             |
-| Invest in the meta-system (plugins, workflows, decomposition) | Only optimize the code, never the process that creates it | Better orchestration compounds — every future task benefits |
-
-## Checkpoint
-
-> "Am I investing in future capability, or just grinding out output?"
-
-If you can't remember the last time you improved your process (not your product), it's time to sharpen the saw.
-
----
-
-_Next: [Habit 8 — Find Your Voice](#habit-8-find-your-voice-and-inspire-others)_
-
----
-
-# Habit 8: Find Your Voice and Inspire Others
-
-**Move from effectiveness to significance — from building things right to building the right things and sharing the knowledge.**
-
-Habits 1-7 make you effective. Habit 8 asks: effective at _what_ and for _whom_? This is where individual productivity becomes community contribution.
-
-## The Principle
-
-Covey's 8th Habit introduces the concept of **Voice**: the intersection of Talent, Passion, Need, and Conscience. In AI-assisted development, finding your voice means:
-
-- **Talent**: What are you uniquely good at? (the technical craft)
-- **Passion**: What energizes you? (the problems you choose to solve)
-- **Need**: What does the world need? (real problems, not resume-driven development)
-- **Conscience**: What should you build? (ethics, responsibility, impact)
-
-## The Whole Person Model
-
-Every system and every component has four dimensions. Neglecting any one creates an imbalance:
-
-| Dimension                  | In Development                                               | Question                                           |
-| -------------------------- | ------------------------------------------------------------ | -------------------------------------------------- |
-| **Body (PQ/Discipline)**   | Robust CI, automated checks, reliable infrastructure         | "Is the system reliable and well-built?"           |
-| **Mind (IQ/Vision)**       | Architecture decisions, roadmap clarity, technical direction | "What does the system become? Where is it going?"  |
-| **Heart (EQ/Passion)**     | Craft quality, user empathy, pride in work                   | "Does this feel right? Would I want to use this?"  |
-| **Spirit (SQ/Conscience)** | Security-first defaults, compliance, ethical choices         | "Should we build this? What are the consequences?" |
-
-AI assistants excel at Body and Mind. Humans bring Heart and Spirit. The best work comes from all four.
-
-## The 4 Leadership Roles
-
-These apply whether you're leading a team, a project, or just your own development practice:
-
-**1. Modeling (Conscience)** — Lead by example.
-
-Follow the process even when nobody is watching. Run code review before every commit, not just when the PR will be scrutinized. AI assistants should be held to the same standards as human contributors.
-
-**2. Pathfinding (Vision)** — Define direction collaboratively.
-
-Architecture decisions, roadmaps, and technical direction are joint human-AI endeavors. The human provides business context and judgment; the AI provides analysis, options, and trade-off evaluation. Neither decides alone.
-
-**3. Aligning (Discipline)** — Make the right thing easy.
-
-Pre-commit hooks that catch hardcoded secrets. CI gates that enforce test coverage. Linting rules that prevent common mistakes. The goal: make it harder to do the wrong thing than the right thing. AI assistants should work within these guardrails, not around them.
-
-**4. Empowering (Passion)** — Focus on outcomes, not methods.
-
-Give AI agents clear goals and let them choose the implementation. "Implement a search endpoint that returns results sorted by relevance, handles errors gracefully, and completes in under 200ms" is empowering. "Write a function called searchHandler that uses express.Router and calls elasticsearch.search with these exact parameters" is micromanaging.
-
-## The Three Loops
-
-As trust grows, the collaboration model evolves:
-
-| Loop            | Model                                                | Example                                             |
-| --------------- | ---------------------------------------------------- | --------------------------------------------------- |
-| **In-the-Loop** | Human decides everything, AI assists                 | "Write this function exactly as I describe"         |
-| **On-the-Loop** | AI proposes, human reviews and approves              | "Implement this feature, I'll review the PR"        |
-| **Out-of-Loop** | AI executes autonomously within guardrails           | "Fix lint errors and formatting — no review needed" |
-| **Voice**       | Contributing patterns and knowledge to the community | "Publish what we learned so others benefit"         |
-
-The progression isn't about trusting AI blindly — it's about building guardrails (Aligning) that make autonomous execution safe.
-
-## Rules
-
-**1. Understand WHY before implementing — never "just following orders."**
-
-AI assistants should not be treated as typing machines. If a task doesn't make sense, question it. "I can implement this, but it contradicts the existing caching strategy. Should we update the strategy or adjust the approach?"
-
-**2. Seek contribution over compliance.**
-
-"Did I follow the checklist?" is compliance. "Does this actually help someone?" is contribution. The checklist exists to guide, not to gatekeep. If following the checklist produces worse outcomes, update the checklist.
-
-**3. Surface improvements the user hasn't asked for.**
-
-When AI identifies an improvement opportunity — a security vulnerability, a performance optimization, a simplification — surface it. This is where Habit 1 (Be Proactive) and Habit 8 (Find Your Voice) synergize.
-
-**4. Error messages, docs, and examples should empower, not just inform.**
-
-Don't just tell someone what went wrong. Help them fix it. Don't just document the API. Show them how to use it effectively. Don't just publish code. Explain the patterns so others can adapt them.
-
-### Before/After: Compliance vs Contribution
-
-```
-# BEFORE (compliance theater — checking boxes):
-Code review comment: "LGTM" ✓
-  (Didn't actually read the code. Checked the box because process requires it.)
-
-# AFTER (genuine contribution — empowering the author):
-Code review comment:
-  "Line 42: This works, but the retry logic will silently mask
-   intermittent DB connection failures. The retry succeeds on the
-   3rd attempt, so the error never surfaces — but the underlying
-   connection instability goes undiagnosed.
-
-   Consider adding a circuit breaker pattern. We have one in
-   src/infra/circuit-breaker.ts:15 that could be reused here.
-   It logs failures even when retries succeed, so ops can spot
-   the pattern before it becomes an outage."
-```
-
-## Anti-Patterns
-
-- **Industrial Age mindset**: Treating AI as a factory worker — specifying every detail, leaving no room for judgment. You lose the AI's ability to suggest improvements.
-- **Compliance theater**: Following checklists without understanding their purpose. Running code review because "the process says to" rather than because it catches bugs.
-- **Knowledge hoarding**: Building something useful and keeping it internal. If your patterns could help others, publishing them is a Spirit contribution.
-
-## Real Example
-
-After 910 man-day-equivalents building a production AI memory system, the team extracted 12 architectural patterns and published them as open-source documentation. This wasn't required — the system worked fine without sharing. But the team recognized that the hard-won lessons about hybrid search, multi-tenancy, LLM provider fallbacks, and benchmark methodology could save other teams months of trial and error. Publishing wasn't about marketing — it was about the Spirit dimension: "Should we share this? Yes, because others need it." The repository received contributions from developers who adapted the patterns to their own systems, creating a feedback loop that improved the original patterns.
-
-## Quick Reference
-
-| Do                                             | Don't                                                 | Why                                                           |
-| ---------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
-| Understand WHY before implementing             | "Just following orders" — execute without questioning | AI can suggest improvements if it understands the goal        |
-| Seek contribution over compliance              | Follow checklists without understanding their purpose | Compliance theater catches nothing; contribution catches bugs |
-| Surface improvements the user hasn't asked for | Wait to be asked                                      | H1 + H8 synergy: proactive + meaningful                       |
-| Error messages, docs, examples should empower  | Just inform without helping fix                       | Empowerment = deposit in everyone's account                   |
-| Share patterns that could help others          | Keep useful solutions internal                        | Spirit: "Should we share this? Yes, others need it."          |
-
-## Checkpoint
-
-> "Am I contributing something meaningful, or just completing a task? Does this empower the next person?"
-
-If your work helps only you, you're effective. If your work helps others build better systems, you've found your voice.
-
----
-
-_Back to [README](https://github.com/pitimon/8-habit-ai-dev#readme)_
-
----
-
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference)
+- [Maturity Model](Maturity-Model)

--- a/docs/wiki/Harness-Engineering.md
+++ b/docs/wiki/Harness-Engineering.md
@@ -1,150 +1,51 @@
-# Harness Engineering — และที่ของ 8-habit-ai-dev ในภาพรวม
+# Harness Engineering
 
-> _"Anytime you find an agent makes a mistake, you take the time to engineer a solution such that the agent never makes that mistake again."_
-> — Mitchell Hashimoto, _My AI Adoption Journey_, 5 กุมภาพันธ์ 2026
->
-> _"ทุกครั้งที่คุณพบว่า agent ทำผิดพลาด ใช้เวลาออกแบบทางแก้เพื่อให้มันไม่พลาดแบบนั้นอีก"_
+Harness engineering is the discipline of keeping the runtime harness thin while putting durable reasoning into portable skills, guides, and review artifacts.
 
----
+> [!NOTE]
+> This is the wiki's intentional Thai/English concept page. The rest of the wiki is English-first for public documentation consistency.
 
-## สรุปสั้น
+## แนวคิดหลัก
 
-**Harness Engineering** คือยุคที่ 3 ของการพัฒนาด้วย AI ต่อจาก **Prompt Engineering** และ **Context Engineering**. เป็นระเบียบในการออกแบบ "สภาพแวดล้อมทั้งระบบ" ที่ agent ทำงานภายใต้ — guide ที่ชี้นำ, sensor ที่ตรวจจับความผิดพลาด, และ feedback loop ที่ป้องกันการพลาดซ้ำ
+Harness ที่ดีไม่ควรพยายามควบคุมทุกอย่างใน runtime. หน้าที่หลักคือเปิดทางให้ agent โหลดคำแนะนำที่ถูกต้องในเวลาที่เหมาะสม แล้วให้มนุษย์ยังเป็นเจ้าของการตัดสินใจสำคัญ.
 
-`8-habit-ai-dev` คือ harness implementation ที่เน้น workflow discipline พร้อม **assertion ที่ verify ได้ 242 ข้อ** และ cross-verification audit 17 คำถาม
+In English: the harness routes and loads context; the skills carry the process discipline.
 
----
+## Thin Harness, Fat Skills
 
-## Harness Engineering คืออะไร?
+| Layer | Responsibility |
+| --- | --- |
+| Thin harness | Entry points, routing, short reminders, validation hooks |
+| Fat skills | Requirements, design, review, deployment, operations, reflection |
+| Human judgment | Architecture, irreversible actions, production acceptance, compliance posture |
 
-### ต้นทางของคำ
+This design keeps the plugin portable across Claude Code, Codex, and other agents that can consume markdown.
 
-คำนี้ถูกตกผลึกโดย **Mitchell Hashimoto** (ผู้สร้าง Terraform / HashiCorp) ใน blog post วันที่ **5 กุมภาพันธ์ 2026** ชื่อ _My AI Adoption Journey_. เขานิยามไว้ว่า:
+## What Belongs Here
 
-> "แนวคิดที่ว่าทุกครั้งที่ agent ทำผิดพลาด คุณใช้เวลาออกแบบทางแก้เพื่อให้มันไม่พลาดแบบนั้นอีก"
+- Skill selection and reading.
+- Concise workflow reminders.
+- Markdown guidance that works across runtimes.
+- Validators that catch documentation and skill drift.
 
-เขายกตัวอย่าง 2 รูปแบบ:
+## What Does Not Belong Here
 
-1. **Implicit prompting** ผ่านการ update `AGENTS.md` — เพิ่มเอกสารชี้นำเวลา agent ทำพลาดซ้ำ
-2. **Programmed tools** — สร้าง script เฉพาะทาง (เช่น screenshot utility, filtered test runner) คู่กับเอกสาร เพื่อให้ agent verify งานของตัวเองได้
+- Runtime policy enforcement.
+- Secret scanning gates.
+- Automatic production mutation.
+- Compliance certification.
+- Dynamic orchestration engines.
 
-ไม่กี่วันถัดมา OpenAI ออก engineering report ตอกย้ำคำนี้, และที่งาน **AI Engineer World's Fair** (เมษายน 2026) มีวิทยากร 3 คนแยกกันชี้ว่า "agent harness" + "context engineering" คือ priority อันดับ 1 ของ production reliability
+Those responsibilities belong in separate governance or automation layers.
 
-### สามชั้นที่ซ้อนกัน
+## Practical Rule
 
-Hashimoto วาง harness เป็นชั้นนอกสุดของ 3 ชั้น. analogy ที่ใช้กันทั่วไป:
+ถ้าสิ่งนั้นเป็น "วินัยในการคิดและตรวจสอบ" ให้ใส่ใน skill. ถ้าสิ่งนั้นเป็น "การบังคับ runtime หรือการอนุมัติ irreversible action" ให้แยกออกจาก plugin core.
 
-| ชั้น        | analogy          | คำถามที่ตอบ                                        |
-| ----------- | ---------------- | -------------------------------------------------- |
-| **Model**   | CPU              | _สมองคำนวณอะไรได้?_                                |
-| **Context** | RAM              | _ตอนนี้รู้อะไร?_                                   |
-| **Harness** | Operating System | _ทำอะไรได้บ้าง, ตรวจอย่างไร, เกิดอะไรขึ้นถ้า off?_ |
+If it is thinking discipline, it can live in a skill. If it is runtime authority, keep it outside the core.
 
-ทั้ง 3 ชั้น **"ครอบกัน" ไม่ใช่ "แทนกัน"**. Harness Engineer ที่ดียังเขียน prompt ดีและประกอบ context เก่ง — แค่ขอบเขตของบทบาทใหญ่กว่า
+## See Also
 
----
-
-## ที่มาทางวิชาการ — 3 source หลัก
-
-| #   | Source                                                                                                           | ที่ contribute                                  | วันที่       | Verified URL                                                                   |
-| --- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------ | ------------------------------------------------------------------------------ |
-| 1   | **Hashimoto** — _My AI Adoption Journey_                                                                         | ตกผลึก "Engineer the Harness", นิยาม + practice | 5 ก.พ. 2026  | [mitchellh.com](https://mitchellh.com/writing/my-ai-adoption-journey)          |
-| 2   | **Lee, Nair, Zhang, Lee, Khattab, Finn** — _Meta-Harness: End-to-End Optimization of Model Harnesses_ (Stanford) | หลักฐานเชิงปริมาณ + automated harness search    | 2026         | [arxiv 2603.28052](https://arxiv.org/abs/2603.28052)                           |
-| 3   | **Böckeler** (Thoughtworks) — _Harness engineering for coding agent users_                                       | Taxonomy: feedforward guides + feedback sensors | 2 เม.ย. 2026 | [martinfowler.com](https://martinfowler.com/articles/harness-engineering.html) |
-
-### ⚠️ หมายเหตุเรื่องเลข viral "3% vs 28-47%"
-
-มีตัวเลขที่ถูก quote กันเยอะว่า _"งานวิจัย Stanford พบว่า prompt tuning ดีขึ้นได้สูงสุด 3% แต่ harness ดีขึ้น 28-47%"_
-
-**ตัวเลขนี้ไม่ปรากฏในเปเปอร์ Stanford ตัวจริง** (Lee et al., _Meta-Harness_, arxiv 2603.28052). ตัวเลขที่เปเปอร์รายงานจริง:
-
-- **+7.7 percentage points** บน text classification — ใช้ token น้อยลง **4 เท่า**
-- **+4.7 percentage points** บน math reasoning ระดับ IMO (เฉลี่ย 5 โมเดลที่ hold out)
-- **SOTA** บน TerminalBench-2 agentic coding ด้วย Claude Haiku 4.5
-
-**ทิศทาง** ของ claim ถูก (harness >> prompt tuning) แต่เลข "28-47%" น่าจะเป็น paraphrase ของ aggregator. ในเอกสารทางการ ใช้ตัวเลขจริงจาก arxiv 2603.28052 ดีกว่า — น่าเชื่อถือกว่าและ verify ได้
-
----
-
-## 8-habit-ai-dev ในฐานะ Harness Implementation
-
-Böckeler แบ่ง harness เป็น 2 ส่วนที่เสริมกัน:
-
-- **Feedforward guides** — ตัวกำหนดทิศ "ก่อน" agent ลงมือ (set context + convention)
-- **Feedback sensors** — กลไก self-correction "หลัง" agent ทำเสร็จ (ตรวจจับการ deviate)
-
-plugin map ลงทั้ง 2 ฝั่งได้ครบ. ทุกแถวด้านล่างมี path ที่ verify ได้ใน repo นี้
-
-### Feedforward guides
-
-| #   | Component                                | Path                                                 | ทำหน้าที่                                                                                        |
-| --- | ---------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| 1   | 8-Habit playbook (auto-load ทุก session) | `rules/effective-development.md`                     | นิยาม "WHY" ของทุกขั้นตอน workflow                                                               |
-| 2   | Session-start hook                       | `hooks/session-start.sh`                             | inject 7-step reminder + maturity-adapted verbosity directive ให้ทุก conversation                |
-| 3   | 17 on-demand process skills              | `skills/*/SKILL.md` (17 directories)                 | หนึ่ง skill ต่อหนึ่ง workflow step + standalone (`/cross-verify`, `/calibrate`, `/reflect`, ...) |
-| 4   | Habit + guide reference content          | `habits/h*.md`, `guides/*.md`                        | โหลด on-demand โดย skills (token-efficient — ไม่ inject ที่ session start)                       |
-| 5   | Maturity profile (per-user calibration)  | `~/.claude/habit-profile.md` (เขียนโดย `/calibrate`) | ขับ runtime verbosity adaptation ทุก skill (Dependence → Significance)                           |
-| 6   | Project + user CLAUDE.md / AGENTS.md     | `CLAUDE.md`, `AGENTS.md`, `~/.claude/CLAUDE.md`      | ตรงกับ pattern "implicit prompting through documentation" ของ Hashimoto, ใช้ที่ 3 scope          |
-
-### Feedback sensors
-
-| #   | Component                          | Path                                                                                    | จับอะไร                                                                                                                    |
-| --- | ---------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 7   | Structural validators (74 checks)  | `tests/validate-structure.sh`                                                           | โครงสร้างไฟล์, frontmatter, required sections                                                                              |
-| 8   | Content validators (132 checks)    | `tests/validate-content.sh`                                                             | Version-4-files consistency, README "What's New" drift, sidebar consistency, anchor integrity                              |
-| 9   | Auxiliary test scripts (36 checks) | `tests/test-skill-graph.sh`, `tests/test-verbosity-hook.sh`                             | Skill-graph integrity, hook output regression coverage                                                                     |
-| 10  | Read-only review agent             | `agents/8-habit-reviewer.md`                                                            | Audit โดยไม่แก้ไฟล์ (model: `sonnet`, tools: `Read`/`Glob`/`Grep`)                                                         |
-| 11  | Pre-commit cross-verification      | `skills/cross-verify/SKILL.md`                                                          | 17 คำถาม 8-Habit audit ก่อน commit                                                                                         |
-| 12  | Find→Fix→Re-Verify loop            | `skills/review-ai/SKILL.md`                                                             | บังคับ re-grep ทุกครั้งหลัง fix เพื่อกัน partial-fix regression                                                            |
-| 13  | Cross-session lesson persistence   | `~/.claude/lessons/` (เขียนโดย `/reflect`, retrieve โดย `/research` และ `/build-brief`) | ปิด gap "AI ไม่มีความจำข้าม session" ที่ Hashimoto เจอตรงๆ — เขียนบทเรียนลง disk แล้วโหลดเวลา task ที่เกี่ยวข้องครั้งถัดไป |
-
-นับรวม: **242 assertion ที่ verify ได้** ผ่าน 4 test script บวก cross-verification 17 ข้อ. ทุกข้อคือการแก้เชิงโครงสร้าง ไม่ใช่ "โปรดจำไว้"
-
-ตัวอย่าง concrete: patch v2.14.1 (issue #157) — user แจ้งว่า README "What's New" section drift ไป. fix ของเรา **ไม่ใช่** "เติม README ให้ครั้งเดียว" — แต่คือ **harden `validate-content.sh:578`** ให้ grep แบบ anchor ที่ section header แทน badge URL. ครั้งหน้าถ้าใครลืม validator จะจับได้ก่อน merge. ตรงตามนิยาม Hashimoto ทุกตัวอักษร
-
----
-
-## "ตอนนี้คุณอยู่ชั้นไหน?" — Self-checklist
-
-ลองติ้กดู — เอา layer ที่ติ้กส่วนใหญ่ได้ = ชั้นที่คุณอยู่:
-
-### Layer 1 — Prompt Engineer
-
-- [ ] iterate ด้วยการแก้คำพูดในข้อความเป็นข้อๆ
-- [ ] วัดความสำเร็จเป็นรายบทสนทนา ไม่ใช่ข้าม run
-- [ ] ไม่มีไฟล์ project ที่ auto-load context ทุก session
-- [ ] เวลา agent พลาด คุณแก้ด้วยการ "บอกครั้งหน้าอย่าทำ"
-- [ ] ไม่มี automated check ที่รันโดยไม่ต้องสั่ง
-
-### Layer 2 — Context Engineer
-
-- [ ] มี `CLAUDE.md` / `AGENTS.md` / system prompt ที่ load ทุก session
-- [ ] curate ไฟล์ที่เข้า working set ของ agent
-- [ ] จัดการ context-window budget ชัดเจน (token count, summarization, RAG)
-- [ ] เพิ่มของเข้า context เวลาเจอปัญหาซ้ำ
-- [ ] **แต่**: การแก้ยังอาศัยคุณจำได้ว่าต้อง update doc
-
-### Layer 3 — Harness Engineer
-
-- [ ] มี automated check ที่บล็อกพฤติกรรมแย่ได้แม้ไม่มีคนดู (session hook, pre-commit validator, reviewer agent)
-- [ ] จัดการความผิดพลาด agent เป็น **system bug** — แก้คือเพิ่ม validator/skill/hook ใหม่ ไม่ใช่ note "อย่าลืม..."
-- [ ] versioning guide, validator, และ decision record (ADR)
-- [ ] วัด agent quality ระดับ **system** (validator pass rate, regression count) ไม่ใช่รายบทสนทนา
-- [ ] มี **cross-session memory** — บทเรียนเก่าเรียกใช้ได้โดยไม่ต้องพิมพ์ใหม่
-
-ถ้าติ้กส่วนใหญ่ใน Layer 3 ได้ — **คุณเป็น Harness Engineer แล้ว** อาจจะก่อนรู้จักคำนี้ด้วยซ้ำ. ประเด็นของการมี "ชื่อ" ไม่ใช่ gatekeep ใคร — มันคือการให้ชื่อบทบาทเพื่อให้ practice ถูก discuss, สอน, และพัฒนาต่อได้
-
----
-
-## อ่านต่อ
-
-- [Architecture](Architecture) — โครงสร้างภายใน plugin
-- [Maturity Model](Maturity-Model) — Dependence → Independence → Interdependence → Significance
-- [Vibe Coding vs Structured](Vibe-Coding-vs-Structured) — failure mode ที่ harness นี้ป้องกัน
-- [Habits Reference](Habits-Reference) — 8 habit ที่ขับเคลื่อนทุก harness component
-
-## Sources
-
-1. Hashimoto, M. _My AI Adoption Journey_, 5 February 2026 — <https://mitchellh.com/writing/my-ai-adoption-journey>
-2. Lee, Y., Nair, R., Zhang, Q., Lee, K., Khattab, O., Finn, C. _Meta-Harness: End-to-End Optimization of Model Harnesses_, 2026 — <https://arxiv.org/abs/2603.28052>
-3. Böckeler, B. _Harness engineering for coding agent users_, Thoughtworks, 2 April 2026 — <https://martinfowler.com/articles/harness-engineering.html>
+- [Architecture](Architecture)
+- [Skills Reference](Skills-Reference)
+- [Workflow Overview](Workflow-Overview)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,134 +1,65 @@
-![Version](https://img.shields.io/badge/version-2.20.2-blue) ![Skills](https://img.shields.io/badge/skills-24-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange) ![Review](https://img.shields.io/badge/external_review-9.5%2F10-gold)
+![Version](https://img.shields.io/badge/version-2.20.2-blue) ![Skills](https://img.shields.io/badge/skills-24-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange)
 
 # 8-Habit AI Dev
 
+`8-habit-ai-dev` is a Claude Code and Codex plugin that adds workflow discipline to AI-assisted development. It ships portable markdown skills, a 7-step development workflow, and review habits grounded in Covey's 8 Habits.
+
 > [!IMPORTANT]
-> **Anti-Vibe-Coding plugin for Claude Code.**
-> A 7-step workflow discipline and 8-Habit cross-verification framework that replaces ad-hoc AI prompting with structured, reviewable, governable development.
->
-> _"ทำเสร็จ ≠ ทำดี"_ — _Done_ is not _Done well_.
+> This plugin provides guidance, prompts, review structure, and documentation. It does not add runtime enforcement, policy authorization, compliance certification, cloud automation, or production mutation.
 
-## Why This Exists
+## Start Here
 
-AI-assisted coding is fast but often undisciplined: missing requirements, skipped reviews, no rollback plans, accumulating tech debt. This plugin enforces the habits that separate effective developers from vibe coders — based on Stephen Covey's _7 Habits_ + _The 8th Habit_, adapted for the AI era.
+| Goal | Page |
+| --- | --- |
+| Install the plugin | [Installation](Installation) |
+| Try the workflow once | [Getting Started](Getting-Started) |
+| Choose the right skill | [Skills Reference](Skills-Reference) |
+| Understand the full process | [Workflow Overview](Workflow-Overview) |
+| Recover from common issues | [Troubleshooting](Troubleshooting) |
 
-## At a Glance
+## What You Get
 
-|                       |                                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------------- |
-| **24 skills**         | 8 workflow + 16 standalone skills for review, security, ops, debugging, compliance, and communication     |
-| **8 Habits**          | Covey's 7 + The 8th, adapted for AI-assisted development                                                  |
-| **24 ADRs**           | Every non-trivial decision documented                                                                     |
-| **4 maturity levels** | [Dependence → Independence → Interdependence → Significance](Maturity-Model)                              |
-| **Zero dependencies** | Pure markdown — no npm, no build step                                                                     |
-| **EU AI Act ready**   | First Claude Code plugin with [compliance toolkit](Skills-Reference#compliance--audit-skills)             |
-| **External review**   | Scored **9.5/10** (EXCELLENT) on [first formal audit](https://github.com/pitimon/8-habit-ai-dev/issues/1) |
+| Area | Included |
+| --- | --- |
+| Workflow | Steps 0-7 from research through monitoring |
+| Skills | 24 markdown skills for planning, review, operations, audit, and reflection |
+| Runtime support | Claude Code package and native Codex package |
+| Validation | Bash validators for skill structure, content, graph integrity, and hook budget |
+| Documentation | Wiki pages generated from `docs/wiki/` through PR review |
 
-> [!TIP]
-> **New here?** Start with [Installation](Installation) then [Getting Started](Getting-Started).
-> Already installed? Jump to [Workflow Overview](Workflow-Overview) or type `/using-8-habits` in Claude Code.
+## Core Workflow
 
-## The 7-Step Workflow
-
-```
-Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
-
-   [O] 0 · /research        H5 Understand    investigate before specifying
-        │
-        ▼
-   [H] 1 · /requirements    H2 End in Mind   define what, why, who
-        │
-        ▼
-   [H] 2 · /design          H8 Voice         architecture (human-led)
-        │
-        ▼
-   [O] 3 · /breakdown       H3 First Things  atomic tasks, no scope creep
-        │
-        ▼
-   [O] 4 · /build-brief     H5 Understand    context before coding
-        │
-        ▼
-   [!] 5 · /review-ai       H4 Win-Win       audit before commit
-        │
-        ▼
-   [H] 6 · /deploy-guide    H1 Proactive     staging first, rollback, reconcile
-        │
-        ▼
-   [O] 7 · /monitor-setup   H7 Sharpen Saw   observe after deploy
+```text
+/research -> /requirements -> /design -> /breakdown
+    -> /build-brief -> /review-ai -> /deploy-guide -> /monitor-setup
 ```
 
-| Step | Command                                  | Habit | Purpose                            |
-| ---- | ---------------------------------------- | ----- | ---------------------------------- |
-| 0    | [`/research`](Step-0-Research)           | H5    | Investigate before specifying      |
-| 1    | [`/requirements`](Step-1-Requirements)   | H2    | Define what, why, who              |
-| 2    | [`/design`](Step-2-Design)               | H8    | Architecture decisions (human-led) |
-| 3    | [`/breakdown`](Step-3-Breakdown)         | H3    | Atomic tasks, no scope creep       |
-| 4    | [`/build-brief`](Step-4-Build-Brief)     | H5    | Context before coding              |
-| 5    | [`/review-ai`](Step-5-Review-AI)         | H4    | Audit before commit                |
-| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1    | Staging first, rollback, reconcile |
-| 7    | [`/monitor-setup`](Step-7-Monitor-Setup) | H7    | Observe after deploy               |
+Most users should begin with two habits:
 
-## Beyond the Workflow
+- Run `/requirements` before building non-trivial work.
+- Run `/review-ai` before committing AI-generated work.
 
-**Assessment** — run at any point for deeper analysis:
+Use the full workflow for larger features, unclear domains, architecture changes, production deploys, or operational fixes.
 
-| Skill                                                        | Purpose                                                        |
-| ------------------------------------------------------------ | -------------------------------------------------------------- |
-| [`/cross-verify`](Skills-Reference#cross-verify)             | 17-question 8-Habit checklist                                  |
-| [`/whole-person-check`](Skills-Reference#whole-person-check) | Body/Mind/Heart/Spirit balance                                 |
-| [`/security-check`](Skills-Reference#security-check)         | OWASP Top 10 focused review                                    |
-| [`/scrutinize`](Skills-Reference#scrutinize)                 | Outsider-perspective review — questions if change should exist |
-| [`/consistency-check`](Skills-Reference#consistency-check)   | Spec artifact and incident/config hotfix drift detection       |
-| [`/reflect`](Skills-Reference#reflect)                       | Post-task retrospective with lesson persistence                |
-| [`/workflow`](Skills-Reference#workflow)                     | Interactive guided walkthrough                                 |
+## Current Release Focus
 
-**Debug Discipline** — active investigation + post-fix record:
+Version `v2.20.2` keeps the plugin's markdown-only boundary while improving operational guidance:
 
-| Skill                                          | Purpose                                                |
-| ---------------------------------------------- | ------------------------------------------------------ |
-| [`/diagnose`](Skills-Reference#diagnose)       | 6-phase active bug investigation (feedback-loop first) |
-| [`/post-mortem`](Skills-Reference#post-mortem) | Canonical RCA writeup after a validated fix lands      |
+- `/operational-state` classifies operational findings before action.
+- `/consistency-check` includes incident/config hotfix drift checks.
+- `/deploy-guide` includes reconciliation gates for provider-managed canaries and capacity changes.
 
-**Spec & Communication** — helpers orthogonal to the 7-step workflow:
+## Compatibility Boundary
 
-| Skill                                                  | Purpose                                          |
-| ------------------------------------------------------ | ------------------------------------------------ |
-| [`/save-spec`](Skills-Reference#save-spec)             | Scaffold project-root SPEC.md orientation hub    |
-| [`/management-talk`](Skills-Reference#management-talk) | Reshape engineer content for leadership channels |
+Claude Code and Codex both consume the same markdown skills. Claude Code also has Claude-specific hooks and session reminders. Codex uses `AGENTS.md`, the Codex plugin manifest, and the same `skills/` directory; it does not run Claude hooks.
 
-**Meta & Onboarding** — learn and adapt:
-
-| Skill                                                | Purpose                                        |
-| ---------------------------------------------------- | ---------------------------------------------- |
-| [`/using-8-habits`](Skills-Reference#using-8-habits) | Onboarding decision tree — which skill when?   |
-| [`/calibrate`](Skills-Reference#calibrate)           | Self-assess maturity, adapt guidance verbosity |
-
-**Compliance & Audit** — governance and transparency:
-
-| Skill                                                  | Purpose                                          |
-| ------------------------------------------------------ | ------------------------------------------------ |
-| [`/eu-ai-act-check`](Skills-Reference#eu-ai-act-check) | EU AI Act 9-obligation checklist (Articles 9-15) |
-| [`/ai-dev-log`](Skills-Reference#ai-dev-log)           | AI-assisted development log from git history     |
-
-## Principles
-
-> [!NOTE]
-> Skills are **read-only guidance** — they tell Claude how to approach a task. They never edit files themselves.
-
-- **Human-in-the-loop** for architecture and irreversible decisions
-- **Zero dependencies**: pure markdown + bash validation
-- **PR-first**: every change goes through review, even documentation
-- **Complementary**: pairs with [`claude-governance`](https://github.com/pitimon/claude-governance) for enforcement + compliance
+For details, see [Architecture](Architecture), [Installation](Installation), and the repository compatibility docs.
 
 ## Reference
 
-- **[8 Habits](Habits-Reference)** — the full playbook
-- **[Skills Catalog](Skills-Reference)** — all 24 skills, when to use each
-- **[Architecture](Architecture)** — how the plugin works internally
-- **[Maturity Model](Maturity-Model)** — adaptive guidance levels
-- **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)** — side-by-side comparison
-- **[FAQ](FAQ)** · **[Troubleshooting](Troubleshooting)**
-
-## Contributing
-
-See [Contributing to Wiki](Contributing-to-Wiki). The wiki is a build artifact — edit `docs/wiki/<page>.md` and open a PR.
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference)
+- [Habits Reference](Habits-Reference)
+- [Maturity Model](Maturity-Model)
+- [Architecture](Architecture)
+- [Changelog](Changelog)

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,61 +1,65 @@
 # Installation
 
-Two commands, zero dependencies. The plugin is pure markdown — no `npm install`, no build step.
+Install `8-habit-ai-dev` through the plugin marketplace for your agent runtime. The package is markdown-only: no dependency install, build step, or application service is required.
 
-## Prerequisites
+> [!NOTE]
+> Claude Code and Codex use different package surfaces. Both load the same `skills/` content, but Codex does not run Claude hooks.
 
-- [Claude Code](https://claude.com/claude-code) installed and authenticated
-- Git (for plugin marketplace cloning)
-
-## Install
+## Claude Code
 
 ```bash
 claude plugin marketplace add pitimon/8-habit-ai-dev
 claude plugin install 8-habit-ai-dev@pitimon-8-habit-ai-dev
 ```
 
-That's it. Restart Claude Code (or start a new session) to load the plugin.
+Start a new Claude Code session after installation. The session banner should include `8-Habit AI Dev Active` and a short 7-step workflow reminder.
 
-## Verify
+Verify:
 
-Inside Claude Code, you should see the session-start banner:
-
-```
-## 8-Habit AI Dev Active
-7-Step Workflow (not Vibe Coding):
-0. /research — Investigate before specifying (H5)
-...
+```bash
+claude plugin list
 ```
 
-List available skills:
-
-```
-/workflow
-```
-
-If the banner does not appear, see [Troubleshooting](Troubleshooting).
-
-## Update
+Update:
 
 ```bash
 claude plugin update 8-habit-ai-dev@pitimon-8-habit-ai-dev
 ```
 
-## Uninstall
+Uninstall:
 
 ```bash
 claude plugin uninstall 8-habit-ai-dev@pitimon-8-habit-ai-dev
 ```
 
-## What gets installed
+## Codex
 
-- **Skills** (loaded on demand):
-  - _Workflow_: `/research`, `/requirements`, `/design`, `/breakdown`, `/build-brief`, `/review-ai`, `/deploy-guide`, `/monitor-setup`
-  - _Assessment_: `/cross-verify`, `/whole-person-check`, `/security-check`, `/reflect`, `/workflow`
-  - _Meta_: `/using-8-habits`, `/calibrate`
-  - _Compliance_: `/eu-ai-act-check`, `/ai-dev-log`
-- **Rules** (auto-loaded every session): `rules/effective-development.md` — the full 8-Habit playbook
-- **Session hook**: ≤300-token reminder of the 7-step workflow
-- **Agent**: `8-habit-reviewer` — read-only cross-verification agent
+```bash
+codex plugin marketplace add pitimon/8-habit-ai-dev
+codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
 
-Next: **[Getting Started](Getting-Started)**.
+Verify:
+
+```bash
+codex plugin list
+```
+
+Codex should use `AGENTS.md` as the operating entrypoint, then route user intent through `skills/RESOLVER.md` to the relevant `skills/<name>/SKILL.md`.
+
+## What Installs
+
+| Surface | Claude Code | Codex |
+| --- | --- | --- |
+| 24 markdown skills | Yes | Yes |
+| 7-step workflow guidance | Yes | Yes |
+| Claude session hook | Yes | No |
+| Hook-based verbosity reminder | Yes | No |
+| Runtime enforcement | No | No |
+| Compliance certification | No | No |
+
+## Next
+
+- [Getting Started](Getting-Started)
+- [Workflow Overview](Workflow-Overview)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Maturity-Model.md
+++ b/docs/wiki/Maturity-Model.md
@@ -1,107 +1,32 @@
 # Maturity Model
 
-> [!IMPORTANT]
-> The maturity model is not a judgment — it is a signal that lets the plugin meet you where you are, not where the template assumes.
+The maturity model controls how much guidance the plugin should provide. It ranges from explicit coaching to concise prompts for experienced users.
 
-The plugin adapts its guidance based on your self-assessed maturity level. A beginner gets full scaffolding; an expert gets minimal prompts. This prevents the common complaint about workflow tools: "too much ceremony for experienced users" or "not enough guidance for new ones."
+## Levels
 
-## The 4 Levels
+| Level | User need | Guidance style |
+| --- | --- | --- |
+| Dependence | Learning the workflow | Full prompts, examples, and reminders |
+| Independence | Can run the basics | Short checklists and key decisions |
+| Interdependence | Works with team context | Collaboration, handoff, and review emphasis |
+| Significance | Experienced operator | Minimal prompts and exception-focused warnings |
 
-Based on Covey's maturity continuum, extended with the 8th Habit's Significance level:
+## How Calibration Works
 
-```
-   Dependence       full guidance — all examples, checkpoints, templates
-        │
-        ▼
-   Independence     key checkpoints — skip beginner detail, trust user
-        │
-        ▼
-   Interdependence  team focus — delegation, parallel execution, synergy
-        │
-        ▼
-   Significance     minimal prompts — expert mode, flag exceptions only
-```
+`/calibrate` asks a short set of questions and writes a local Claude Code profile at `~/.claude/habit-profile.md`. Skills can use that profile to adjust verbosity.
 
-| Level               | You are...                                                  | Plugin behavior                                                                                          |
-| ------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Dependence**      | New to structured AI dev. Need scaffolding to build habits. | Full guidance: all examples shown, all checkpoints explained, templates provided, skip rules spelled out |
-| **Independence**    | Self-directed. Have foundations but still refining.         | Key checkpoints only: skip beginner explanations, show decision points, trust you to fill in details     |
-| **Interdependence** | Team-embedded. Lead or mentor others.                       | Team and synergy focus: delegation patterns, review quality, parallel execution, minimal solo ceremony   |
-| **Significance**    | Set standards. Define how others work.                      | Minimal prompts: expert mode, only flag exceptions, trust judgment on process, focus on meta-system      |
+> [!NOTE]
+> Hook-based profile adaptation is Claude Code-specific. Codex can still use the skill content, but it does not run Claude hooks.
 
-## How to Calibrate
+## When To Recalibrate
 
-Run `/calibrate` in Claude Code. The skill asks 5-7 questions about your development practices:
+- Guidance feels too verbose.
+- Guidance feels too sparse.
+- Your role changes from solo implementation to team review or production operations.
+- You are onboarding a new team member.
 
-1. How do you typically start a new feature?
-2. What happens after you write code?
-3. How do you handle architecture decisions?
-4. How do you work with AI assistants?
-5. How do you share knowledge with your team?
+## See Also
 
-Based on your answers, the skill identifies your dominant maturity level and writes a profile.
-
-> [!TIP]
-> You don't need to calibrate before using the plugin. It defaults to Independence level if no profile exists. Calibrate when you want more or less guidance than the default provides.
-
-## Where the Profile Lives
-
-The profile is stored at `~/.claude/habit-profile.md` — global, per-user, not per-project. Format:
-
-```yaml
----
-schema-version: 1
-dominant-level: interdependence
-assessed-date: 2026-04-15
----
-## Assessment Summary
-...
-```
-
-See [`guides/habit-profile-schema.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/habit-profile-schema.md) for the full schema specification.
-
-## How Skills Adapt
-
-The adaptation happens at session start, not per-skill:
-
-1. `hooks/session-start.sh` reads `~/.claude/habit-profile.md`
-2. Emits a level-specific directive into session context
-3. All 24 skills automatically adapt their verbosity — **zero per-skill changes needed**
-
-This means a single calibration affects every skill invocation for the rest of the session. The canonical adaptation rules are in [`guides/verbosity-adaptation.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/verbosity-adaptation.md).
-
-## Opting Out
-
-If you've internalized the workflow and find even the session-start reminder distracting:
-
-```bash
-export HABIT_QUIET=1
-```
-
-This suppresses the session-start banner entirely. Skills still work when invoked — only the automatic reminder is silenced. See [ADR-006](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-006-audience-honesty-and-superpowers-deferral.md) for rationale.
-
-## Re-Calibration
-
-Your maturity level changes over time. After ~90 days, consider re-running `/calibrate` — especially if:
-
-- You've moved to a new team or role
-- You've adopted or dropped development practices
-- The plugin guidance feels too detailed or too sparse
-
-## Connection to the Three Loops
-
-The maturity levels map naturally to the decision authority model:
-
-| Level           | Primary Loop              | Decision style                                              |
-| --------------- | ------------------------- | ----------------------------------------------------------- |
-| Dependence      | In-the-Loop               | Human decides everything, AI assists step by step           |
-| Independence    | On-the-Loop               | AI proposes, human reviews and approves                     |
-| Interdependence | On-the-Loop → Out-of-Loop | Team delegates well-scoped tasks to AI                      |
-| Significance    | Out-of-Loop + Voice       | AI executes within guardrails; human defines the guardrails |
-
-## See also
-
-- [`/calibrate`](Skills-Reference#calibrate) — the self-assessment skill
-- [Architecture](Architecture) — how the hook-based adaptation works
-- [8 Habits → H8 Find Your Voice](Habits-Reference#habit-8-find-your-voice-and-inspire-others) — the principle behind adaptive guidance
-- [ADR-008](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-008-user-maturity-calibration-design.md) — design decisions
+- [Skills Reference](Skills-Reference#calibrate)
+- [Workflow Overview](Workflow-Overview)
+- [Habits Reference](Habits-Reference)

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,219 +1,217 @@
-# Skills Catalog
+# Skills Reference
 
-All **24 skills** shipped through `8-habit-ai-dev` v2.20.2. Skills are **read-only guidance** — they tell Claude how to approach a task, they do not modify files themselves.
+`8-habit-ai-dev` ships 24 user-facing markdown skills. Skills are read-only guidance: they structure investigation, planning, review, deployment, communication, and reflection, but they do not execute changes by themselves.
 
 > [!TIP]
-> Not sure which skill to use? Type `/using-8-habits` for an interactive decision tree, or see the [quick-select matrix](#quick-select-matrix) below.
+> If you are unsure where to start, use `/using-8-habits` or the quick selector below.
 
-## 7-Step Workflow Skills
+## Quick Selector
 
-| #   | Skill                                    | Habit | When to use                                              |
-| --- | ---------------------------------------- | ----- | -------------------------------------------------------- |
-| 0   | [`/research`](Step-0-Research)           | H5    | Problem space is unclear — investigate before specifying |
-| 1   | [`/requirements`](Step-1-Requirements)   | H2    | Any new feature or non-trivial change                    |
-| 2   | [`/design`](Step-2-Design)               | H8    | Architecture decisions — human decides                   |
-| 3   | [`/breakdown`](Step-3-Breakdown)         | H3    | Decompose work into atomic tasks                         |
-| 4   | [`/build-brief`](Step-4-Build-Brief)     | H5    | Before coding each task — read existing code first       |
-| 5   | [`/review-ai`](Step-5-Review-AI)         | H4    | **Always** before committing AI-generated code           |
-| 6   | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1    | Staging-first deploys with rollback and provider reconciliation |
-| 7   | [`/monitor-setup`](Step-7-Monitor-Setup) | H7    | Observability after deploy                               |
+| Situation | Start with |
+| --- | --- |
+| New feature | [`/requirements`](#requirements) |
+| Unclear problem | [`/research`](#research) |
+| Architecture decision | [`/design`](#design) |
+| AI-generated diff | [`/review-ai`](#review-ai) |
+| Security-sensitive change | [`/security-check`](#security-check) |
+| Production deploy | [`/deploy-guide`](#deploy-guide) |
+| Operational finding | [`/operational-state`](#operational-state) |
+| Bug with unclear cause | [`/diagnose`](#diagnose) |
+| Incident/config hotfix drift | [`/consistency-check`](#consistency-check) |
+| After a validated fix | [`/post-mortem`](#post-mortem) |
+| Need stakeholder-ready wording | [`/management-talk`](#management-talk) |
 
-## Assessment Skills
+## Workflow Skills
 
-Run at any point in the workflow for deeper analysis.
+### `/research` {#research}
+
+Investigate before specifying. Produces a research brief with findings, constraints, open questions, and recommended next step.
+
+- Page: [Step 0 · Research](Step-0-Research)
+- Habit: H5 Seek First to Understand
+- Source: [`skills/research/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/research/SKILL.md)
+
+### `/requirements` {#requirements}
+
+Define what, why, who, scope, success criteria, and Definition of Done before implementation.
+
+- Page: [Step 1 · Requirements](Step-1-Requirements)
+- Habit: H2 Begin with End in Mind
+- Source: [`skills/requirements/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/requirements/SKILL.md)
+
+### `/design` {#design}
+
+Surface architecture options and make the human decision explicit.
+
+- Page: [Step 2 · Design](Step-2-Design)
+- Habit: H8 Find Your Voice
+- Source: [`skills/design/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/design/SKILL.md)
+
+### `/breakdown` {#breakdown}
+
+Decompose approved work into atomic, ordered tasks.
+
+- Page: [Step 3 · Breakdown](Step-3-Breakdown)
+- Habit: H3 Put First Things First
+- Source: [`skills/breakdown/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/breakdown/SKILL.md)
+
+### `/build-brief` {#build-brief}
+
+Read existing code and produce an implementation brief before editing.
+
+- Page: [Step 4 · Build Brief](Step-4-Build-Brief)
+- Habit: H5 Seek First to Understand
+- Source: [`skills/build-brief/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/build-brief/SKILL.md)
+
+### `/review-ai` {#review-ai}
+
+Review AI-generated changes before commit, with findings ordered by severity.
+
+- Page: [Step 5 · Review AI](Step-5-Review-AI)
+- Habit: H4 Think Win-Win
+- Source: [`skills/review-ai/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/review-ai/SKILL.md)
+
+### `/deploy-guide` {#deploy-guide}
+
+Plan staging, production, rollback, verification, and reconciliation for deploys.
+
+- Page: [Step 6 · Deploy Guide](Step-6-Deploy-Guide)
+- Habit: H1 Be Proactive
+- Current note: includes provider-managed canary/capacity reconciliation gates.
+- Source: [`skills/deploy-guide/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/deploy-guide/SKILL.md)
+
+### `/monitor-setup` {#monitor-setup}
+
+Add or verify health checks, alerting, metrics, logging, dashboards, and runbooks after deployment.
+
+- Page: [Step 7 · Monitor Setup](Step-7-Monitor-Setup)
+- Habit: H7 Sharpen the Saw
+- Source: [`skills/monitor-setup/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/monitor-setup/SKILL.md)
+
+## Assessment And Review Skills
 
 ### `/cross-verify` {#cross-verify}
 
-17-question 8-Habit cross-verification checklist. Run **after** planning and **before** committing to implementation. Produces a dimension summary across all 8 habits with confidence levels.
+Run a 17-question 8-Habit readiness check across a plan, diff, or implementation.
 
-- **Habit**: H1-H8 (all)
-- **When to use**: Before `ExitPlanMode`, before PR creation
-- **Source**: [`skills/cross-verify/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/cross-verify/SKILL.md)
+- Use before implementation commitment, PR creation, or risky merge.
+- Source: [`skills/cross-verify/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/cross-verify/SKILL.md)
 
 ### `/whole-person-check` {#whole-person-check}
 
-Assess a feature/component/PR against Covey's 4 dimensions: **Body** (discipline), **Mind** (vision), **Heart** (passion), **Spirit** (conscience). Scores 1-5 per dimension.
+Assess Body, Mind, Heart, and Spirit balance for a feature, component, or PR.
 
-- **Habit**: H8 Find Your Voice
-- **When to use**: After `/review-ai` when you want a balance check
-- **Source**: [`skills/whole-person-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/whole-person-check/SKILL.md)
+- Use when a technically correct change may still be unbalanced.
+- Source: [`skills/whole-person-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/whole-person-check/SKILL.md)
 
 ### `/security-check` {#security-check}
 
-Focused security review — secrets, injection, auth, dependencies, OWASP Top 10. A dedicated security lens separate from general code review.
+Run a focused security lens across secrets, input handling, auth, dependencies, config, infrastructure, and source-of-truth drift.
 
-- **Habit**: H1 Be Proactive
-- **When to use**: Any change touching user input, auth, data handling, or dependencies
-- **Source**: [`skills/security-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/security-check/SKILL.md)
+- Use for code, infrastructure, alerting, email, webhook, container, environment, and mounted-config changes with risk-bearing behavior.
+- Source: [`skills/security-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/security-check/SKILL.md)
 
 ### `/scrutinize` {#scrutinize}
 
-Outsider-perspective end-to-end review — questions intent first ("is there a simpler way?"), then traces the actual code path (not just the diff) to verify the change does what it claims. Pairs with `/review-ai` (scope-question vs diff-local). Operating Rules hardened in v2.18.1 (ADR-017) with MUST/NEVER + Why blocks.
+Question whether the proposed change should exist, then trace the actual path to verify it does what it claims.
 
-- **Habit**: H5 Understand First + H8 Find Your Voice
-- **When to use**: Before committing to an implementation, or before merging a PR alongside `/review-ai`
-- **Source**: [`skills/scrutinize/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/scrutinize/SKILL.md)
+- Use before committing to a plan or before merging a PR.
+- Source: [`skills/scrutinize/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/scrutinize/SKILL.md)
 
 ### `/consistency-check` {#consistency-check}
 
-Cross-artifact consistency analyzer — runs 5 detection passes (Coverage, Drift, Ambiguity, Underspec, Inconsistency) across persisted spec artifacts (PRD ↔ design ↔ tasks). Also includes incident/config hotfix mode for symptom ↔ evidence ↔ root cause ↔ fix ↔ verification drift when no spec bundle exists. Read-only — reports drift, coverage gaps, contradictions. Inspired by github/spec-kit `/analyze`.
+Check drift across PRD, design, and tasks. Also supports incident/config hotfix mode for symptom, evidence, root cause, fix, deploy path, and verification consistency.
 
-- **Habit**: H5 Understand First + H1 Be Proactive
-- **When to use**: After `/requirements`, `/design`, `/breakdown` have been run with `--persist <slug>` to catch drift before code, or before closing an incident/config hotfix PR
-- **Source**: [`skills/consistency-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/consistency-check/SKILL.md)
-
-### `/operational-state` {#operational-state}
-
-Operational finding classifier — chooses Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue, False Positive, or Self-Resolved before action. Maps evidence, allowed/prohibited actions, approval gates, required artifacts, escalation criteria, and closure criteria.
-
-- **Habit**: H1 Be Proactive + H5 Understand First + H8 Find Your Voice
-- **When to use**: Before mutating or closing an operational finding, especially recovered-but-recurring signals, Running-but-unhealthy workloads, source-of-truth drift, accepted known issues, or ownership handoffs
-- **Source**: [`skills/operational-state/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/operational-state/SKILL.md)
+- Use after persisted spec artifacts or before closing an operational hotfix PR.
+- Source: [`skills/consistency-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/consistency-check/SKILL.md)
 
 ### `/reflect` {#reflect}
 
-Post-task micro-retrospective — 6 questions, 5 minutes. Captures lessons to `~/.claude/lessons/` for future retrieval by `/research` and `/build-brief`. Includes skill-effectiveness signal (Q6) feeding `SKILL-EFFECTIVENESS.md`.
+Capture a short post-task lesson, including what helped, what confused, and which skill was missed.
 
-- **Habit**: H7 Sharpen the Saw
-- **When to use**: After completing a task or workflow
-- **Source**: [`skills/reflect/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/reflect/SKILL.md)
+- Use after meaningful work, especially after incidents or release work.
+- Source: [`skills/reflect/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/reflect/SKILL.md)
 
-### `/workflow` {#workflow}
+## Operations And Debugging Skills
 
-Interactive guided walkthrough of the 7-step workflow. Prompts at each step to invoke or skip.
+### `/operational-state` {#operational-state}
 
-- **Habit**: All
-- **When to use**: Starting a new feature when you're unsure which step comes next
-- **Source**: [`skills/workflow/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/workflow/SKILL.md)
+Classify operational findings as Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue, False Positive, or Self-Resolved before action.
 
-## Debug Discipline Skills
-
-Active bug investigation and post-fix engineering record. Ported from prior-art (mattpocock/skills, 9arm-skills) per ADR-014 + ADR-015.
+- Use before mutating production state, closing an alert/issue, accepting a known problem, or handing off ownership.
+- Boundary: read-only guidance; no runtime state engine or automatic production change.
+- Source: [`skills/operational-state/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/operational-state/SKILL.md)
 
 ### `/diagnose` {#diagnose}
 
-6-phase active bug investigation methodology — feedback-loop → reproduce → hypothesise → instrument → fix-with-regression-test → cleanup. Closes the gap between `/research` (too broad) and `/post-mortem` (too late). Phase 6 hardened in v2.18.1 (ADR-017) with MUST re-run Phase 1 feedback loop, citing Anthropic pptx.
+Investigate a bug through feedback loop, reproduction, hypothesis, instrumentation, fix with regression test, and cleanup.
 
-- **Habit**: H1 Be Proactive + H5 Understand First
-- **When to use**: When a bug needs to be fixed and the cause isn't obvious from stack trace; hands off to `/post-mortem` once fix lands
-- **Source**: [`skills/diagnose/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/diagnose/SKILL.md)
+- Use when the cause is not obvious.
+- Source: [`skills/diagnose/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/diagnose/SKILL.md)
 
 ### `/post-mortem` {#post-mortem}
 
-Engineering RCA writeup — canonical record of a fixed bug (root cause, mechanism, fix, validation, how it slipped through). Refuses to draft without 4 inputs (reliable repro, known cause, identified fix, validated outcome).
+Write the engineering record after a validated fix: root cause, mechanism, fix, validation, and how it slipped through.
 
-- **Habit**: H4 Win-Win + H7 Sharpen the Saw
-- **When to use**: AFTER a debug session lands a validated fix, BEFORE closing the ticket
-- **Source**: [`skills/post-mortem/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/post-mortem/SKILL.md)
+- Use after a reliable repro, known cause, identified fix, and validated outcome exist.
+- Source: [`skills/post-mortem/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/post-mortem/SKILL.md)
 
-## Spec & Communication Skills
+## Onboarding, Memory, And Communication Skills
 
-Helpers for project orientation and audience reshape — orthogonal to the 7-step workflow.
+### `/workflow` {#workflow}
 
-### `/save-spec` {#save-spec}
+Walk through the 7-step workflow interactively.
 
-Scaffolds a project-root `SPEC.md` digest following the spec-digest-pattern archetype (project orientation hub). User-invoked. Generator-only Phase 1; refuses to overwrite an existing SPEC.md. Distinct from per-feature `/requirements --persist <slug>` mode.
-
-- **Habit**: H2 Begin with End in Mind + H5 Understand First
-- **When to use**: When starting on an unfamiliar repo or after a `/clear` flushing pain — gives Claude a 4-section orientation hub
-- **Source**: [`skills/save-spec/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/save-spec/SKILL.md)
-
-### `/management-talk` {#management-talk}
-
-Channel-aware audience reshape — converts engineer-to-engineer content into leadership-channel-shaped form (JIRA / Slack / standup / email / meeting). Strips function/file/SHA noise but keeps JIRA keys, PR numbers, workload names. Inspired by 9arm-skills (v2.17.0).
-
-- **Habit**: H4 Win-Win + H6 Synergize
-- **When to use**: When VPs, directors, PMs, or release managers need a status — and your raw engineering notes are too dense
-- **Source**: [`skills/management-talk/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/management-talk/SKILL.md)
-
-## Meta & Onboarding Skills
-
-Learn the plugin and adapt it to your style.
+- Use when starting a feature and you want the agent to prompt step by step.
+- Source: [`skills/workflow/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/workflow/SKILL.md)
 
 ### `/using-8-habits` {#using-8-habits}
 
-Onboarding meta-skill — explains the 8 habits, all 24 skills, and provides a decision tree for "which skill next?". Includes a complete walkthrough example (password-reset feature).
+Explain the plugin and route user intent to the most relevant skill.
 
-- **Habit**: H5 Understand First + H8 Find Your Voice
-- **When to use**: First time using the plugin, or when unsure which skill applies
-- **Source**: [`skills/using-8-habits/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/using-8-habits/SKILL.md)
+- Use for onboarding or when a request does not map clearly to one skill.
+- Source: [`skills/using-8-habits/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/using-8-habits/SKILL.md)
 
 ### `/calibrate` {#calibrate}
 
-Self-assessment skill that determines your maturity level (Dependence → Independence → Interdependence → Significance) and writes a profile to `~/.claude/habit-profile.md`. Other skills read this profile to adapt verbosity — full guidance for beginners, minimal prompts for experts.
+Assess guidance maturity and write a local verbosity profile for Claude Code.
 
-- **Habit**: H8 Find Your Voice
-- **When to use**: When plugin guidance feels too detailed or too sparse
-- **Deep dive**: [Maturity Model](Maturity-Model)
-- **Source**: [`skills/calibrate/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/calibrate/SKILL.md)
+- Use when guidance feels too verbose or too sparse.
+- Source: [`skills/calibrate/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/calibrate/SKILL.md)
 
-## Compliance & Audit Skills
+### `/save-spec` {#save-spec}
 
-Governance, transparency, and regulatory readiness.
+Scaffold a project-root `SPEC.md` orientation hub when a repository needs a durable project digest.
+
+- Use when starting in an unfamiliar repo and the repo fits the project-orientation hub mode.
+- Source: [`skills/save-spec/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/save-spec/SKILL.md)
+
+### `/management-talk` {#management-talk}
+
+Reshape engineer-to-engineer content for leadership channels such as JIRA, Slack, standup, email, or meeting notes.
+
+- Use after technical investigation when the audience changes.
+- Source: [`skills/management-talk/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/management-talk/SKILL.md)
+
+## Audit And Governance-Adjacent Skills
 
 ### `/eu-ai-act-check` {#eu-ai-act-check}
 
-EU AI Act Regulation 2024/1689 compliance checker. 9 obligations from Articles 9-15 with a tiered checklist: **25 MUST** + **27 SHOULD** + **8 COULD** items. Includes a scope-check pre-flight to skip quickly if your system is not high-risk or not EU-targeted.
+Redirect stub for EU AI Act compliance work. The canonical implementation lives in `pitimon/claude-governance`.
 
-- **Habit**: H1 Be Proactive + H8 Spirit (Conscience)
-- **When to use**: Before major releases of high-risk AI systems targeting the EU
-- **Enforcement date**: 2 August 2026
-- **Source**: [`skills/eu-ai-act-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/eu-ai-act-check/SKILL.md)
+- Use the governance plugin for the full checklist.
+- Boundary: this plugin does not certify compliance.
+- Source: [`skills/eu-ai-act-check/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/eu-ai-act-check/SKILL.md)
 
 ### `/ai-dev-log` {#ai-dev-log}
 
-Generates an AI-assisted development log from `git log` + `Co-Authored-By` trailers. 4 output modes: markdown, JSON, summary, and stdout. Useful for EU AI Act Article 11 (technical documentation) audit trails and team transparency.
+Generate an AI-assisted development log from git history and co-author trailers.
 
-- **Habit**: H4 Win-Win + H1 Be Proactive
-- **When to use**: Before releases, audits, or when stakeholders ask "how much was AI-generated?"
-- **Source**: [`skills/ai-dev-log/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/ai-dev-log/SKILL.md)
+- Use for transparency, release review, or audit trail preparation.
+- Source: [`skills/ai-dev-log/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/ai-dev-log/SKILL.md)
 
-## Quick-Select Matrix
+## See Also
 
-| I need to...                             | Use                                                                    |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| Start a new feature from scratch         | [`/workflow`](#workflow) or [`/requirements`](#7-step-workflow-skills) |
-| Understand this plugin                   | [`/using-8-habits`](#using-8-habits)                                   |
-| Adjust guidance verbosity                | [`/calibrate`](#calibrate)                                             |
-| Research before deciding                 | [`/research`](Step-0-Research)                                         |
-| Review AI-generated code                 | [`/review-ai`](Step-5-Review-AI)                                       |
-| Check all 8 habits at once               | [`/cross-verify`](#cross-verify)                                       |
-| Assess Body/Mind/Heart/Spirit balance    | [`/whole-person-check`](#whole-person-check)                           |
-| Run a focused security review            | [`/security-check`](#security-check)                                   |
-| Check EU AI Act compliance               | [`/eu-ai-act-check`](#eu-ai-act-check)                                 |
-| Generate AI audit trail                  | [`/ai-dev-log`](#ai-dev-log)                                           |
-| Capture lessons after a task             | [`/reflect`](#reflect)                                                 |
-| Deploy safely to production or run a provider canary | [`/deploy-guide`](Step-6-Deploy-Guide)                                 |
-| Question whether the change should exist | [`/scrutinize`](#scrutinize)                                           |
-| Catch drift between PRD↔design↔tasks or incident/config hotfix claims | [`/consistency-check`](#consistency-check)                             |
-| Classify an operational finding          | [`/operational-state`](#operational-state)                             |
-| Investigate a bug from feedback-loop     | [`/diagnose`](#diagnose)                                               |
-| Write the engineering record post-fix    | [`/post-mortem`](#post-mortem)                                         |
-| Scaffold a project orientation hub       | [`/save-spec`](#save-spec)                                             |
-| Reshape engineer content for leadership  | [`/management-talk`](#management-talk)                                 |
-
-## Skill Anatomy
-
-Every skill follows the same structure ([source convention](https://github.com/pitimon/8-habit-ai-dev/blob/main/CLAUDE.md#skill-authoring-conventions)):
-
-```yaml
----
-name: <skill-name>
-description: >
-  When to use this skill
-user-invocable: true
-argument-hint: "[arg description]"
-allowed-tools: ["Read", "Glob", "Grep"]
-prev-skill: <predecessor|any|none>
-next-skill: <successor|any|none>
----
-```
-
-Body: Habit mapping → Process → Handoff → When to Skip → Definition of Done → Checkpoint.
-
-## See also
-
-- **[Workflow Overview](Workflow-Overview)**
-- **[Habits Reference](Habits-Reference)**
-- **[Architecture](Architecture)** — how skills load and connect
-- **[FAQ: When should I use which skill?](FAQ)**
+- [Workflow Overview](Workflow-Overview)
+- [Maturity Model](Maturity-Model)
+- [Architecture](Architecture)

--- a/docs/wiki/Step-0-Research.md
+++ b/docs/wiki/Step-0-Research.md
@@ -1,56 +1,40 @@
 # Step 0 · Research
 
-**Command**: `/research [topic]` · **Habit**: H5 Seek First to Understand · **Position**: Optional pre-step before [`/requirements`](Step-1-Requirements)
+`/research` investigates the problem space before requirements are written. Use it when the domain, precedent, options, or constraints are not yet clear.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/research [topic]` |
+| Habit | H5 Seek First to Understand |
+| Previous | None |
+| Next | [Step 1 · Requirements](Step-1-Requirements) |
 
-Investigate the problem space **before** writing requirements. Prevents specifying the wrong thing — the most expensive bug class.
+## Use This When
 
-## When to use
+- The user request is vague or unfamiliar.
+- You need prior art, constraints, standards, or trade-offs.
+- A bug or incident has unclear causes and needs investigation before planning.
 
-- Problem space is unclear or unfamiliar
-- Multiple existing solutions exist and you need a comparison
-- Domain has non-obvious constraints (regulatory, performance, security)
-- You catch yourself thinking "I'll just start coding and see"
+## Skip When
 
-## When to skip
-
-- You have deep domain knowledge already
-- Requirement is crystal clear (e.g. "fix typo in header")
-- Prior ADR already covers the decision space
-
-## Process
-
-1. **Define the question** — 1 sentence, specific
-2. **Check past lessons** — search `~/.claude/lessons/` for relevant lessons from prior sessions (v2.6.0+)
-3. **Gather prior art** — existing code, docs, web research, comparable libraries
-4. **Compare** — if evaluating alternatives, produce a trade-off matrix
-5. **Surface constraints** — legal, performance, team skills, budget
-6. **Recommend** (not decide) — AI recommends; human decides in Step 2
+- The change is obvious and local.
+- Requirements are already clear and current.
+- The task is pure formatting or mechanical cleanup.
 
 ## Output
 
-A **research brief** containing:
-
-- Problem statement
-- Findings summary
-- Comparison matrix (if applicable)
-- Constraints
-- Recommendation + rationale
-- Open questions
+- Research question and scope.
+- Findings with source quality noted.
+- Open questions and risks.
+- Recommendation for whether to continue to `/requirements`, `/diagnose`, or another skill.
 
 ## Handoff
 
-- **Expects**: A topic or question from the user
-- **Produces for `/requirements`**: Research brief that informs PRD scope and success criteria
+`/requirements` should receive the problem statement, constraints, evidence, unresolved questions, and any recommended boundaries.
 
-## H5 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Have I fully understood the problem before proposing a solution?"_
-
-## See also
-
-- [Source: `skills/research/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/research/SKILL.md)
-- [Habits Reference → H5](Habits-Reference#habit-5-seek-first-to-understand)
-- Next: [Step 1 · Requirements](Step-1-Requirements)
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference#research)
+- [Habits Reference](Habits-Reference#habit-5-seek-first-to-understand)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/research/SKILL.md)

--- a/docs/wiki/Step-1-Requirements.md
+++ b/docs/wiki/Step-1-Requirements.md
@@ -1,55 +1,40 @@
 # Step 1 · Requirements
 
-**Command**: `/requirements [feature]` · **Habit**: H2 Begin with End in Mind · **Previous**: [Step 0 · Research](Step-0-Research) · **Next**: [Step 2 · Design](Step-2-Design)
+`/requirements` defines what should change, why it matters, who it serves, and how success will be evaluated before implementation begins.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/requirements [feature or change]` |
+| Habit | H2 Begin with End in Mind |
+| Previous | [Step 0 · Research](Step-0-Research) |
+| Next | [Step 2 · Design](Step-2-Design) |
 
-Define what "done" looks like before touching code. A PRD you can verify against.
+## Use This When
 
-## When to use
+- Starting a feature, refactor, workflow change, or non-trivial bug fix.
+- The request needs explicit scope or acceptance criteria.
+- The agent needs a stable target before coding.
 
-- Any new feature
-- Any bug fix whose scope is unclear
-- Any refactor affecting >1 module
+## Skip When
 
-## When to skip
-
-- Single-line bug fix with obvious root cause
-- Formatting / linting
-- Dependency version bumps
-
-## Process
-
-1. **Interview** — follow the [Interview Protocol](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/templates/interview-protocol.md) to discover requirements through structured conversation. Adaptive depth: Quick (3 questions) for small scope, Standard (5) by default, Deep (7+) for complex features
-2. Read existing `CLAUDE.md`, `PRD.md`, `DOMAIN.md`, `README.md` — don't duplicate
-3. Draft PRD summary (10–20 lines)
-4. Define 3–5 verifiable success criteria in EARS notation
-5. List what's **out of scope** explicitly
+- The change is a small, obvious fix and the expected behavior is already explicit.
+- You are only correcting formatting, typos, or generated docs noise.
 
 ## Output
 
-```
-## Feature: [Name]
-**What**: [1-2 sentences]
-**Why**: [Problem it solves]
-**Who**: [Target user]
-**In scope**: [bullets]
-**Out of scope**: [bullets]
-**Success criteria**: [3-5 verifiable conditions]
-**Definition of Done**: [what must be true]
-```
+- Problem and goal.
+- Users or affected stakeholders.
+- In-scope and out-of-scope items.
+- Success criteria, preferably in EARS-style wording when useful.
+- Definition of Done and test expectations.
 
 ## Handoff
 
-- **Expects**: User intent (and optionally a research brief from Step 0)
-- **Produces for `/design`**: PRD with scope and success criteria
+`/design` should receive the requirements, constraints, acceptance criteria, and any decisions that still require human judgment.
 
-## H2 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Can I describe what success looks like before writing code?"_
-
-## See also
-
-- [Source: `skills/requirements/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/requirements/SKILL.md)
-- [Habits Reference → H2](Habits-Reference#habit-2-begin-with-the-end-in-mind)
+- [Workflow Overview](Workflow-Overview)
+- [Step 2 · Design](Step-2-Design)
+- [Habits Reference](Habits-Reference#habit-2-begin-with-end-in-mind)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/requirements/SKILL.md)

--- a/docs/wiki/Step-2-Design.md
+++ b/docs/wiki/Step-2-Design.md
@@ -1,72 +1,43 @@
 # Step 2 · Design
 
-**Command**: `/design [component]` · **Habit**: H8 Find Your Voice · **Previous**: [Step 1 · Requirements](Step-1-Requirements) · **Next**: [Step 3 · Breakdown](Step-3-Breakdown)
+`/design` turns requirements into architecture options and records the human decision. It is the step that keeps AI from silently choosing the architecture.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/design [requirements or context]` |
+| Habit | H8 Find Your Voice |
+| Previous | [Step 1 · Requirements](Step-1-Requirements) |
+| Next | [Step 3 · Breakdown](Step-3-Breakdown) |
 
-Make architecture decisions **with human judgment**. AI proposes options and trade-offs; the human decides. This is the most important checkpoint in the workflow — architecture is hard to reverse.
+## Use This When
 
-## When to use
+- The change affects architecture, persistence, API contracts, security boundaries, or deployment shape.
+- More than one viable implementation path exists.
+- The decision should be reviewable later.
 
-- Any change affecting >3 files
-- Any change to public API or data schema
-- Any change to auth, authorization, or data flow
-- Any change introducing a new dependency
+## Skip When
 
-## When to skip
-
-- Change follows an existing, established pattern
-- Cosmetic / UI-only with no architecture impact
-- Already covered by a previously accepted ADR
-
-## Process
-
-1. Read existing `CLAUDE.md`, `DESIGN.md`, `ARCHITECTURE.md`, `docs/adr/`
-2. Identify decisions needing human input (DB, auth, API, boundaries, deps)
-3. Present **at least 2 options with trade-offs** for each decision
-4. **Human decides** — record the choice
-5. Write an **ADR** if the decision affects >3 files or changes public API
+- The implementation path is already decided and local.
+- The work is mechanical and does not change behavior or structure.
 
 ## Output
 
-Decision document or ADR following `guides/templates/adr-template.md`:
+- Key decisions.
+- At least two options for meaningful decisions.
+- Trade-offs, risks, and constraints.
+- Recommended option, with the human decision made explicit.
+- ADR guidance when the decision is durable.
 
-```
-## Decision: [Topic]
-**Option A**: ... — Pro/Con
-**Option B**: ... — Pro/Con
-**Recommendation**: ...
-**Chosen**: [by human]
-```
+> [!IMPORTANT]
+> Architecture decisions stay human-led. The skill structures options; it does not transfer accountability to the model.
 
 ## Handoff
 
-- **Expects**: PRD summary from `/requirements`
-- **Produces for `/breakdown`**: Architecture decisions, technology choices, constraints
+`/breakdown` should receive the selected design, rejected alternatives, constraints, and any sequencing requirements.
 
-## H8 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Do I understand WHY we're building it this way, not just WHAT?"_
-
-## Sticky Decisions (v2.8.0)
-
-Some decisions act as **sticky latches** — once set, reversing them mid-session wastes all context built on top. For each decision, ask: _"If we change this after implementation starts, how much rework?"_
-
-| Rework | Classification                                    | Example                          |
-| ------ | ------------------------------------------------- | -------------------------------- |
-| >50%   | **Sticky** — revisit only via new `/design` cycle | DB choice, auth model, API style |
-| 10-50% | **Semi-sticky** — adjustable but flag the cost    | ORM, test framework              |
-| <10%   | **Flexible** — change freely                      | Variable names, UI copy          |
-
-Mark sticky decisions in the ADR: **STICKY — changing this requires re-running `/design`, not patching mid-build.**
-
-## Three Loops reminder
-
-Architecture decisions are **In-the-Loop** — human decides, not AI. Irreversible decisions (data migration, breaking API change) are always In-the-Loop regardless of perceived simplicity.
-
-## See also
-
-- [Source: `skills/design/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/design/SKILL.md)
-- [Habits Reference → H8](Habits-Reference#habit-8-find-your-voice-and-inspire-others)
-- [`docs/adr/` template](https://github.com/pitimon/8-habit-ai-dev/tree/main/guides/templates/adr-template.md)
+- [Workflow Overview](Workflow-Overview)
+- [Architecture](Architecture)
+- [Habits Reference](Habits-Reference#habit-8-find-your-voice)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/design/SKILL.md)

--- a/docs/wiki/Step-3-Breakdown.md
+++ b/docs/wiki/Step-3-Breakdown.md
@@ -1,59 +1,40 @@
 # Step 3 · Breakdown
 
-**Command**: `/breakdown [feature]` · **Habit**: H3 Put First Things First · **Previous**: [Step 2 · Design](Step-2-Design) · **Next**: [Step 4 · Build Brief](Step-4-Build-Brief)
+`/breakdown` decomposes approved work into small, ordered tasks that can be implemented and reviewed without hidden scope creep.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/breakdown [design or requirements]` |
+| Habit | H3 Put First Things First |
+| Previous | [Step 2 · Design](Step-2-Design) |
+| Next | [Step 4 · Build Brief](Step-4-Build-Brief) |
 
-Decompose a feature into atomic tasks — 1 task per focused unit of work. Prevents "one giant prompt that tries to do everything at once."
+## Use This When
 
-## When to use
+- The work spans multiple files or phases.
+- Tasks need dependencies, sequencing, or parallelization decisions.
+- You want to separate required work from optional ideas.
 
-- Any feature with >1 distinct concern
-- Any work that could be parallelized
-- Any time you're tempted to write a 500-word prompt
+## Skip When
 
-## When to skip
-
-- Single-file change with no dependencies
-- Bug fix with single touch point
-- Tasks already broken down in an external tracker
-
-## Process
-
-1. Read PRD and design decisions from previous steps
-2. Decompose — each task in 1 sentence, ≤5 files, explicit dependencies
-3. Prioritize by Covey's Quadrants: **Q2 > Q1 > Q3**, eliminate Q4 (gold-plating)
-4. Classify orchestration: `sequential`, `parallel-safe`, `parallel-worktree`
-5. Apply the **Lazy Parallelism Gate** — only parallelize when the cost of coordination is less than the wall-clock savings
+- The change is a single, obvious edit.
+- A reviewed task list already exists and is still current.
 
 ## Output
 
-```
-| # | Task | Files | Depends | Type | Q |
-```
+- Atomic tasks.
+- Dependencies and ordering.
+- Priority by importance, not novelty.
+- Explicit exclusions for out-of-scope work.
+- Suggested validation per task.
 
 ## Handoff
 
-- **Expects**: Architecture decisions from `/design`
-- **Produces for `/build-brief`**: Prioritized task list with dependencies and file paths
+`/build-brief` should receive one task at a time, with dependencies and expected validation clear.
 
-## Token-Efficient Parallel Design (v2.8.0)
+## See Also
 
-When designing `parallel-safe` or `parallel-worktree` tasks, optimize for prompt cache sharing:
-
-- **Maximize shared context** — group tasks that read the same files so their `/build-brief` prefixes overlap (~90% token savings)
-- **Minimize divergence point** — task-specific instructions go LAST in the agent prompt; everything before is the cached shared prefix
-- **Avoid redundant reads** — include shared files in the brief once rather than having each agent read them independently
-
-Most valuable for 3+ parallel tasks. For 2 tasks, the optimization overhead rarely pays off.
-
-## H3 Checkpoint
-
-> [!IMPORTANT]
-> _"Am I doing what's important, or what's interesting?"_
-
-## See also
-
-- [Source: `skills/breakdown/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/breakdown/SKILL.md)
-- [Orchestration patterns guide](https://github.com/pitimon/8-habit-ai-dev/blob/main/guides/orchestration-patterns.md)
-- [Habits Reference → H3](Habits-Reference#habit-3-put-first-things-first)
+- [Workflow Overview](Workflow-Overview)
+- [Step 4 · Build Brief](Step-4-Build-Brief)
+- [Habits Reference](Habits-Reference#habit-3-put-first-things-first)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/breakdown/SKILL.md)

--- a/docs/wiki/Step-4-Build-Brief.md
+++ b/docs/wiki/Step-4-Build-Brief.md
@@ -1,62 +1,40 @@
 # Step 4 · Build Brief
 
-**Command**: `/build-brief [task]` · **Habit**: H5 Seek First to Understand · **Previous**: [Step 3 · Breakdown](Step-3-Breakdown) · **Next**: [Step 5 · Review AI](Step-5-Review-AI)
+`/build-brief` prepares implementation by reading the existing code and turning one task into a concrete engineering brief.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/build-brief [task]` |
+| Habit | H5 Seek First to Understand |
+| Previous | [Step 3 · Breakdown](Step-3-Breakdown) |
+| Next | [Step 5 · Review AI](Step-5-Review-AI) |
 
-Produce a context-rich implementation brief **before** Claude writes any code. Forces the "read first, write second" discipline that separates expert engineers from vibe coders.
+## Use This When
 
-## When to use
+- A task is ready to implement.
+- The agent needs to inspect local code before writing.
+- Existing patterns, tests, or integration points matter.
 
-- Before every non-trivial task from the breakdown
-- When the file you're editing has >100 lines you haven't read
-- When the task touches an unfamiliar module
+## Skip When
 
-## When to skip
-
-- Single-file bugfix in code you wrote this session
-- Formatting / obvious mechanical changes
-
-## Process
-
-0. **Problem statement gate** (required) — state the problem in 1 sentence
-1. **Read existing code** — files the task will touch, plus their callers
-2. **Identify patterns** to follow (naming, error handling, testing style)
-3. **List edge cases** — null inputs, permissions, concurrency, failure modes
-4. **Produce the brief** — files to touch, functions to add/modify, test plan
+- The edit is trivial and the relevant context is already visible.
+- The task is documentation-only and no repo pattern discovery is needed.
 
 ## Output
 
-```
-## Brief: [Task]
-**Problem**: 1 sentence
-**Files to touch**: [list]
-**Existing patterns**: [observations]
-**Edge cases**: [list]
-**Test plan**: [what to verify]
-**Rollback**: [if applicable]
-```
+- Files likely to change.
+- Existing patterns to follow.
+- Edge cases and failure modes.
+- Test and validation commands.
+- Implementation constraints.
 
 ## Handoff
 
-- **Expects**: A task from `/breakdown`
-- **Produces for `/review-ai`**: Implemented code with a brief to review against
+`/review-ai` should receive the implemented diff plus the brief, so review can check whether the code matches the intended task.
 
-## Context Survival (v2.8.0)
+## See Also
 
-Claude Code uses a 4-layer context compression pipeline that progressively removes older content as the context window fills. Briefs written early in a session may be summarized or removed mid-implementation. To survive compression:
-
-- **Front-load critical info** — success criteria, constraints, and file paths at the TOP
-- **Keep briefs under ~4,000 tokens** — longer briefs are prime compression targets; split into per-phase briefs instead
-- **Stable content first, volatile last** — architecture decisions at the top, task specifics at the bottom (mirrors prompt cache stability)
-- **Self-contained references** — "see file X at line Y" instead of pasting large code blocks
-
-## H5 Checkpoint
-
-> [!IMPORTANT]
-> _"Have I read enough of the existing code to make good judgments here?"_
-
-## See also
-
-- [Source: `skills/build-brief/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/build-brief/SKILL.md)
-- [Habits Reference → H5](Habits-Reference#habit-5-seek-first-to-understand)
+- [Workflow Overview](Workflow-Overview)
+- [Step 5 · Review AI](Step-5-Review-AI)
+- [Habits Reference](Habits-Reference#habit-5-seek-first-to-understand)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/build-brief/SKILL.md)

--- a/docs/wiki/Step-5-Review-AI.md
+++ b/docs/wiki/Step-5-Review-AI.md
@@ -1,54 +1,45 @@
 # Step 5 · Review AI
 
-**Command**: `/review-ai [files or diff]` · **Habit**: H4 Think Win-Win · **Previous**: [Step 4 · Build Brief](Step-4-Build-Brief) · **Next**: [Step 6 · Deploy Guide](Step-6-Deploy-Guide)
+`/review-ai` audits AI-generated work before commit. It prioritizes correctness, security, scope control, and whether the implementation matches the brief.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/review-ai [diff or PR]` |
+| Habit | H4 Think Win-Win |
+| Previous | [Step 4 · Build Brief](Step-4-Build-Brief) |
+| Next | [Step 6 · Deploy Guide](Step-6-Deploy-Guide) |
 
-Audit AI-generated code **before** commit. This is the non-negotiable step — never skip it, no matter how small the change feels.
+## Use This When
 
-## When to use
+- AI generated code, docs, config, tests, or release material.
+- You are preparing a commit or PR.
+- You are reviewing another agent's output.
 
-- **Always** — after any code generation, before any commit
-- Before opening a PR
-- Before merging someone else's AI-generated contribution
+## Skip When
 
-## When to skip
-
-- **Never.** Every other step has legitimate skip cases. Review does not.
-
-## Process
-
-1. Get the diff: `git diff --name-only HEAD` and `git diff HEAD`
-2. Review against the brief from Step 4 — did the implementation match?
-3. Check for AI hallucinations: nonexistent APIs, wrong function signatures, fabricated imports
-4. Security pass: secrets, injection, auth bypass, unsafe deserialization, SSRF
-5. Error handling: null/empty inputs, permission denied, partial failures
-6. Scope creep: did Claude add features nobody asked for?
-7. Test coverage: are new code paths tested?
+Do not skip this step for AI-generated work. For tiny non-AI edits, use normal human judgment.
 
 ## Output
 
-Findings categorized **CRITICAL · HIGH · MEDIUM · LOW** with actionable fixes. Fix all CRITICAL and HIGH before committing.
+- Findings ordered by severity.
+- File and line references where possible.
+- Concrete fixes for each blocking issue.
+- Residual risks or test gaps.
+- Clear pass/fail review posture.
 
-## Complementary lenses
+## Complementary Checks
 
-Run these **in addition** to `/review-ai` for deeper coverage:
-
-- [`/security-check`](Skills-Reference#security-check) — focused OWASP Top 10
-- [`/cross-verify`](Skills-Reference#cross-verify) — 17-question 8-Habit checklist
-- [`/whole-person-check`](Skills-Reference#whole-person-check) — Body/Mind/Heart/Spirit balance
+- `/security-check` for auth, input, secrets, dependency, config, or infrastructure risk.
+- `/cross-verify` for broader 8-Habit readiness.
+- `/scrutinize` when intent and necessity should be challenged.
 
 ## Handoff
 
-- **Expects**: Implemented code + brief from `/build-brief`
-- **Produces for `/deploy-guide`**: Reviewed, fix-applied code ready to deploy
+`/deploy-guide` should receive reviewed changes, validation results, and known residual risks.
 
-## H4 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Does this interaction leave the next developer better informed and more capable?"_
-
-## See also
-
-- [Source: `skills/review-ai/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/review-ai/SKILL.md)
-- [Habits Reference → H4](Habits-Reference#habit-4-think-win-win)
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference#review-ai)
+- [Habits Reference](Habits-Reference#habit-4-think-win-win)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/review-ai/SKILL.md)

--- a/docs/wiki/Step-6-Deploy-Guide.md
+++ b/docs/wiki/Step-6-Deploy-Guide.md
@@ -1,66 +1,44 @@
 # Step 6 · Deploy Guide
 
-**Command**: `/deploy-guide [staging|production]` · **Habit**: H1 Be Proactive · **Previous**: [Step 5 · Review AI](Step-5-Review-AI) · **Next**: [Step 7 · Monitor Setup](Step-7-Monitor-Setup)
+`/deploy-guide` produces a staging-first deployment plan with verification, rollback, and operational reconciliation before production is treated as complete.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/deploy-guide [staging|production]` |
+| Habit | H1 Be Proactive |
+| Previous | [Step 5 · Review AI](Step-5-Review-AI) |
+| Next | [Step 7 · Monitor Setup](Step-7-Monitor-Setup) |
 
-Produce a staging-first deploy plan with a **rollback ready to paste**. Prevents the class of incidents caused by "let's just push it, it looks fine."
+## Use This When
 
-## When to use
+- Production or shared infrastructure may change.
+- A database, dependency, environment, alerting, or config change has runtime impact.
+- You are planning a provider-managed canary or capacity change.
 
-- Any deploy touching production
-- Any database migration
-- Any config change to shared infrastructure
-- Any production canary or provider-managed capacity change, such as nodegroup/ASG scale-down
+## Skip When
 
-## When to skip
-
-- Never for production. Local-only changes do not need this step.
-
-## Process
-
-1. Read existing deploy scripts, CI/CD configs, `docker-compose.yml`, `Makefile`
-2. Produce **staging steps** first, with exact commands
-3. Define staging **verification** — health check, smoke test, feature verify
-4. Produce **production steps** (only after staging QA passes)
-5. Produce **rollback procedure** — copy-pasteable commands
-6. For provider-managed canaries, add reconciliation gates: planned target vs actual provider-selected target, desired/min/max alignment, schedulable capacity, and no unintended `SchedulingDisabled` nodes
-7. Produce **post-deploy verification**
+- The change is local-only and cannot affect a deployed runtime.
+- You are only editing documentation with no consumer behavior change.
 
 ## Output
 
-A deploy plan document containing:
+- Deploy type classifier.
+- Staging plan and staging verification.
+- Production plan gated on staging evidence.
+- Rollback commands ready to paste.
+- Post-deploy verification.
+- For provider-managed canaries: planned target, actual provider-selected target, desired/min/max capacity, scheduling state, readiness, and mitigation path.
 
-- **Deploy: [version/feature]** title
-- **Staging** — numbered command list
-- **Staging QA** — verification checklist (health, feature, smoke test)
-- **Production** — numbered command list (only after staging QA passes)
-- **Rollback (ready to paste)** — copy-pasteable commands inside a fenced block
-- **Canary reconciliation** — planned target, actual provider target, scale/update status, scheduling state, and mitigation path
-- **Post-deploy verification** — checklist
-
-## Rules
-
-- **Never** combine build + deploy in one step for production
-- **Never** skip staging
-- **Never** deploy on a Friday afternoon without explicit reason
-- **Never** call a provider scale-down complete until Kubernetes scheduling state is reconciled
+> [!WARNING]
+> Do not call a provider-managed scale or canary complete only because the provider accepted the change. Reconcile the intended target and the actual runtime state.
 
 ## Handoff
 
-- **Expects**: Reviewed, passing code from `/review-ai`
-- **Produces for `/monitor-setup`**: A deployed service ready to observe
+`/monitor-setup` should receive deployed state, validation evidence, rollback notes, and any monitoring gaps discovered during rollout.
 
-## H1 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Am I preventing future incidents, or reacting to current ones?"_
-
-## See also
-
-- [Source: `skills/deploy-guide/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/deploy-guide/SKILL.md)
-- [Habits Reference → H1](Habits-Reference#habit-1-be-proactive)
-
-```
-
-```
+- [Workflow Overview](Workflow-Overview)
+- [Step 7 · Monitor Setup](Step-7-Monitor-Setup)
+- [Skills Reference](Skills-Reference#deploy-guide)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/deploy-guide/SKILL.md)

--- a/docs/wiki/Step-7-Monitor-Setup.md
+++ b/docs/wiki/Step-7-Monitor-Setup.md
@@ -1,53 +1,40 @@
 # Step 7 · Monitor Setup
 
-**Command**: `/monitor-setup [project]` · **Habit**: H7 Sharpen the Saw · **Previous**: [Step 6 · Deploy Guide](Step-6-Deploy-Guide)
+`/monitor-setup` closes the loop after deploy by making the new behavior observable and supportable.
 
-## Purpose
+| Field | Value |
+| --- | --- |
+| Command | `/monitor-setup [project or feature]` |
+| Habit | H7 Sharpen the Saw |
+| Previous | [Step 6 · Deploy Guide](Step-6-Deploy-Guide) |
+| Next | [Step 0 · Research](Step-0-Research) for the next cycle |
 
-Set up error tracking, alerting, and health checks so you **learn from production**. The final step closes the loop between deploy and the next planning cycle.
+## Use This When
 
-## When to use
+- A service, feature, integration, or operational workflow has been deployed.
+- An incident revealed missing logs, metrics, alerts, or runbook detail.
+- You need evidence that production is healthy after change.
 
-- After a new service is deployed
-- When adding a new critical feature to an existing service
-- When an incident reveals a monitoring gap
+## Skip When
 
-## When to skip
-
-- Internal tools with zero users (use judgment — often you still want basic health)
-- Ephemeral preview deploys
-
-## Process
-
-1. Read existing monitoring — don't duplicate what's already wired up
-2. Define the **4 golden signals**: latency, traffic, errors, saturation
-3. Add or verify:
-   - `/health` endpoint (liveness + readiness)
-   - Structured logging with correlation IDs
-   - Error tracking (Sentry, Rollbar, etc.)
-   - Metrics export (Prometheus, OpenTelemetry)
-   - Alerts on SLO breach
-4. Document the runbook: "If X alerts fire, do Y"
+- The change cannot affect runtime behavior.
+- Existing monitoring already covers the new behavior and this has been verified.
 
 ## Output
 
-- Monitoring config (code + infra)
-- Alert rules
-- Runbook entry for this feature
-- Dashboard link
+- Health checks or readiness checks to add or verify.
+- Logging, metrics, and tracing gaps.
+- Alerting thresholds or ownership notes.
+- Dashboard and runbook updates.
+- Follow-up items for the next planning cycle.
 
 ## Handoff
 
-- **Expects**: A deployed service from `/deploy-guide`
-- **Produces for the next cycle**: Production feedback that informs the next `/research` or `/requirements`
+The next `/research` or `/requirements` cycle should receive real production feedback rather than assumptions.
 
-## H7 Checkpoint
+## See Also
 
-> [!IMPORTANT]
-> _"Am I investing in future capability, or just grinding out output?"_
-
-## See also
-
-- [Source: `skills/monitor-setup/SKILL.md`](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/monitor-setup/SKILL.md)
-- [Habits Reference → H7](Habits-Reference#habit-7-sharpen-the-saw)
-- Next cycle: [Step 0 · Research](Step-0-Research)
+- [Workflow Overview](Workflow-Overview)
+- [Step 6 · Deploy Guide](Step-6-Deploy-Guide)
+- [Habits Reference](Habits-Reference#habit-7-sharpen-the-saw)
+- [Source skill](https://github.com/pitimon/8-habit-ai-dev/blob/main/skills/monitor-setup/SKILL.md)

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,84 +1,99 @@
 # Troubleshooting
 
-Common issues and fixes. If your problem is not listed, [open an issue](https://github.com/pitimon/8-habit-ai-dev/issues).
+Use this page when installation, skill routing, wiki sync, or validation does not behave as expected.
 
 ## Installation
 
-### The session-start banner does not appear
+### Claude Code Banner Does Not Appear
 
-**Symptom**: No `## 8-Habit AI Dev Active` block at the top of the conversation.
+Checks:
 
-**Checks**:
+1. Confirm the plugin is installed: `claude plugin list`.
+2. Start a new Claude Code session; hooks run at session start.
+3. Confirm the plugin package includes `hooks/session-start.sh`.
+4. If installed from a local checkout, confirm the hook is executable.
 
-1. Confirm installation: `claude plugin list` should show `8-habit-ai-dev@pitimon-8-habit-ai-dev`
-2. Restart Claude Code — the session hook runs at session start, not mid-session
-3. Check `hooks/hooks.json` is loaded — if you cloned the plugin manually, ensure the `hooks/` directory is intact
-4. Verify `hooks/session-start.sh` is executable: `chmod +x hooks/session-start.sh`
+Codex users should not expect this banner because Codex does not run Claude hooks.
 
-### `plugin install` fails with "marketplace not found"
+### Marketplace Not Found
 
-Run `claude plugin marketplace add pitimon/8-habit-ai-dev` **first**, then `claude plugin install ...`. See [Installation](Installation).
+Add the marketplace before installing:
 
-### Skills do not appear when I type `/`
+```bash
+claude plugin marketplace add pitimon/8-habit-ai-dev
+```
 
-- Restart Claude Code after installation
-- Confirm the plugin is enabled: `claude plugin list`
-- The skills autoload on first invocation — try typing `/workflow` directly
+For Codex:
+
+```bash
+codex plugin marketplace add pitimon/8-habit-ai-dev
+```
+
+### Skills Do Not Appear
+
+Checks:
+
+1. Verify plugin installation with your runtime's plugin list command.
+2. Start a fresh session.
+3. Invoke a known skill directly, such as `/workflow` or `/requirements`.
+4. For Codex, confirm `AGENTS.md` and `skills/RESOLVER.md` are available to the runtime.
 
 ## Workflow
 
-### `/review-ai` says "no diff to review"
+### `/review-ai` Reports No Diff
 
-You have no staged or unstaged changes. Run it **after** writing code, not before.
+There are no local changes for the skill to inspect. Run it after generating or editing code, or pass the relevant diff or PR context.
 
-### `/design` only gives me one option
+### `/design` Gives Only One Option
 
-The skill requires **at least 2 options with trade-offs**. If Claude produced only one, re-prompt: _"Show me at least 2 alternatives with pros and cons for each decision."_ See [Step 2 · Design](Step-2-Design).
+Ask for alternatives explicitly: "Show at least two viable options with trade-offs and a recommendation." Architecture decisions should not be hidden inside a single path.
 
-### `/breakdown` produces tasks that touch >5 files
+### `/breakdown` Produces Large Tasks
 
-Tasks are too big. Re-prompt: _"Break task N down further — each task must touch at most 5 files."_
+Ask it to split the task until each item is independently reviewable and has a clear validation step.
 
-### I keep skipping `/review-ai`
+## Operations
 
-Add a git pre-commit hook or CI gate that blocks commits without a recorded review. The rule is **never skip review**, no matter how small.
+### A Finding Recovered By Itself
 
-## Cross-verify
+Use `/operational-state` before closing it. Recovered is not always fixed; the skill helps distinguish self-resolved, false positive, accepted known issue, handoff, and active incident states.
 
-### `/cross-verify` fails with "no plan to verify"
+### A Config Hotfix Has No Spec Bundle
 
-`/cross-verify` expects an implementation plan or a draft commit. Run it **after** `/breakdown` and **before** committing, or pass the file path explicitly.
+Use `/consistency-check` incident/config mode. It checks symptom, evidence, root cause, actual fix, deploy path, and live verification without requiring persisted PRD/design/task artifacts.
 
-### The 17-question checklist feels like overkill for a 3-line fix
+### A Provider Canary Changed A Different Target
 
-It is. Skip `/cross-verify` for trivial fixes; use it for anything touching >3 files or affecting architecture.
+Use `/deploy-guide` reconciliation gates. Compare planned target, provider-selected target, desired/min/max capacity, readiness, scheduling state, and follow-up action before calling the rollout complete.
 
 ## Wiki
 
-### My wiki edit disappeared
+### Wiki Edit Disappeared
 
-You edited via the GitHub Wiki web UI. **The wiki is a build artifact** — source lives in `docs/wiki/` and web edits are overwritten on the next sync. See [Contributing to Wiki](Contributing-to-Wiki) for the correct workflow.
+The wiki is generated from `docs/wiki/`. Edit the repository file and open a PR instead of editing the GitHub Wiki web UI directly.
 
-### Wiki sync Action failed with "wiki not found"
+### Wiki Sync Failed
 
-Enable the wiki on the repository first: **Settings → Features → Wikis** → check. Then seed a stub `Home` page via the web UI once. After that, the Action takes over.
+Confirm the repository wiki is enabled and the sync workflow has permission to push to the wiki repository. Then inspect the failing action log.
 
-### `lychee` link-check fails on a new PR
+### Link Check Failed
 
-A link in `docs/wiki/**/*.md` is broken. Check the Action log for the specific URL. Fix the link or add it to a `lychee.toml` allowlist if it is a known flaky external URL.
+Check the link-check workflow output. Fix broken external URLs or update the allowlist only for known flaky URLs.
 
-## Validation scripts
+## Validation
 
-### `tests/validate-structure.sh` fails after adding a new skill
+Run local validation from the repository root:
 
-The script expects every skill to have: `SKILL.md` with valid frontmatter, matching directory name, and allowed `allowed-tools` values. Run the script output — it points at the exact file and line.
+```bash
+git diff --check
+bash tests/validate-structure.sh
+bash tests/validate-content.sh
+```
 
-### `tests/validate-content.sh` fails on fitness functions
+If a validator fails, read the first failure carefully; later failures often cascade.
 
-The three fitness functions enforce limits on skill complexity, content depth, and cross-reference integrity. See [ADR-003](https://github.com/pitimon/8-habit-ai-dev/blob/main/docs/adr/ADR-003-content-validation.md) for details and thresholds.
+## See Also
 
-## Still stuck?
-
-- **FAQ**: [FAQ](FAQ)
-- **Open an issue**: [github.com/pitimon/8-habit-ai-dev/issues](https://github.com/pitimon/8-habit-ai-dev/issues)
-- **Source**: [github.com/pitimon/8-habit-ai-dev](https://github.com/pitimon/8-habit-ai-dev)
+- [Installation](Installation)
+- [FAQ](FAQ)
+- [Contributing to Wiki](Contributing-to-Wiki)

--- a/docs/wiki/Vibe-Coding-vs-Structured.md
+++ b/docs/wiki/Vibe-Coding-vs-Structured.md
@@ -1,62 +1,39 @@
-# Vibe Coding vs Structured Development
+# Vibe Coding Vs Structured Development
 
-> _"ทำเสร็จ ≠ ทำดี"_ — _Done_ is not _Done well_.
+Vibe coding is ad hoc AI prompting without clear requirements, design ownership, review, deployment planning, or feedback loops. Structured development keeps those responsibilities visible.
 
-**Vibe coding** is the default failure mode of AI-assisted development: ad-hoc prompts, no requirements, no review, no rollback plan. It feels fast. It generates tech debt faster than any human ever could.
+> [!NOTE]
+> "ทำเสร็จ ≠ ทำดี" means "done is not done well." The plugin is built around that distinction.
 
-**Structured development** is the 7-step workflow in this plugin. It feels slightly slower at the start and dramatically faster by week 3.
+## Comparison
 
-## Side-by-side
+| Area | Vibe coding | Structured development |
+| --- | --- | --- |
+| Problem definition | Prompt first | `/requirements` first |
+| Unknown domain | Guess | `/research` |
+| Architecture | Model chooses implicitly | `/design`, human decides |
+| Tasks | One large request | `/breakdown` |
+| Context | Edits before reading | `/build-brief` |
+| Review | "Looks good" | `/review-ai` and focused checks |
+| Deployment | Push and hope | `/deploy-guide` with rollback |
+| Operations | Close on appearance | `/operational-state` and evidence |
+| Learning | Lost after task | `/reflect` and `/post-mortem` |
 
-| Phase                  | Vibe Coding                    | Structured (this plugin)                           |
-| ---------------------- | ------------------------------ | -------------------------------------------------- |
-| **Problem**            | "Hey Claude, build me X"       | `/research` → `/requirements`                      |
-| **Architecture**       | Claude picks whatever's trendy | `/design` — human decides from options             |
-| **Task decomposition** | One giant prompt               | `/breakdown` — atomic tasks, Q2 prioritized        |
-| **Before coding**      | Straight to code generation    | `/build-brief` — read existing code first          |
-| **Review**             | "Looks good, commit it"        | `/review-ai` + `/security-check` + `/cross-verify` |
-| **Deploy**             | Push to prod directly          | `/deploy-guide` — staging first, rollback planned, provider state reconciled |
-| **After deploy**       | Forget about it                | `/monitor-setup` — observe and learn               |
-| **Reflection**         | None                           | `/reflect` — capture lessons                       |
+## Cost
 
-## What vibe coding costs you
+Structured development adds a small amount of up-front process. It pays for itself when review, deployment, incident handling, or future maintenance would otherwise have to reconstruct intent.
 
-> [!CAUTION]
-> These are not hypothetical. Every item below has been observed in production AI-generated codebases.
+## When Lightweight Is Fine
 
-- **Hallucinated APIs** shipped to production
-- **Missing error handling** that surfaces during the first outage
-- **Scope creep** — features nobody asked for
-- **Architecture drift** — every feature picks its own pattern
-- **No rollback plan** — 2 a.m. incidents become catastrophes
-- **No shared understanding** — the next developer (or future-you) has no idea why
-- **Invisible tech debt** — accumulating silently until the codebase is unmaintainable
+- Throwaway scripts.
+- Local experiments.
+- Formatting-only changes.
+- Edits with no behavioral or operational impact.
 
-## What structured costs you
+Even then, use normal review judgment before committing.
 
-- **~10 extra minutes** on small features, ~1 hour on larger ones
-- **Discipline** — you have to actually run the steps
-- **Human judgment** — you cannot delegate architecture
+## See Also
 
-## Break-even
-
-For a small feature: structured is break-even by the time of the first bug report. For a medium feature: by the first code review. For a large feature: before the first commit.
-
-## The deeper point
-
-Vibe coding optimizes for **production output** — lines of code shipped today. Structured development optimizes for **production capability** — the ability to keep shipping reliably for months. Covey calls this **P/PC balance** (Habit 7, Sharpen the Saw). Ignore PC and the P eventually collapses.
-
-## When vibe coding is actually fine
-
-- Throwaway scripts with lifespan < 1 day
-- Personal experiments you will never deploy
-- Learning exercises where the output is irrelevant
-
-Everything else should be structured.
-
-## See also
-
-- **[Workflow Overview](Workflow-Overview)**
-- **[Getting Started](Getting-Started)**
-- **[Habits Reference → H7 Sharpen the Saw](Habits-Reference#habit-7-sharpen-the-saw)**
-- **[FAQ](FAQ)**
+- [Getting Started](Getting-Started)
+- [Workflow Overview](Workflow-Overview)
+- [Skills Reference](Skills-Reference)

--- a/docs/wiki/Workflow-Overview.md
+++ b/docs/wiki/Workflow-Overview.md
@@ -1,99 +1,63 @@
-# 7-Step Workflow Overview
+# Workflow Overview
 
-The antidote to vibe coding. Each step is a Claude Code skill, maps to one of Covey's 8 Habits, and has an explicit handoff contract with the next step.
+The workflow is a sequence of markdown skills that keeps AI-assisted work reviewable. Each step has a purpose, a handoff, and a skip rule.
 
-## The 7 Steps (+ Step 0)
+## Steps
 
-```
-Legend:  [O] optional   [H] human checkpoint   [!] NEVER SKIP
+| Step | Skill | Habit | Output |
+| --- | --- | --- | --- |
+| 0 | [`/research`](Step-0-Research) | H5 | Research brief |
+| 1 | [`/requirements`](Step-1-Requirements) | H2 | PRD-style scope and success criteria |
+| 2 | [`/design`](Step-2-Design) | H8 | Architecture options and decision |
+| 3 | [`/breakdown`](Step-3-Breakdown) | H3 | Atomic task list |
+| 4 | [`/build-brief`](Step-4-Build-Brief) | H5 | Implementation brief |
+| 5 | [`/review-ai`](Step-5-Review-AI) | H4 | Review findings before commit |
+| 6 | [`/deploy-guide`](Step-6-Deploy-Guide) | H1 | Deploy, rollback, and verification plan |
+| 7 | [`/monitor-setup`](Step-7-Monitor-Setup) | H7 | Observability and runbook updates |
 
-   [O] 0 · /research        H5 Understand    investigate before specifying
-        │
-        ▼
-   [H] 1 · /requirements    H2 End in Mind   define what, why, who
-        │
-        ▼
-   [H] 2 · /design          H8 Voice         architecture (human-led)
-        │
-        ▼
-   [O] 3 · /breakdown       H3 First Things  atomic tasks, no scope creep
-        │
-        ▼
-   [O] 4 · /build-brief     H5 Understand    context before coding
-        │
-        ▼
-   [!] 5 · /review-ai       H4 Win-Win       audit before commit
-        │
-        ▼
-   [H] 6 · /deploy-guide    H1 Proactive     staging, rollback, reconcile
-        │
-        ▼
-   [O] 7 · /monitor-setup   H7 Sharpen Saw   observe after deploy
+```text
+/research
+  -> /requirements
+  -> /design
+  -> /breakdown
+  -> /build-brief
+  -> /review-ai
+  -> /deploy-guide
+  -> /monitor-setup
 ```
 
-| Step | Skill                                    | Habit                 | Output                        | Human checkpoint? |
-| ---- | ---------------------------------------- | --------------------- | ----------------------------- | ----------------- |
-| 0    | [`/research`](Step-0-Research)           | H5 Understand First   | Research brief                | Optional          |
-| 1    | [`/requirements`](Step-1-Requirements)   | H2 Begin with End     | PRD summary                   | Yes               |
-| 2    | [`/design`](Step-2-Design)               | H8 Find Your Voice    | Architecture decisions (ADR)  | **Required**      |
-| 3    | [`/breakdown`](Step-3-Breakdown)         | H3 First Things First | Atomic task list              | Optional          |
-| 4    | [`/build-brief`](Step-4-Build-Brief)     | H5 Understand First   | Implementation brief per task | Optional          |
-| 5    | [`/review-ai`](Step-5-Review-AI)         | H4 Win-Win            | Code review findings          | **Required**      |
-| 6    | [`/deploy-guide`](Step-6-Deploy-Guide)   | H1 Be Proactive       | Deploy + rollback + reconciliation | **Required**      |
-| 7    | [`/monitor-setup`](Step-7-Monitor-Setup) | H7 Sharpen the Saw    | Observability config          | Optional          |
+## Use This When
 
-## Handoff Contracts
+- The change is larger than a trivial local edit.
+- The domain is unclear.
+- Architecture, data, security, or deployment behavior may change.
+- A production or operational finding needs controlled handling.
 
-Each skill declares `prev-skill` and `next-skill` in its frontmatter and explicitly documents:
+## Practical Skip Guide
 
-- **Expects from predecessor**: what input the skill needs
-- **Produces for successor**: what output the next step will consume
-
-This prevents context loss between steps and makes the workflow composable.
-
-> [!NOTE]
-> The handoff DAG is machine-verified by `tests/test-skill-graph.sh` — no cycles, no dangling references, symmetric edges.
-
-## When to Skip
-
-| Change type                              | Steps to run           |
-| ---------------------------------------- | ---------------------- |
-| Single-line bug fix (obvious root cause) | 5                      |
-| Formatting / linting                     | 5                      |
-| Dependency version bump                  | 5, 6                   |
-| New feature (small, <3 files)            | 1, 3, 4, 5, 6          |
-| New feature (medium)                     | 1, 2, 3, 4, 5, 6, 7    |
-| New feature (complex / unclear domain)   | 0, 1, 2, 3, 4, 5, 6, 7 |
-| Refactor (no behavior change)            | 2, 3, 4, 5             |
-| Architecture change                      | 0, 1, 2, 3, 4, 5, 6, 7 |
+| Change type | Typical path |
+| --- | --- |
+| Formatting only | `/review-ai` |
+| Obvious one-line bug fix | `/review-ai` |
+| Dependency or config change | `/review-ai` -> `/deploy-guide` |
+| Small feature | `/requirements` -> `/breakdown` -> `/build-brief` -> `/review-ai` |
+| Medium feature | `/requirements` -> `/design` -> `/breakdown` -> `/build-brief` -> `/review-ai` -> `/deploy-guide` |
+| Unclear domain or architecture change | Full workflow |
+| Production incident or config hotfix | `/diagnose` or `/operational-state`, then `/consistency-check`, `/review-ai`, `/deploy-guide` as applicable |
 
 > [!WARNING]
-> **Never skip `/review-ai` (Step 5).** Every other step has legitimate skip cases; review does not.
+> Do not skip `/review-ai` for AI-generated work. Other steps have legitimate skip cases; review is the baseline.
 
-## Beyond the Workflow
+## Operational Extensions
 
-These skills complement the pipeline and can run at any point:
+The workflow now includes explicit operational support outside the linear steps:
 
-**Assessment:**
+- `/operational-state` classifies findings before mutation or closure.
+- `/consistency-check` can check incident/config hotfix claims against evidence.
+- `/deploy-guide` includes reconciliation gates for provider-managed canaries and capacity changes.
 
-- [`/cross-verify`](Skills-Reference#cross-verify) — 17-question 8-Habit checklist
-- [`/whole-person-check`](Skills-Reference#whole-person-check) — Body/Mind/Heart/Spirit balance
-- [`/security-check`](Skills-Reference#security-check) — OWASP Top 10 focused review
-- [`/reflect`](Skills-Reference#reflect) — post-task retrospective with lesson persistence
-- [`/workflow`](Skills-Reference#workflow) — interactive guided walkthrough
+## See Also
 
-**Meta & Onboarding:**
-
-- [`/using-8-habits`](Skills-Reference#using-8-habits) — onboarding decision tree (no-arg) **or** smart-routing mode when invoked with intent (e.g. `/using-8-habits "I need to verify what we built last week"` returns ≤3 ranked skills with reasoning)
-- [`/calibrate`](Skills-Reference#calibrate) — maturity self-assessment, verbosity adaptation
-
-**Compliance & Audit:**
-
-- [`/eu-ai-act-check`](Skills-Reference#eu-ai-act-check) — EU AI Act 9-obligation checklist
-- [`/ai-dev-log`](Skills-Reference#ai-dev-log) — AI development log from git history
-
-## See also
-
-- **[Skills Catalog](Skills-Reference)** — all 24 skills with when-to-use guidance
-- **[Habits Reference](Habits-Reference)**
-- **[Vibe Coding vs Structured](Vibe-Coding-vs-Structured)**
+- [Skills Reference](Skills-Reference)
+- [Getting Started](Getting-Started)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,5 +1,5 @@
 ---
 
-📖 **Source of truth**: This wiki is generated from [`docs/wiki/`](https://github.com/pitimon/8-habit-ai-dev/tree/main/docs/wiki) in the main repository. **Edits made via the GitHub Wiki web UI will be overwritten** on the next sync. To change a page, open a PR against `docs/wiki/<page>.md`.
+**Source of truth**: this wiki is generated from [`docs/wiki/`](https://github.com/pitimon/8-habit-ai-dev/tree/main/docs/wiki). Edits made through the GitHub Wiki web UI may be overwritten by the next sync. To change a page, open a PR against the repository source file.
 
-🔗 [Repository](https://github.com/pitimon/8-habit-ai-dev) · [Issues](https://github.com/pitimon/8-habit-ai-dev/issues) · [README](https://github.com/pitimon/8-habit-ai-dev#readme) · [License (MIT)](https://github.com/pitimon/8-habit-ai-dev/blob/main/LICENSE)
+[Repository](https://github.com/pitimon/8-habit-ai-dev) · [Issues](https://github.com/pitimon/8-habit-ai-dev/issues) · [README](https://github.com/pitimon/8-habit-ai-dev#readme) · [License](https://github.com/pitimon/8-habit-ai-dev/blob/main/LICENSE)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,14 +1,15 @@
 ### 8-Habit AI Dev
 
-_Structured AI development_
+_Workflow discipline for AI-assisted development_
 
-**Get Started**
+**Start**
 
 - [Home](Home)
 - [Installation](Installation)
 - [Getting Started](Getting-Started)
+- [Troubleshooting](Troubleshooting)
 
-**7-Step Workflow**
+**Workflow**
 
 - [Overview](Workflow-Overview)
 - [0 · Research](Step-0-Research)
@@ -20,21 +21,21 @@ _Structured AI development_
 - [6 · Deploy Guide](Step-6-Deploy-Guide)
 - [7 · Monitor Setup](Step-7-Monitor-Setup)
 
-**Concepts**
+**Operations**
 
-- [Architecture](Architecture)
-- [Maturity Model](Maturity-Model)
-- [8 Habits](Habits-Reference)
-- [Vibe Coding vs Structured](Vibe-Coding-vs-Structured)
-- [Harness Engineering](Harness-Engineering)
+- [Skills Reference](Skills-Reference)
+- [Troubleshooting](Troubleshooting)
+- [Changelog](Changelog)
 
 **Reference**
 
-- [Skills Catalog](Skills-Reference)
-- [FAQ](FAQ)
-- [Troubleshooting](Troubleshooting)
+- [Habits Reference](Habits-Reference)
+- [Maturity Model](Maturity-Model)
+- [Architecture](Architecture)
+- [Vibe Coding vs Structured](Vibe-Coding-vs-Structured)
+- [Harness Engineering](Harness-Engineering)
 
 **Project**
 
-- [Changelog](Changelog)
+- [FAQ](FAQ)
 - [Contributing to Wiki](Contributing-to-Wiki)


### PR DESCRIPTION
## Summary

- rewrites all `docs/wiki/` pages with a consistent professional template family
- keeps the plugin boundary precise: portable markdown guidance, no runtime enforcement or compliance certification claim
- keeps current `v2.20.2` operational updates visible: `/operational-state`, incident/config consistency mode, and provider-managed deploy reconciliation gates

## Scope

- docs-only wiki rewrite
- no plugin behavior change
- no version bump
- existing wiki filenames preserved

## Validation

- `git diff --check -- docs/wiki`
- `bash tests/validate-structure.sh`
- `bash tests/validate-content.sh`
- targeted wiki-relative link scan

`lychee` was not installed locally, so the external URL check is left to the existing GitHub Actions wiki link-check workflow.

## Why This Matters

Clearer public docs make onboarding easier, keep Claude/Codex runtime boundaries honest, and reduce the chance that release documentation overclaims what a markdown guidance plugin provides.