### PR TITLE
chore: scaffolding diet — cadence default, retire pulse-note ritual, fix F21 (#329)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,17 +270,17 @@ Version lives in **6 files** — all must be bumped together:
 
 Before bumping the version files above and tagging a release, run through this list. Each item is a forcing function against drift — skipping any item is how dormancy starts (see ADR-018 §"Context" for the 13-month dormancy precedent that motivated this checklist).
 
-- [ ] Release decision recorded before any version bump:
-  - `Release now` for installed-user surfaces: `skills/`, `guides/`, `hooks/`, manifests, `AGENTS.md`, `llms.txt`, generated catalogs, install/update docs, runtime-boundary docs, or root context files shipped in the plugin package.
-  - `Bundle later` for consumer-facing changes that can wait; do not bump version files until the bundled release PR.
-  - `No release` for contributor-only tests, CI, ADRs, internal docs, or validator maintenance that does not change installed-user behavior or package contents.
-- [ ] Run [`SKILL-EFFECTIVENESS.md`](SKILL-EFFECTIVENESS.md) tally update per its §"Maintainer update protocol" — grep Q6 across new lessons since last tally **and harvest invocation ground truth** (`<command-name>` + Skill-tool grep across `~/.claude/projects/`, excluding `claude-mem-observer-sessions` and the plugin's own repo dir per #314), increment counters, refresh the Skill class index + `Last updated` + `Lessons analyzed`, note any new trends. Usage informs discoverability/footprint only — **never deprecation** (Governing principle). ADR-018 Edge #1, anti-dormancy mechanism per issue [#227](https://github.com/pitimon/8-habit-ai-dev/issues/227).
+- [ ] Release decision recorded (**default = `Bundle later`**):
+  - `Bundle later` (default) — doc/doctrine deltas (guides, ADRs, wording, validators, a single rule/checkpoint tweak) ride the next release; do not bump version files for a one-change release.
+  - `Release now` — only when a change must reach installed users promptly (new/changed skill behavior, packaging/manifest fix, install-blocking bug); state the reason.
+  - `No release` — contributor-only paths (tests, CI, ADRs, internal docs, validator maintenance): no bump (ADR-019 contributor-doctrine).
+- [ ] **If** a `/reflect` Q6 window has accumulated since the last tally, run the [`SKILL-EFFECTIVENESS.md`](SKILL-EFFECTIVENESS.md) §"Maintainer update protocol" harvest (Q6 + invocation ground truth per #314; usage informs discoverability/footprint only, **never deprecation**). No per-release "tally unchanged" pulse note is required when nothing accumulated (ritual retired 2026-06-20; anticipates ADR-018 §"Forward-Guardrail Sunset", 2026-11-24).
 - [ ] CHANGELOG entry added (or explicitly marked doctrine-only per ADR-017 §C5).
 - [ ] Version bumped in all 6 files (see "Version Bumping" above) — `tests/validate-structure.sh` will fail CI if any drifts.
 - [ ] `README.md` "What's New" mentions the bumped version (Check 19 enforces this).
 - [ ] Real behavior proof captured for changed user surfaces: validators, generated catalog freshness, install/list evidence when packaging changed, and explicit "not tested" notes.
 
-**ADR-018 reversal trigger**: if the SKILL-EFFECTIVENESS tally is not updated for ≥2 release cycles, ADR-018 itself enters reversal review per its Forward-Guardrail Sunset criteria. This checklist's existence is part of the proof-of-life mechanism.
+**ADR-018 dormancy signal** (reframed 2026-06-20): dormancy = a real `/reflect` Q6 window accumulated but went **un-harvested**. Calendar release cadence is **not** dormancy — releases with nothing to harvest need no pulse note (that calendar-cycle reading was generating self-referential "tally unchanged" overhead). The genuine proof-of-life is that real signal gets harvested when it exists; this anticipates the ADR-018 §"Forward-Guardrail Sunset" review window (2026-11-24).
 
 ## Quality Checklist
 

--- a/SKILL-EFFECTIVENESS.md
+++ b/SKILL-EFFECTIVENESS.md
@@ -34,6 +34,8 @@ Trend analysis informs /skill-improve cycles, discoverability + footprint decisi
 
 ## Maintainer update protocol
 
+> **Cadence (relaxed 2026-06-20, #329)**: harvest when a `/reflect` Q6 window has **accumulated** — not once per release. A release with nothing new to harvest requires **no** "tally unchanged" pulse note. This retires the per-release note ritual, which had become self-referential overhead (a note written each release purely to avoid tripping a calendar-based reversal trigger). Dormancy is now measured as un-harvested real signal, not elapsed release count — anticipates the ADR-018 §"Forward-Guardrail Sunset" review (2026-11-24). The tally itself is preserved.
+
 When updating this file:
 
 1. **Read lesson files**: `ls ~/.claude/lessons/*.md` on the maintainer's machine, plus any contributor reports shared via PR or issue.

--- a/plugin/CONTRIBUTING.md
+++ b/plugin/CONTRIBUTING.md
@@ -270,17 +270,17 @@ Version lives in **6 files** — all must be bumped together:
 
 Before bumping the version files above and tagging a release, run through this list. Each item is a forcing function against drift — skipping any item is how dormancy starts (see ADR-018 §"Context" for the 13-month dormancy precedent that motivated this checklist).
 
-- [ ] Release decision recorded before any version bump:
-  - `Release now` for installed-user surfaces: `skills/`, `guides/`, `hooks/`, manifests, `AGENTS.md`, `llms.txt`, generated catalogs, install/update docs, runtime-boundary docs, or root context files shipped in the plugin package.
-  - `Bundle later` for consumer-facing changes that can wait; do not bump version files until the bundled release PR.
-  - `No release` for contributor-only tests, CI, ADRs, internal docs, or validator maintenance that does not change installed-user behavior or package contents.
-- [ ] Run [`SKILL-EFFECTIVENESS.md`](SKILL-EFFECTIVENESS.md) tally update per its §"Maintainer update protocol" — grep Q6 across new lessons since last tally **and harvest invocation ground truth** (`<command-name>` + Skill-tool grep across `~/.claude/projects/`, excluding `claude-mem-observer-sessions` and the plugin's own repo dir per #314), increment counters, refresh the Skill class index + `Last updated` + `Lessons analyzed`, note any new trends. Usage informs discoverability/footprint only — **never deprecation** (Governing principle). ADR-018 Edge #1, anti-dormancy mechanism per issue [#227](https://github.com/pitimon/8-habit-ai-dev/issues/227).
+- [ ] Release decision recorded (**default = `Bundle later`**):
+  - `Bundle later` (default) — doc/doctrine deltas (guides, ADRs, wording, validators, a single rule/checkpoint tweak) ride the next release; do not bump version files for a one-change release.
+  - `Release now` — only when a change must reach installed users promptly (new/changed skill behavior, packaging/manifest fix, install-blocking bug); state the reason.
+  - `No release` — contributor-only paths (tests, CI, ADRs, internal docs, validator maintenance): no bump (ADR-019 contributor-doctrine).
+- [ ] **If** a `/reflect` Q6 window has accumulated since the last tally, run the [`SKILL-EFFECTIVENESS.md`](SKILL-EFFECTIVENESS.md) §"Maintainer update protocol" harvest (Q6 + invocation ground truth per #314; usage informs discoverability/footprint only, **never deprecation**). No per-release "tally unchanged" pulse note is required when nothing accumulated (ritual retired 2026-06-20; anticipates ADR-018 §"Forward-Guardrail Sunset", 2026-11-24).
 - [ ] CHANGELOG entry added (or explicitly marked doctrine-only per ADR-017 §C5).
 - [ ] Version bumped in all 6 files (see "Version Bumping" above) — `tests/validate-structure.sh` will fail CI if any drifts.
 - [ ] `README.md` "What's New" mentions the bumped version (Check 19 enforces this).
 - [ ] Real behavior proof captured for changed user surfaces: validators, generated catalog freshness, install/list evidence when packaging changed, and explicit "not tested" notes.
 
-**ADR-018 reversal trigger**: if the SKILL-EFFECTIVENESS tally is not updated for ≥2 release cycles, ADR-018 itself enters reversal review per its Forward-Guardrail Sunset criteria. This checklist's existence is part of the proof-of-life mechanism.
+**ADR-018 dormancy signal** (reframed 2026-06-20): dormancy = a real `/reflect` Q6 window accumulated but went **un-harvested**. Calendar release cadence is **not** dormancy — releases with nothing to harvest need no pulse note (that calendar-cycle reading was generating self-referential "tally unchanged" overhead). The genuine proof-of-life is that real signal gets harvested when it exists; this anticipates the ADR-018 §"Forward-Guardrail Sunset" review window (2026-11-24).
 
 ## Quality Checklist
 

--- a/plugin/SKILL-EFFECTIVENESS.md
+++ b/plugin/SKILL-EFFECTIVENESS.md
@@ -34,6 +34,8 @@ Trend analysis informs /skill-improve cycles, discoverability + footprint decisi
 
 ## Maintainer update protocol
 
+> **Cadence (relaxed 2026-06-20, #329)**: harvest when a `/reflect` Q6 window has **accumulated** — not once per release. A release with nothing new to harvest requires **no** "tally unchanged" pulse note. This retires the per-release note ritual, which had become self-referential overhead (a note written each release purely to avoid tripping a calendar-based reversal trigger). Dormancy is now measured as un-harvested real signal, not elapsed release count — anticipates the ADR-018 §"Forward-Guardrail Sunset" review (2026-11-24). The tally itself is preserved.
+
 When updating this file:
 
 1. **Read lesson files**: `ls ~/.claude/lessons/*.md` on the maintainer's machine, plus any contributor reports shared via PR or issue.

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -835,6 +835,7 @@ echo ""
 # the version-bearing files, even if the change is "doctrine refinement" in spirit. Contributor-
 # doctrine paths (docs/, CLAUDE.md, CONTRIBUTING.md, .github/, SELF-CHECK.md, tests/)
 # do not — they preserve ADR-017 §C5 intent. See ADR-019 for full rationale and tables.
+# The `plugin/` mirror is classified by its logical (de-mirrored) path — see the F21 fix below.
 echo "--- Check 27: consumer-doctrine bump enforcement (ADR-019 + ADR-023) ---"
 
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -848,8 +849,14 @@ else
   if [ -z "$CHANGED" ]; then
     pass "no file changes since $LAST_TAG — Check 27 trivially passes"
   else
+    # F21 fix (#329): normalize the leading `plugin/` mirror prefix before classifying, so a
+    # contributor-doctrine file (docs/, CONTRIBUTING.md, SELF-CHECK.md, …) does NOT trip
+    # consumer-doctrine merely via its mirrored `plugin/` copy. Check 28 guarantees root↔mirror
+    # byte-parity, so classifying by logical path is sound. `plugin/.codex-plugin/plugin.json`
+    # still normalizes to `.codex-plugin/` → consumer (correct: it is a version manifest).
+    CHANGED_LOGICAL=$(echo "$CHANGED" | sed 's#^plugin/##')
     # Match any path under consumer-doctrine top-level dirs plus native Codex packaging.
-    CONSUMER_TOUCHED=$(echo "$CHANGED" | grep -E '^((rules|skills|hooks|habits|guides|agents|plugin)/|\.codex-plugin/|\.agents/plugins/marketplace\.json$)' || true)
+    CONSUMER_TOUCHED=$(echo "$CHANGED_LOGICAL" | grep -E '^((rules|skills|hooks|habits|guides|agents)/|\.codex-plugin/|\.agents/plugins/marketplace\.json$)' | sort -u || true)
 
     if [ -z "$CONSUMER_TOUCHED" ]; then
       pass "contributor-doctrine only since $LAST_TAG — no bump required (ADR-019)"


### PR DESCRIPTION
## Summary

Applies the plugin's own **earn-each-line** bar to its *scaffolding* layer (from the over-engineering self-audit, 2026-06-20). The audit found the discipline/skills layer healthy but the scaffolding — release ceremony, a self-feeding pulse-note ritual, and a validator self-contradiction — had become process-as-burden. Three levers, **contributor-doctrine only**:

1. **Cadence** (`CONTRIBUTING.md`) — release-decision default flipped to **`Bundle later`** for doc/doctrine deltas; stop one-change version-bump releases. Tally item relaxed from per-release to harvest-on-accumulation.
2. **Pulse-note ritual retired** (`SKILL-EFFECTIVENESS.md` + `CONTRIBUTING.md`) — no per-release "tally unchanged" note required; dormancy reframed from calendar cadence to **un-harvested real `/reflect` Q6 signal**. Anticipates ADR-018 §"Forward-Guardrail Sunset" (2026-11-24). The tally itself is preserved.
3. **F21 fix** (`tests/validate-structure.sh` Check 27) — normalize the leading `plugin/` mirror prefix before consumer/contributor classification, so a pure `docs/`/`CONTRIBUTING.md` change no longer trips a version bump via its mirrored copy. Honors ADR-019; closes the catch-22 recorded at `CHANGELOG.md:186` (F21).

## Self-proof (the fix demonstrates itself)

This PR touches only contributor-doctrine paths (incl. `plugin/`-mirrored copies). Under the **old** Check 27, `plugin/CONTRIBUTING.md` + `plugin/SKILL-EFFECTIVENESS.md` would have matched `^plugin/` and forced a spurious version bump. Post-fix, Check 27 reports:

> `PASS: contributor-doctrine only since v2.21.33 — no bump required (ADR-019)`

So this ships with **no version bump and no CHANGELOG entry** — which is exactly the bug being fixed, proven live.

## Review

`@8-habit-reviewer` cross-verify: **17/17, ship-as-is**. F21 correctness gate verified with a 5-case truth table (real consumer changes — `skills/`, `plugin/skills/`, `plugin/.codex-plugin/plugin.json` — all still require a bump; only non-consumer mirrors are newly exempted). No false-negative introduced.

## Test plan
- [x] `tests/validate-structure.sh` → **439/0**; Check 27 → "contributor-doctrine only — no bump required"; Check 28 mirror parity holds
- [x] `tests/validate-content.sh` → **362/0**
- [x] No version bump / no CHANGELOG (correct per ADR-019 contributor-doctrine classification)
- [x] No new skill/hook/validator check; no discipline-layer (skills/habits/rules) behavior change

## Out of scope (each earns its own PR)
- Broad audit of all ~801 validator checks (unbounded — would be the 7th over-engineering symptom).
- `plugin/` **mirror generation** (generate at release vs hand-sync + byte-parity) — highest mechanical leverage but real build-work; deferred.

## Follow-up (non-blocking, pre-existing — not introduced here)
Reviewer flagged a pre-existing gap: Check 27's consumer alternation omits `^\.claude-plugin/`, though ADR-019 (lines 89/101) classifies non-version edits to `.claude-plugin/plugin.json` + `marketplace.json` as consumer-doctrine. Will file separately.

Refs #329