### PR TITLE
feat(validate): Check 5b — bash-tooling size exemption, close B1 (#343)

### DIFF
--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -125,6 +125,30 @@ if [ "$SIZE_FAIL" -eq 0 ]; then
 fi
 echo ""
 
+# --- Check 5b: Bash tooling size limit (1500 lines) — documented exemption (#343 B1) ---
+# The 800-line rule (Check 5) is a READABILITY budget for CONTENT files (skills/habits/guides)
+# that a reader grasps in one sitting. Bash validators and scripts are LINEAR TOOLING (check
+# suites, sync helpers) where that budget does not fit — but they must still be BOUNDED so they
+# cannot grow without limit. This is a DOCUMENTED, ENFORCED exemption, not a silent self-exemption
+# (closes the enforce-on-others-skip-on-self gap the Fable review + adversarial Spirit pass
+# flagged). Supersedes the v2.14.3 (#163) "trim to <800" approach: that trim regressed
+# (validate-content 793->1012, validate-structure ->1164), proving trim-alone is not durable as
+# checks accrete. The 1500 cap bounds growth; if a validator approaches it, the check fires and
+# forces a real decision (extract sourced helpers or raise the cap deliberately).
+echo "--- Check 5b: Bash tooling < 1500 lines (documented exemption from the 800 content limit, #343 B1) ---"
+SIZE_FAIL_BASH=0
+while read -r f; do
+  lines=$(wc -l < "$f")
+  if [ "$lines" -gt 1500 ]; then
+    fail "$f has $lines lines (bash-tooling limit: 1500 — see Check 5b comment)"
+    SIZE_FAIL_BASH=$((SIZE_FAIL_BASH + 1))
+  fi
+done < <(find tests/ scripts/ hooks/ -name "*.sh" -type f)
+if [ "$SIZE_FAIL_BASH" -eq 0 ]; then
+  pass "All bash tooling under 1500 lines (documented exemption from 800 content limit, #343 B1)"
+fi
+echo ""
+
 # --- Check 6: prev-skill/next-skill fields exist ---
 echo "--- Check 6: prev-skill/next-skill frontmatter ---"
 for skill_dir in skills/*/; do

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -132,10 +132,14 @@ echo ""
 # cannot grow without limit. This is a DOCUMENTED, ENFORCED exemption, not a silent self-exemption
 # (closes the enforce-on-others-skip-on-self gap the Fable review + adversarial Spirit pass
 # flagged). Supersedes the v2.14.3 (#163) "trim to <800" approach: that trim regressed
-# (validate-content 793->1012, validate-structure ->1164), proving trim-alone is not durable as
-# checks accrete. The 1500 cap bounds growth; if a validator approaches it, the check fires and
-# forces a real decision (extract sourced helpers or raise the cap deliberately).
-echo "--- Check 5b: Bash tooling < 1500 lines (documented exemption from the 800 content limit, #343 B1) ---"
+# (validate-content 793->1012, validate-structure 605->1164), proving trim-alone is not durable
+# as checks accrete. The 1500 cap is an UPPER BOUND that prevents unbounded growth — not a
+# maintainability target; four-digit validators are tolerated for tooling, but approaching 1500
+# should trigger extracting sourced helpers. Scope: tests/ scripts/ hooks/ (root). The plugin/
+# mirrors of hooks/ + scripts/ are byte-identical (Check 28), so they are transitively covered;
+# tests/ is intentionally not mirrored. `find` is used instead of `git ls-files` because this
+# validator also runs from non-git installed caches.
+echo "--- Check 5b: Bash tooling <= 1500 lines (documented exemption from the 800 content limit, #343 B1) ---"
 SIZE_FAIL_BASH=0
 while read -r f; do
   lines=$(wc -l < "$f")
@@ -145,7 +149,7 @@ while read -r f; do
   fi
 done < <(find tests/ scripts/ hooks/ -name "*.sh" -type f)
 if [ "$SIZE_FAIL_BASH" -eq 0 ]; then
-  pass "All bash tooling under 1500 lines (documented exemption from 800 content limit, #343 B1)"
+  pass "All bash tooling <= 1500 lines (documented exemption from 800 content limit, #343 B1)"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

Closes the **B1** Body gap from #343: the plugin's own validators (`validate-structure.sh` ~1188, `validate-content.sh` 1012) exceeded the **800-line rule that Check 5 enforces on content files** — the enforce-on-others-skip-on-self pattern flagged by the Fable review + adversarial Spirit pass.

**Approach: documented + enforced exemption (not silent skip, not re-trim).**

⚠️ **This supersedes a prior maintainer decision — flagging for your review.** v2.14.3 (#163) closed this exact gap once by **trimming** the validators under 800. But it **regressed** (793 → 1012/1188), proving trim-alone is not durable as checks accrete. Rather than re-trim (high-effort refactor of 2 critical CI validators, will regress again), this **document-exempts** bash tooling at a higher enforced cap — the option the Fable review explicitly endorsed.

- **Check 5b** (`validate-structure.sh`, mirrors Check 5's pattern): caps `tests/` `scripts/` `hooks/` `*.sh` at **1500 lines**.
- **Documented rationale** (in the check comment): the 800-line rule is a *readability budget for content files* (skills/habits/guides, read in one sitting); bash validators are *linear tooling* (check suites) where that budget doesn't fit — but must still be **bounded**. 1500 gives headroom (current max 1188) while preventing unbounded growth; if a validator approaches it, the check fires and forces a real decision (extract sourced helpers, or raise the cap deliberately).
- Converts a **silent** self-exemption into a **documented + enforced** policy — the honesty fix.

## Test plan
- [x] `bash tests/validate-structure.sh` → ALL PASS (Check 5b passes: all bash tooling < 1500)
- [x] `bash tests/validate-content.sh` + `test-skill-graph.sh` + `test-verbosity-hook.sh` → ALL PASS
- [x] **Negative-proof**: cap=100 variant of the check logic FIRES on the real >cap files (`validate-structure.sh`, `validate-content.sh`) — confirms it would catch >1500
- [x] `bash -n` syntax OK; no secrets
- [ ] CI *Validate* green on this PR

No version bump: `tests/` is not a consumer-doctrine path (Check 27 agrees — 0 consumer files changed).

Refs #343.