### PR TITLE
fix: guard README version badge freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Skills](https://img.shields.io/badge/Skills-24-blue)]()
 [![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-ready-green)]()
 [![Habits](https://img.shields.io/badge/Habits-8-orange)]()
-[![Version](https://img.shields.io/badge/Version-2.20.2-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.20.2)
+[![Version](https://img.shields.io/badge/Version-2.21.0-brightgreen)](https://github.com/pitimon/8-habit-ai-dev/releases/tag/v2.21.0)
 [![Wiki](https://img.shields.io/badge/docs-Wiki-informational)](https://github.com/pitimon/8-habit-ai-dev/wiki)
 
 📖 **Full documentation**: **[Wiki](https://github.com/pitimon/8-habit-ai-dev/wiki)** — deep-dive guides per step, [FAQ](https://github.com/pitimon/8-habit-ai-dev/wiki/FAQ), [Troubleshooting](https://github.com/pitimon/8-habit-ai-dev/wiki/Troubleshooting), and the [8 Habits Reference](https://github.com/pitimon/8-habit-ai-dev/wiki/Habits-Reference).

--- a/tests/validate-content.sh
+++ b/tests/validate-content.sh
@@ -769,6 +769,15 @@ else
   else
     fail "README.md missing '## What's New in v${current_version}' section header — sub-check A passed on badge URL but the user-facing upgrade-discovery surface is stale. Add the section between the existing 'Zero dependencies' block and the previous '## What's New in v...' entry. See issue #157."
   fi
+
+  # H. README.md version badge must match current version. v2.21.0 initially updated the
+  # "What's New" section and footer but left the top badge pointing at v2.20.2.
+  if grep -q "badge/Version-${current_version}-brightgreen" README.md &&
+     grep -q "releases/tag/v${current_version}" README.md; then
+    pass "README.md version badge matches v${current_version}"
+  else
+    fail "README.md version badge stale — bump both badge text and release link to v${current_version}."
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Post-merge release drift fix for v2.21.0. PR #271 updated the README v2.21.0 section and footer, but the top README version badge still pointed at v2.20.2.

- update README version badge text and release link to v2.21.0
- add Check 19 sub-check H to assert README badge text + release URL match the current plugin version

## Validation

- `bash tests/validate-content.sh` — PASS (316 PASS, 0 FAIL, 1 WARN, 0 fitness breaches)
- `bash tests/validate-structure.sh` — PASS (409 PASS, 0 FAIL)
- `bash tests/test-skill-graph.sh` — PASS (78 PASS, 0 FAIL, 0 WARN)