### PR TITLE
docs: reconcile ADR-026 stale 'not done here' note with shipped Deliverable B

### DIFF
--- a/docs/adr/ADR-026-external-prior-art-audit-karpathy-gstack.md
+++ b/docs/adr/ADR-026-external-prior-art-audit-karpathy-gstack.md
@@ -105,7 +105,8 @@ All verdicts stay inside `8-habit-ai-dev`'s charter (workflow discipline). The o
 **Negative / Honest disclosure**:
 
 - This is a popularity-driven audit, not a friction-driven one. Per ADR-014's lesson, that is acceptable **only** because it ships nothing — it records verdicts and defers. The two T2 gaps remain unaddressed until a real friction signal appears; if none does by 2026-12-27, they are evicted per ADR-016.
-- The discoverability follow-up (appending Karpathy #2/#3 to `guides/anthropic-engineering-doctrine-audit.md` Table 2, so the grep-protocol at `:52-59` finds them) is **deliberately not done here** — touching `guides/` is a consumer-doctrine change requiring a version bump, and is left as a separate maintainer decision.
+- The discoverability follow-up (appending Karpathy #2/#3 to `guides/anthropic-engineering-doctrine-audit.md` Table 2, so the grep-protocol at `:52-59` finds them) was **deliberately not done in this PR (#340)** — touching `guides/` is a consumer-doctrine change requiring a version bump, and was left as a separate maintainer decision.
+  - **Update 2026-06-28 (post-merge):** that separate decision was taken — "Deliverable B" shipped in **PR #341 / v2.21.34** as rows **N8 + N9 (T2, drop-date 2026-12-27)** in the doctrine-audit guide. This bullet's "not done here" is scoped to PR #340; it is no longer outstanding on `main`.
 
 ## Options Considered
 

--- a/plugin/docs/adr/ADR-026-external-prior-art-audit-karpathy-gstack.md
+++ b/plugin/docs/adr/ADR-026-external-prior-art-audit-karpathy-gstack.md
@@ -105,7 +105,8 @@ All verdicts stay inside `8-habit-ai-dev`'s charter (workflow discipline). The o
 **Negative / Honest disclosure**:
 
 - This is a popularity-driven audit, not a friction-driven one. Per ADR-014's lesson, that is acceptable **only** because it ships nothing — it records verdicts and defers. The two T2 gaps remain unaddressed until a real friction signal appears; if none does by 2026-12-27, they are evicted per ADR-016.
-- The discoverability follow-up (appending Karpathy #2/#3 to `guides/anthropic-engineering-doctrine-audit.md` Table 2, so the grep-protocol at `:52-59` finds them) is **deliberately not done here** — touching `guides/` is a consumer-doctrine change requiring a version bump, and is left as a separate maintainer decision.
+- The discoverability follow-up (appending Karpathy #2/#3 to `guides/anthropic-engineering-doctrine-audit.md` Table 2, so the grep-protocol at `:52-59` finds them) was **deliberately not done in this PR (#340)** — touching `guides/` is a consumer-doctrine change requiring a version bump, and was left as a separate maintainer decision.
+  - **Update 2026-06-28 (post-merge):** that separate decision was taken — "Deliverable B" shipped in **PR #341 / v2.21.34** as rows **N8 + N9 (T2, drop-date 2026-12-27)** in the doctrine-audit guide. This bullet's "not done here" is scoped to PR #340; it is no longer outstanding on `main`.
 
 ## Options Considered
 


### PR DESCRIPTION
## Summary

A post-merge Codex coherence audit of `main` (v2.21.34) found one genuine drift: ADR-026's Consequences section still said the guide follow-up was "deliberately not done here / left as a separate maintainer decision" — but that follow-up (**Deliverable B**) shipped in #341 / v2.21.34 as rows N8 + N9. On `main`, the bullet now reads as false unless you parse "here" as "PR #340".

ADRs are immutable historical records, so this keeps the original PR-#340-scoped sentence and appends a dated **"Update 2026-06-28 (post-merge)"** sub-bullet pointing to #341. No decision is rewritten.

Everything else in the audit passed: version coherence across all surfaces, no adoption overclaim, "popularity ≠ friction" consistent, #3↔H1 tension stated wherever #3 appears.

## Test plan
- [x] Docs-only (`docs/adr/` + mirror) — contributor-doctrine, no version bump (Check 27)
- [x] All 4 CI validators pass locally (validate-structure, test-skill-graph, validate-content, test-verbosity-hook)
- [x] `plugin/` mirror byte-parity (Check 28)

Refs #339 · follows #340, #341