### PR TITLE
docs: add cross-agent evidence discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## Unreleased
+
+### Documentation
+
+- Add Headroom-inspired cross-agent evidence discipline docs: a wiki Limitations page, expanded runtime/plugin comparison and release-evidence guidance, and real-behavior-proof contribution/release checklist language. Tracks issues #273, #274, and #275.
+
+---
+
 ## v2.21.0 — Cross-Agent Discovery and Portability Contract (2026-06-06)
 
 Adds a conservative discovery/export layer inspired by `cosmicstack-labs/mercury-agent-skills`, adapted to this plugin's Claude Code + Codex portability boundary. This closes the v2.21.0 milestone scope for issues #267, #268, #269, and #270.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,23 @@ This catches the "stuck at v2.N-5" scenario at PR time instead of 4 months later
 
 See [issue #108](https://github.com/pitimon/8-habit-ai-dev/issues/108) and [issue #106](https://github.com/pitimon/8-habit-ai-dev/issues/106) for the drift incident that motivated this check.
 
+### Real behavior proof
+
+For user-facing doctrine, packaging, install, release, generated catalog, or cross-agent runtime-boundary changes, include a **Real behavior proof** section in the PR body. Unit tests and source diffs are necessary, but they are not enough by themselves when the user-facing surface is a plugin install, wiki page, or generated discovery artifact.
+
+Good proof for this repo includes:
+
+- exact validator commands and pass summaries,
+- `node scripts/generate-skill-catalog.js --check` when skill metadata or discovery docs are touched,
+- `claude plugin list` output when Claude plugin install/update behavior changes,
+- `codex plugin list` output after `codex plugin marketplace upgrade pitimon-8-habit-ai-dev` when Codex packaging or cache-refresh behavior changes,
+- links to the exact README, wiki, compatibility, or integration page changed,
+- a short "not tested" note for any host platform you did not verify.
+
+Do not use secrets, tokens, credentials, private customer evidence, raw incident transcripts, or sensitive local memory captures as proof. Redact or summarize operational evidence before it enters GitHub.
+
+This is documentation discipline, not a new enforcement hook. If a future contributor proposes turning this checklist into a runtime gate, route that design to `claude-governance` or a separate adapter first.
+
 ### Link check (external URLs)
 
 Two GitHub Actions workflows guard against dead links:
@@ -256,6 +273,7 @@ Before bumping the version files above and tagging a release, run through this l
 - [ ] CHANGELOG entry added (or explicitly marked doctrine-only per ADR-017 §C5).
 - [ ] Version bumped in all 5 files (see "Version Bumping" above) — `tests/validate-structure.sh` will fail CI if any drifts.
 - [ ] `README.md` "What's New" mentions the bumped version (Check 19 enforces this).
+- [ ] Real behavior proof captured for changed user surfaces: validators, generated catalog freshness, install/list evidence when packaging changed, and explicit "not tested" notes.
 
 **ADR-018 reversal trigger**: if the SKILL-EFFECTIVENESS tally is not updated for ≥2 release cycles, ADR-018 itself enters reversal review per its Forward-Guardrail Sunset criteria. This checklist's existence is part of the proof-of-life mechanism.
 
@@ -270,3 +288,4 @@ Before submitting:
 - [ ] Habit mapping is documented
 - [ ] No hardcoded secrets or sensitive patterns
 - [ ] File under 800 lines
+- [ ] PR includes real behavior proof when the change affects install, release, packaging, generated docs/catalogs, or cross-agent runtime expectations

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@
 
 **Reference**
 
-- [What's New](#whats-new-in-v2202) — Version history
+- [What's New](#whats-new-in-v2210) — Version history
 - [Not a Checklist](#not-a-checklist) — Principles, not gates
 - [Origin](#origin) — Where these habits come from
+- [Limitations](https://github.com/pitimon/8-habit-ai-dev/wiki/Limitations) — Runtime boundaries and evidence expectations
 - [FAQ](#faq) — Common questions answered
 - [Glossary](#glossary) — Key terms defined
 - [Alternative Setup](#alternative-setup-without-plugin) | [Contributing](#contributing) | [License](#license)
@@ -109,7 +110,7 @@ codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev
 
 **New to the plugin?** Start with `/workflow` for a guided walkthrough, or see [Use Cases](#use-cases-which-skill-when) to find the right skill for your situation.
 
-Two commands to install per platform. Claude Code also loads a session reminder; both platforms make 24 skills available. For exact runtime boundaries, see the [runtime compatibility matrix](docs/compatibility-matrix.md) and [Codex integration guide](docs/codex-integration.md): Codex gets native packaging and the same markdown skills, not Claude hook execution or runtime enforcement.
+Two commands to install per platform. Claude Code also loads a session reminder; both platforms make 24 skills available. For exact runtime boundaries, see the [runtime compatibility matrix](docs/compatibility-matrix.md), [Codex integration guide](docs/codex-integration.md), and wiki [Limitations](https://github.com/pitimon/8-habit-ai-dev/wiki/Limitations): Codex gets native packaging and the same markdown skills, not Claude hook execution or runtime enforcement.
 
 ### Keeping the plugin updated
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -18,9 +18,11 @@ This matrix documents what `8-habit-ai-dev` promises across agent runtimes. It i
 | Hook-based verbosity adaptation | Claude Code only | Not runtime-integrated | Not runtime-integrated |
 | `disable-model-invocation` intent marker | Decorative for current plugin skills per ADR-014 | Must remain Codex-ingestible | Varies |
 | `docs/data/skills.json` generated catalog | Yes, documentation/export metadata | Yes, documentation/export metadata | Yes, if the platform can read JSON |
+| Install/update verification | `claude plugin list` | `codex plugin list` after marketplace refresh | Platform-specific |
+| Real behavior proof for releases | Claude installed version + validators + docs links | Codex installed version/cache path + validators + docs links | Concrete load/use evidence from the host platform |
+| Durable project memory | External curated memory | External curated memory | External curated memory |
 | Runtime enforcement gates | No, use `claude-governance` | No, use adapter or companion tooling | Varies |
 | Compliance framework implementation | Redirects/delegates to `claude-governance` | Redirects/delegates to `claude-governance` | Varies |
-| Obsidian project memory | External curated memory | External curated memory | External curated memory |
 
 ## Platform Contracts
 
@@ -58,6 +60,34 @@ Other agent platforms can consume the plugin as structured markdown:
 4. Load the cited `SKILL.md` through the platform's native instruction mechanism.
 
 The skill content is portable; the runtime packaging is not.
+
+## Runtime and Plugin Comparison
+
+Use this table when deciding where a behavior belongs. The shared product is the markdown skill corpus; each host decides how to load, display, and optionally wrap it.
+
+| Area | Shared plugin core | Claude Code surface | Codex surface | Other-agent surface |
+| --- | --- | --- | --- | --- |
+| Skill behavior | `skills/*/SKILL.md` prose and Definition of Done | Loaded through Claude plugin skills | Loaded through Codex plugin skills | Loaded manually or through that platform's skill/rules mechanism |
+| Skill routing | `skills/RESOLVER.md` and frontmatter descriptions | May also be aided by Claude UX | Codex should read resolver + matching `SKILL.md` | Platform-specific dispatcher or manual selection |
+| Entry context | `README.md`, docs, `llms.txt` | `CLAUDE.md` is the primary auto-loaded reference | `AGENTS.md` is the operating protocol | `AGENTS.md` + `llms.txt` |
+| Packaging | Portable markdown and manifests | `.claude-plugin/` | `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json` | Git clone, raw URLs, or platform-specific import |
+| Hooks | Not part of the shared skill core | `hooks/` can run in Claude Code | Not executed | Not executed unless a separate adapter implements equivalent behavior |
+| Memory | Not internal plugin state | External memory systems may be used by the agent | External memory systems may be used by the agent | External memory systems may be used by the agent |
+| Enforcement | Out of scope | Route to `claude-governance` or another companion | Route to `claude-governance` or a future adapter | Platform-specific, outside this plugin |
+| Release evidence | Validators, generated catalog freshness, docs links | Add `claude plugin list` evidence when install behavior changes | Add `codex plugin list` and marketplace/cache evidence when install behavior changes | Add concrete host load/use evidence |
+
+## Evidence and Release Proof
+
+Docs and plugin packaging changes should include real behavior proof when they affect what users install, load, or trust. Useful evidence includes:
+
+- validator output from `tests/validate-structure.sh`, `tests/validate-content.sh`, `tests/test-skill-graph.sh`, and `tests/test-verbosity-hook.sh`;
+- `node scripts/generate-skill-catalog.js --check` when skill metadata or generated discovery surfaces are touched;
+- `claude plugin list` or `codex plugin list` when package manifests, marketplace docs, install instructions, or cache-refresh behavior changes;
+- exact wiki/docs links for new user-facing pages.
+
+Do not use secrets, customer-sensitive raw data, private incident transcripts, or unverifiable summaries as release evidence.
+
+For product boundaries that should stay visible to users, see the wiki [Limitations](https://github.com/pitimon/8-habit-ai-dev/wiki/Limitations).
 
 ## Frontmatter Contract
 

--- a/docs/wiki/Contributing-to-Wiki.md
+++ b/docs/wiki/Contributing-to-Wiki.md
@@ -49,10 +49,12 @@ For link validation, rely on the wiki link-check workflow or run the same tool l
 - No unbalanced code fences.
 - No overclaiming language.
 - Operational updates remain visible when relevant.
+- User-facing doctrine, install, packaging, generated catalog, or compatibility changes include real behavior proof: validator output, generated catalog freshness, install/list evidence when relevant, and explicit not-tested notes.
 - The PR states that the change is docs-only if no package behavior changed.
 
 ## See Also
 
 - [Architecture](Architecture)
+- [Limitations](Limitations)
 - [Changelog](Changelog)
 - [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,4 +1,4 @@
-![Version](https://img.shields.io/badge/version-2.20.2-blue) ![Skills](https://img.shields.io/badge/skills-24-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange)
+![Version](https://img.shields.io/badge/version-2.21.0-blue) ![Skills](https://img.shields.io/badge/skills-24-green) ![License](https://img.shields.io/badge/license-MIT-brightgreen) ![Dependencies](https://img.shields.io/badge/dependencies-0-orange)
 
 # 8-Habit AI Dev
 
@@ -16,6 +16,7 @@
 | Choose the right skill | [Skills Reference](Skills-Reference) |
 | Understand the full process | [Workflow Overview](Workflow-Overview) |
 | Recover from common issues | [Troubleshooting](Troubleshooting) |
+| Understand boundaries | [Limitations](Limitations) |
 
 ## What You Get
 
@@ -43,17 +44,17 @@ Use the full workflow for larger features, unclear domains, architecture changes
 
 ## Current Release Focus
 
-Version `v2.20.2` keeps the plugin's markdown-only boundary while improving operational guidance:
+Version `v2.21.0` keeps the plugin's markdown-only boundary while improving cross-agent discovery:
 
-- `/operational-state` classifies operational findings before action.
-- `/consistency-check` includes incident/config hotfix drift checks.
-- `/deploy-guide` includes reconciliation gates for provider-managed canaries and capacity changes.
+- `docs/data/skills.json` exports generated skill metadata for cross-agent discovery.
+- The frontmatter compatibility contract now documents Claude Code, Codex, and portable markdown expectations.
+- `/review-ai` and `/reflect` include AI-work health and audit-evidence checkpoints.
 
 ## Compatibility Boundary
 
 Claude Code and Codex both consume the same markdown skills. Claude Code also has Claude-specific hooks and session reminders. Codex uses `AGENTS.md`, the Codex plugin manifest, and the same `skills/` directory; it does not run Claude hooks.
 
-For details, see [Architecture](Architecture), [Installation](Installation), and the repository compatibility docs.
+For details, see [Architecture](Architecture), [Limitations](Limitations), [Installation](Installation), and the repository compatibility docs.
 
 ## Reference
 
@@ -62,4 +63,5 @@ For details, see [Architecture](Architecture), [Installation](Installation), and
 - [Habits Reference](Habits-Reference) - includes the Covey origin and engineering adaptation
 - [Maturity Model](Maturity-Model)
 - [Architecture](Architecture)
+- [Limitations](Limitations)
 - [Changelog](Changelog)

--- a/docs/wiki/Limitations.md
+++ b/docs/wiki/Limitations.md
@@ -1,0 +1,54 @@
+# Limitations
+
+`8-habit-ai-dev` is workflow discipline packaged as markdown skills. It helps agents and humans ask better questions, preserve evidence, review AI-generated work, and hand off decisions. It does not execute work by itself.
+
+> [!IMPORTANT]
+> Treat this plugin as guidance, not authority. A skill can remind you to verify, review, stage, or monitor; it cannot make a production action safe on its own.
+
+## Where It Helps
+
+| Situation | Useful Starting Point | Why |
+| --- | --- | --- |
+| Unclear problem or unfamiliar domain | `/research` | Forces source-backed investigation before requirements |
+| Feature planning | `/requirements` | Defines scope, success criteria, and EARS-style behavior before implementation |
+| Architecture choices | `/design` | Surfaces trade-offs and human decision points |
+| AI-generated implementation | `/review-ai` | Produces a verdict with evidence, severity, and verification expectations |
+| Pre-merge or pre-release uncertainty | `/cross-verify` | Checks the work across all 8 habits and Body/Mind/Heart/Spirit dimensions |
+| Operational finding or incident closure | `/operational-state`, `/deploy-guide`, `/post-mortem` | Separates observation, action, rollout, and learning |
+
+## What It Does Not Do
+
+| Not Provided | Use Instead |
+| --- | --- |
+| Runtime policy enforcement | Companion tooling such as `claude-governance` or host-specific gates |
+| Irreversible-action authorization | Human approval and the deployment/change-management system you already trust |
+| Compliance certification or legal advice | Qualified compliance/legal review and auditable control evidence |
+| Cloud, Kubernetes, Docker, or database mutation | Your normal infrastructure tooling, runbooks, and staged rollout process |
+| Secret scanning or credential handling | Dedicated security scanners and secret-management systems |
+| Dynamic sub-agent orchestration engine | A separate adapter or orchestration product |
+| Claude hook behavior inside Codex | Codex-native adapters or explicit manual checks |
+
+## Platform Boundaries
+
+Claude Code and Codex both receive the same markdown skills. Claude Code may also run Claude-specific hooks from `hooks/`; Codex does not run those hooks. Other agents can use the repo as markdown instructions when they can load `AGENTS.md`, `skills/RESOLVER.md`, and the relevant `SKILL.md`.
+
+The shared source of truth remains `skills/*/SKILL.md`. Packaging, hooks, banners, and marketplace behavior are host-specific presentation layers.
+
+## Evidence Expectations
+
+When a change affects install behavior, generated discovery metadata, skill routing, docs, or release trust, prove it from the surface the user will touch:
+
+- run the repository validators,
+- check generated catalog freshness when metadata changes,
+- verify installed plugin state for Claude Code or Codex when packaging changes,
+- link the exact docs or wiki page affected,
+- state what was not tested.
+
+Do not use secrets, customer-sensitive raw data, or private incident transcripts as proof.
+
+## See Also
+
+- [Architecture](Architecture)
+- [Installation](Installation)
+- [Troubleshooting](Troubleshooting)
+- [Contributing to Wiki](Contributing-to-Wiki)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -32,6 +32,7 @@ _Workflow discipline for AI-assisted development_
 - [Habits Reference](Habits-Reference)
 - [Maturity Model](Maturity-Model)
 - [Architecture](Architecture)
+- [Limitations](Limitations)
 - [Vibe Coding vs Structured](Vibe-Coding-vs-Structured)
 - [Harness Engineering](Harness-Engineering)
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,6 +15,7 @@ Repo: https://github.com/pitimon/8-habit-ai-dev
 - [docs/data/skills.json](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/docs/data/skills.json): Generated machine-readable skill catalog for cross-agent discovery. Metadata only; not a runtime dispatcher.
 - [docs/compatibility-matrix.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/docs/compatibility-matrix.md): Runtime compatibility contract across Claude Code, Codex, and other markdown-capable agents.
 - [docs/codex-integration.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/docs/codex-integration.md): Codex install, verify, routing, adapter boundary, and release-flow guidance.
+- [docs/wiki/Limitations.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/docs/wiki/Limitations.md): User-facing boundaries, non-goals, runtime limits, and release-evidence expectations.
 
 ## Skills
 
@@ -29,6 +30,7 @@ Repo: https://github.com/pitimon/8-habit-ai-dev
 - [guides/integrity-principles.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/integrity-principles.md): Evidence standards for reviews, cross-verification, and reflection.
 - [guides/vendor-portability.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/vendor-portability.md): Discipline for staying portable when adopting managed-agent platforms (memory, self-evaluation, orchestration).
 - [guides/independent-source-verification.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/guides/independent-source-verification.md): Confirm a root cause from an independent source (different tool/command/vantage) and reconcile contradictions — catches confident-but-wrong diagnoses that survive every author-side gate.
+- [docs/wiki/Limitations.md](https://raw.githubusercontent.com/pitimon/8-habit-ai-dev/main/docs/wiki/Limitations.md): Boundary and evidence expectations for users evaluating whether plugin behavior is in scope.
 
 ## Compliance
 

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -372,6 +372,7 @@ if [ -d "docs/wiki" ]; then
     "Step-7-Monitor-Setup.md"
     "Habits-Reference.md"
     "Skills-Reference.md"
+    "Limitations.md"
     "Vibe-Coding-vs-Structured.md"
     "FAQ.md"
     "Troubleshooting.md"


### PR DESCRIPTION
## Summary

- Add a wiki Limitations page that makes the plugin boundary explicit: guidance, not runtime authority.
- Expand the runtime compatibility matrix with a plugin/runtime comparison and release-evidence expectations.
- Add real-behavior-proof guidance to CONTRIBUTING, README/wiki entry points, llms.txt, changelog, and wiki skeleton validation.

Closes #273
Closes #274
Closes #275

## Real behavior proof

Validated from a clean detached worktree at commit `0026571`, separate from local untracked context files:

- `git diff --check` — pass
- `bash tests/validate-structure.sh` — PASS 410, FAIL 0
- `bash tests/validate-content.sh` — PASS 310, FAIL 0, WARN 1 (`research` Definition of Done length; existing non-blocking warning)
- `bash tests/test-skill-graph.sh` — PASS 78, FAIL 0
- `bash tests/test-verbosity-hook.sh` — PASS 19, FAIL 0
- `node scripts/generate-skill-catalog.js --check` — `docs/data/skills.json is fresh`

Installed-plugin spot checks before PR:

- `codex plugin list` — `8-habit-ai-dev@pitimon-8-habit-ai-dev` installed/enabled at `2.21.0`
- `claude plugin list` — `8-habit-ai-dev@pitimon-8-habit-ai-dev` enabled at `2.21.0`

## Not tested

- No package install/update behavior changed, so no marketplace cache refresh or release tag was created in this PR.
- External wiki publication is not visible until after merge/publish flow.
