### PR TITLE
chore: mirror-untracking out-of-scope (ADR-023) + sync-mirror.sh helper (#333)

### DIFF
--- a/docs/out-of-scope/mirror-untracking.md
+++ b/docs/out-of-scope/mirror-untracking.md
@@ -1,0 +1,49 @@
+---
+date: 2026-06-20
+originating-decision: "Issue #333 (deferred 'mirror generation' item from the scaffolding-diet arc, #329)"
+rejected-because: Untracking or generating `plugin/` at release time contradicts ADR-023's requirement that it be a real committed Codex child directory; the symlink alternative already failed on Linux. Only the hand-sync toil is reducible (via scripts/sync-mirror.sh), not the tracked-mirror surface itself.
+---
+
+# We don't untrack or auto-generate the `plugin/` mirror — ADR-023 conflict
+
+The over-engineering audit (2026-06-20) correctly named the `plugin/` mirror as the root of the
+high ceremony-to-payload ratio: every content change to a mirrored path must be duplicated into
+`plugin/`, and Check 28 enforces byte-for-byte parity. The tempting fix — "stop tracking `plugin/`
+and generate it only at release" — was evaluated and **rejected**.
+
+## Why the tempting fix is a no-go
+
+[ADR-023](../adr/ADR-023-codex-native-packaging.md) (Accepted; amended by v2.21.10) requires
+`plugin/` to be a **real, committed child directory**:
+
+- Codex marketplace install resolves `codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev`
+  against `./plugin` as the **child source path** — it must exist in the cloned repo, not be
+  produced by a release step the installer never runs.
+- The original `plugin -> .` symlink satisfied Codex but **broke Claude Code install on Linux**
+  with `ENOENT: no such file or directory, symlink`. v2.21.10 replaced it with a real directory
+  precisely to fix that regression. Untracking / generating the mirror would re-open that class.
+
+So the doubled tracked surface is a **requirement of cross-agent packaging**, not incidental waste.
+Removing it would require redesigning Codex packaging itself — a far larger, regression-prone change
+than the toil it saves.
+
+## What we do instead
+
+- **`scripts/sync-mirror.sh`** (shipped with this decision) removes the _hand-copying_ toil: it
+  copies the 8 mirrored dirs + 11 root files into `plugin/` in one command, so Check 28 passes
+  without manually `cp`-ing each touched file. The mirror stays tracked; only the keystrokes go away.
+- The **cadence default = `Bundle later`** (CONTRIBUTING.md) and the **F21 Check-27 fix** (#329)
+  already removed the _other_ half of the "14 files for one sentence" pain — spurious version bumps
+  on contributor-doctrine changes. What remains is just the (required) mirror copy.
+
+## If reconsidering, these must all hold
+
+1. Codex packaging gains a supported way to resolve a child source that is generated at install
+   (or the marketplace contract changes) such that `./plugin` need not be committed.
+2. A Linux Claude Code install is verified end-to-end against the new shape (the exact regression
+   ADR-023 v2.21.10 fixed) — with evidence, not assumption.
+3. The change is scoped via its own `/research` + `/design`; it is an architecture decision (H8),
+   not a tooling tweak.
+
+Until then, the disciplined outcome is this record plus the sync helper — a decision to **not build**
+the ambitious version, with the toil reduced rather than the contract broken.

--- a/plugin/docs/out-of-scope/mirror-untracking.md
+++ b/plugin/docs/out-of-scope/mirror-untracking.md
@@ -1,0 +1,49 @@
+---
+date: 2026-06-20
+originating-decision: "Issue #333 (deferred 'mirror generation' item from the scaffolding-diet arc, #329)"
+rejected-because: Untracking or generating `plugin/` at release time contradicts ADR-023's requirement that it be a real committed Codex child directory; the symlink alternative already failed on Linux. Only the hand-sync toil is reducible (via scripts/sync-mirror.sh), not the tracked-mirror surface itself.
+---
+
+# We don't untrack or auto-generate the `plugin/` mirror — ADR-023 conflict
+
+The over-engineering audit (2026-06-20) correctly named the `plugin/` mirror as the root of the
+high ceremony-to-payload ratio: every content change to a mirrored path must be duplicated into
+`plugin/`, and Check 28 enforces byte-for-byte parity. The tempting fix — "stop tracking `plugin/`
+and generate it only at release" — was evaluated and **rejected**.
+
+## Why the tempting fix is a no-go
+
+[ADR-023](../adr/ADR-023-codex-native-packaging.md) (Accepted; amended by v2.21.10) requires
+`plugin/` to be a **real, committed child directory**:
+
+- Codex marketplace install resolves `codex plugin add 8-habit-ai-dev@pitimon-8-habit-ai-dev`
+  against `./plugin` as the **child source path** — it must exist in the cloned repo, not be
+  produced by a release step the installer never runs.
+- The original `plugin -> .` symlink satisfied Codex but **broke Claude Code install on Linux**
+  with `ENOENT: no such file or directory, symlink`. v2.21.10 replaced it with a real directory
+  precisely to fix that regression. Untracking / generating the mirror would re-open that class.
+
+So the doubled tracked surface is a **requirement of cross-agent packaging**, not incidental waste.
+Removing it would require redesigning Codex packaging itself — a far larger, regression-prone change
+than the toil it saves.
+
+## What we do instead
+
+- **`scripts/sync-mirror.sh`** (shipped with this decision) removes the _hand-copying_ toil: it
+  copies the 8 mirrored dirs + 11 root files into `plugin/` in one command, so Check 28 passes
+  without manually `cp`-ing each touched file. The mirror stays tracked; only the keystrokes go away.
+- The **cadence default = `Bundle later`** (CONTRIBUTING.md) and the **F21 Check-27 fix** (#329)
+  already removed the _other_ half of the "14 files for one sentence" pain — spurious version bumps
+  on contributor-doctrine changes. What remains is just the (required) mirror copy.
+
+## If reconsidering, these must all hold
+
+1. Codex packaging gains a supported way to resolve a child source that is generated at install
+   (or the marketplace contract changes) such that `./plugin` need not be committed.
+2. A Linux Claude Code install is verified end-to-end against the new shape (the exact regression
+   ADR-023 v2.21.10 fixed) — with evidence, not assumption.
+3. The change is scoped via its own `/research` + `/design`; it is an architecture decision (H8),
+   not a tooling tweak.
+
+Until then, the disciplined outcome is this record plus the sync helper — a decision to **not build**
+the ambitious version, with the toil reduced rather than the contract broken.

--- a/plugin/scripts/sync-mirror.sh
+++ b/plugin/scripts/sync-mirror.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# sync-mirror.sh — copy the root content into the `plugin/` Codex child package so that
+# `tests/validate-structure.sh` Check 28 (byte-for-byte mirror parity) passes.
+#
+# WHY THIS EXISTS (and what it deliberately does NOT do):
+#   `plugin/` is a REAL, git-tracked child directory by design — Codex marketplace install
+#   points at `./plugin` as the child source, and the earlier `plugin -> .` symlink failed on
+#   Linux Claude Code install (ENOENT). See ADR-023 and docs/out-of-scope/mirror-untracking.md.
+#   This script only removes the TOIL of hand-copying each touched file; it does NOT untrack or
+#   generate-away the mirror. The doubled tracked surface is required, not incidental.
+#
+# USAGE: run from anywhere; it cd's to the repo root.
+#     bash scripts/sync-mirror.sh
+#   Then `git add` the changed plugin/ files and commit alongside your root edits.
+#
+# The dir + file lists below MUST stay in lock-step with Check 28's sync lists in
+# tests/validate-structure.sh (the `for path in ...` and `for file in ...` loops).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Mirrored directories (Check 28 enforces `diff -qr <dir> plugin/<dir>`).
+DIRS="skills guides habits hooks agents rules scripts docs"
+# Mirrored root files (Check 28 enforces `cmp -s <file> plugin/<file>`).
+FILES="AGENTS.md CHANGELOG.md CLAUDE.md CONTRIBUTING.md DOMAIN.md LICENSE README.md SELF-CHECK.md SKILL-EFFECTIVENESS.md SPEC.md llms.txt"
+
+# NOTE: `.codex-plugin/` is intentionally NOT synced — the root and plugin/ Codex manifests are
+# distinct files (Check 28 does not diff them), so copying would corrupt the child manifest.
+
+for d in $DIRS; do
+  if [ -d "$d" ]; then
+    rsync -a --delete "$d/" "plugin/$d/"
+  fi
+done
+
+for f in $FILES; do
+  if [ -f "$f" ]; then
+    cp "$f" "plugin/$f"
+  fi
+done
+
+echo "Mirror synced: $(echo "$DIRS" | wc -w | tr -d ' ') dirs + $(echo "$FILES" | wc -w | tr -d ' ') files → plugin/"
+echo "Next: review with 'git status', stage the plugin/ changes, and run tests/validate-structure.sh."

--- a/scripts/sync-mirror.sh
+++ b/scripts/sync-mirror.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# sync-mirror.sh — copy the root content into the `plugin/` Codex child package so that
+# `tests/validate-structure.sh` Check 28 (byte-for-byte mirror parity) passes.
+#
+# WHY THIS EXISTS (and what it deliberately does NOT do):
+#   `plugin/` is a REAL, git-tracked child directory by design — Codex marketplace install
+#   points at `./plugin` as the child source, and the earlier `plugin -> .` symlink failed on
+#   Linux Claude Code install (ENOENT). See ADR-023 and docs/out-of-scope/mirror-untracking.md.
+#   This script only removes the TOIL of hand-copying each touched file; it does NOT untrack or
+#   generate-away the mirror. The doubled tracked surface is required, not incidental.
+#
+# USAGE: run from anywhere; it cd's to the repo root.
+#     bash scripts/sync-mirror.sh
+#   Then `git add` the changed plugin/ files and commit alongside your root edits.
+#
+# The dir + file lists below MUST stay in lock-step with Check 28's sync lists in
+# tests/validate-structure.sh (the `for path in ...` and `for file in ...` loops).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Mirrored directories (Check 28 enforces `diff -qr <dir> plugin/<dir>`).
+DIRS="skills guides habits hooks agents rules scripts docs"
+# Mirrored root files (Check 28 enforces `cmp -s <file> plugin/<file>`).
+FILES="AGENTS.md CHANGELOG.md CLAUDE.md CONTRIBUTING.md DOMAIN.md LICENSE README.md SELF-CHECK.md SKILL-EFFECTIVENESS.md SPEC.md llms.txt"
+
+# NOTE: `.codex-plugin/` is intentionally NOT synced — the root and plugin/ Codex manifests are
+# distinct files (Check 28 does not diff them), so copying would corrupt the child manifest.
+
+for d in $DIRS; do
+  if [ -d "$d" ]; then
+    rsync -a --delete "$d/" "plugin/$d/"
+  fi
+done
+
+for f in $FILES; do
+  if [ -f "$f" ]; then
+    cp "$f" "plugin/$f"
+  fi
+done
+
+echo "Mirror synced: $(echo "$DIRS" | wc -w | tr -d ' ') dirs + $(echo "$FILES" | wc -w | tr -d ' ') files → plugin/"
+echo "Next: review with 'git status', stage the plugin/ changes, and run tests/validate-structure.sh."


### PR DESCRIPTION
## Summary

Resolves the deferred **mirror generation** item from the scaffolding-diet arc with the disciplined outcome: a decision-to-not-build + a small toil reducer.

- **B — `docs/out-of-scope/mirror-untracking.md`**: untracking/generating `plugin/` is a **NO-GO**. ADR-023 requires `plugin/` to be a real committed Codex child directory (Codex marketplace install resolves `./plugin`); the `plugin -> .` symlink already broke Linux Claude Code install (`ENOENT`, fixed v2.21.10). The doubled tracked surface is a packaging requirement. Records re-entry conditions.
- **A — `scripts/sync-mirror.sh`**: removes the _hand-copy_ toil (8 mirrored dirs + 11 root files → `plugin/` in one command, matching Check 28's sync lists). The mirror stays tracked; only keystrokes go away.

## Why not the ambitious version

The cadence default (`Bundle later`) + F21 fix (#329) already removed the _spurious-bump_ half of the "14 files for one sentence" pain. What remains is the required mirror copy — reducible in toil, not removable in surface without redesigning Codex packaging (its own H8 decision, gated in the out-of-scope record).

## Test plan

- [x] Dogfooded: running `sync-mirror.sh` synced exactly the 2 new files + mirrors, no other drift
- [x] `validate-structure.sh` 439/0 (Check 28 parity holds) · `validate-content.sh` 362/0
- [x] Contributor-doctrine (scripts/ + docs/out-of-scope/) → no version bump (ADR-019)

Closes #333
