### PR TITLE
docs: document plugin maintenance commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
 
 Two commands to install per platform. Claude Code also loads a session reminder; both platforms make 24 skills available. For exact runtime boundaries, see the [runtime compatibility matrix](docs/compatibility-matrix.md) and [Codex integration guide](docs/codex-integration.md): Codex gets native packaging and the same markdown skills, not Claude hook execution or runtime enforcement.
 
+### Keeping the plugin updated
+
+This plugin is maintained through regular releases. Check the [GitHub Releases](https://github.com/pitimon/8-habit-ai-dev/releases), the [wiki changelog](https://github.com/pitimon/8-habit-ai-dev/wiki/Changelog), or the "What's New" sections below to see recent changes.
+
+**Claude Code:**
+
+```bash
+claude plugin update 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
+
+Restart Claude Code after updating so hook and skill changes are loaded.
+
+**Codex:**
+
+```bash
+codex plugin marketplace upgrade pitimon-8-habit-ai-dev
+codex plugin list
+```
+
+Codex installs from a marketplace snapshot. Refresh the marketplace snapshot first, then verify the installed plugin is still present. If a local cache ever looks stale, remove and add the plugin again:
+
+```bash
+codex plugin remove 8-habit-ai-dev@pitimon-8-habit-ai-dev
+codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
+
 ---
 
 ## The 7-Step Workflow

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -15,12 +15,28 @@ Verify with:
 codex plugin list
 ```
 
+## Update
+
+Codex installs plugins from configured marketplace snapshots. Refresh the Git marketplace snapshot before checking for current plugin metadata:
+
+```bash
+codex plugin marketplace upgrade pitimon-8-habit-ai-dev
+codex plugin list
+```
+
+If a local cache appears stale, reinstall from the refreshed snapshot:
+
+```bash
+codex plugin remove 8-habit-ai-dev@pitimon-8-habit-ai-dev
+codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
+
 ## Codex Runtime Contract
 
 Codex integration promises:
 
 - Codex can install the plugin through the native marketplace flow.
-- Codex can load the same 23 markdown skills from `skills/`.
+- Codex can load the same 24 markdown skills from `skills/`.
 - Codex should start from `AGENTS.md`, then use `skills/RESOLVER.md` to select a skill.
 - Codex should treat `CLAUDE.md` as architecture reference, not as automatically loaded runtime state.
 - Codex should treat Obsidian or other memory systems as external curated memory, not as the plugin's internal state.

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -47,6 +47,20 @@ codex plugin list
 
 Codex should use `AGENTS.md` as the operating entrypoint, then route user intent through `skills/RESOLVER.md` to the relevant `skills/<name>/SKILL.md`.
 
+Update the configured Git marketplace snapshot:
+
+```bash
+codex plugin marketplace upgrade pitimon-8-habit-ai-dev
+codex plugin list
+```
+
+If the local plugin cache appears stale, remove and add the plugin again:
+
+```bash
+codex plugin remove 8-habit-ai-dev@pitimon-8-habit-ai-dev
+codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
+```
+
 ## What Installs
 
 | Surface | Claude Code | Codex |


### PR DESCRIPTION
## Summary

- adds README guidance for keeping the plugin updated in Claude Code and Codex
- documents Claude Code `plugin update` and Codex marketplace snapshot refresh flow
- adds Codex reinstall fallback for stale local caches
- syncs the same maintenance guidance into wiki Installation and Codex integration docs
- corrects Codex integration wording from 23 to 24 markdown skills

## Validation

- `codex plugin marketplace list` to confirm configured marketplace name
- `git diff --check`
- targeted wiki-relative link and code-fence scan
- `bash tests/validate-structure.sh`
- `bash tests/validate-content.sh`

Note: `validate-content.sh` still reports the existing non-blocking warning for `research` Definition of Done length; no failures.

## Scope

Docs-only. No plugin behavior change, no package metadata change, no version bump.