### PR TITLE
docs(claude-md): reconcile Bash-skill drift 3 -> 10 (#343 F5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,31 +57,31 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 
 > For phrase-based lookup ("given these words, which skill?"), see [`skills/RESOLVER.md`](skills/RESOLVER.md). The table below indexes by workflow step.
 
-| Skill                 | Step | Habit                 | Purpose                                                                                                                         |
-| --------------------- | ---- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                   |
-| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                     |
-| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                      |
-| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                    |
-| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                        |
-| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                             |
-| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready, provider canary reconciliation                                                                     |
-| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                         |
-| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                       |
+| Skill                 | Step | Habit                 | Purpose                                                                                                                            |
+| --------------------- | ---- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                      |
+| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                        |
+| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                         |
+| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                       |
+| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                           |
+| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                                |
+| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready, provider canary reconciliation                                                                      |
+| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                            |
+| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                          |
 | `/consistency-check`  | —    | H5 + H1               | Spec artifact analyzer + incident/config hotfix consistency-lite (v2.20.1, [ADR-013](docs/adr/ADR-013-spec-persistence-opt-in.md)) |
-| `/operational-state`  | —    | H1 + H5 + H8          | Classify operational findings before action: Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue      |
-| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                   |
-| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                          |
-| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                  |
-| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation checklist (migrating per [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md))                  |
-| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                   |
-| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question retrospective + lesson file + Q6 → `SKILL-EFFECTIVENESS.md` ([ADR-018](docs/adr/ADR-018-memory-layer-activation.md)) |
-| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` ([ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md))                |
-| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                       |
+| `/operational-state`  | —    | H1 + H5 + H8          | Classify operational findings before action: Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue        |
+| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                      |
+| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                             |
+| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                     |
+| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation checklist (migrating per [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md))                     |
+| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                      |
+| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question retrospective + lesson file + Q6 → `SKILL-EFFECTIVENESS.md` ([ADR-018](docs/adr/ADR-018-memory-layer-activation.md))    |
+| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` ([ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md))                   |
+| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                          |
 
 ## Proposed (awaiting evidence)
 
 Rules below have no traceable lesson, ADR, or memory obs ID yet. Per [ADR-018](docs/adr/ADR-018-memory-layer-activation.md) "Earn each line" discipline and [ADR-016](docs/adr/ADR-016-t2-bag-drop-date-eviction-policy.md) eviction convention: **drop date 2026-11-24**. If no citation accumulates by then, the rule is dropped (soft fail, not silent deletion). If a lesson cites the rule, ratchet back into "Key Conventions" with the citation.
 
-- **Bash tool minimization in skills** — new skills default to `Read/Glob/Grep` only; Bash is added only with justification. Currently used by `/review-ai`, `/eu-ai-act-check`, `/ai-dev-log`. Rationale is least-privilege but no failure mode has been recorded.
+- **Bash tool minimization in skills** — new skills default to `Read/Glob/Grep` only; Bash is added only with justification. Currently used by 10 skills: `ai-dev-log`, `deploy-guide`, `diagnose`, `eu-ai-act-check`, `monitor-setup`, `post-mortem`, `reflect`, `review-ai`, `scrutinize`, `security-check` (most justify it via git/test/deploy/scan workflows; `eu-ai-act-check` is now a redirect stub per ADR-012 and is the one questionable carry — tracked as a least-privilege follow-up in #343). Rationale is least-privilege but no failure mode has been recorded.
 - **Reference directories are skill-immutable** — `habits/`, `guides/`, `rules/` are reference content; skills must never generate or modify them. No incident has been recorded of a skill attempting this; rule stands on convention alone.

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -57,31 +57,31 @@ Body pattern: Habit mapping → Process steps → Handoff → When to Skip → D
 
 > For phrase-based lookup ("given these words, which skill?"), see [`skills/RESOLVER.md`](skills/RESOLVER.md). The table below indexes by workflow step.
 
-| Skill                 | Step | Habit                 | Purpose                                                                                                                         |
-| --------------------- | ---- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                   |
-| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                     |
-| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                      |
-| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                    |
-| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                        |
-| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                             |
-| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready, provider canary reconciliation                                                                     |
-| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                         |
-| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                       |
+| Skill                 | Step | Habit                 | Purpose                                                                                                                            |
+| --------------------- | ---- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `/research`           | 0    | H5 Understand First   | Investigate before specifying                                                                                                      |
+| `/requirements`       | 1    | H2 Begin with End     | Define done before starting                                                                                                        |
+| `/design`             | 2    | H8 Find Your Voice    | Human decides architecture                                                                                                         |
+| `/breakdown`          | 3    | H3 First Things First | Atomic tasks, no scope creep                                                                                                       |
+| `/build-brief`        | 4    | H5 Understand First   | Read code before writing                                                                                                           |
+| `/review-ai`          | 5    | H4 Win-Win            | Actionable feedback                                                                                                                |
+| `/deploy-guide`       | 6    | H1 Be Proactive       | Staging first, rollback ready, provider canary reconciliation                                                                      |
+| `/monitor-setup`      | 7    | H7 Sharpen the Saw    | Invest in observability                                                                                                            |
+| `/cross-verify`       | All  | H1-H8                 | 17-question checklist + dimension summary                                                                                          |
 | `/consistency-check`  | —    | H5 + H1               | Spec artifact analyzer + incident/config hotfix consistency-lite (v2.20.1, [ADR-013](docs/adr/ADR-013-spec-persistence-opt-in.md)) |
-| `/operational-state`  | —    | H1 + H5 + H8          | Classify operational findings before action: Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue      |
-| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                   |
-| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                          |
-| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                  |
-| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation checklist (migrating per [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md))                  |
-| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                   |
-| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question retrospective + lesson file + Q6 → `SKILL-EFFECTIVENESS.md` ([ADR-018](docs/adr/ADR-018-memory-layer-activation.md)) |
-| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` ([ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md))                |
-| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                       |
+| `/operational-state`  | —    | H1 + H5 + H8          | Classify operational findings before action: Watch, Fix Candidate, Active Incident, Resolved, Handoff, Known Accepted Issue        |
+| `/whole-person-check` | —    | H8 Find Your Voice    | Body/Mind/Heart/Spirit 4-dimension assessment                                                                                      |
+| `/security-check`     | —    | H1 Be Proactive       | Focused security review — OWASP Top 10                                                                                             |
+| `/using-8-habits`     | —    | H5 + H8               | Onboarding meta-skill + decision tree (v2.4.0)                                                                                     |
+| `/eu-ai-act-check`    | —    | H1 + H8 (Spirit)      | EU AI Act 9-obligation checklist (migrating per [ADR-012](docs/adr/ADR-012-eu-ai-act-migration-completion.md))                     |
+| `/ai-dev-log`         | —    | H4 Win-Win + H1       | AI-assisted dev log from git history (v2.3.0)                                                                                      |
+| `/reflect`            | —    | H7 Sharpen the Saw    | 6-question retrospective + lesson file + Q6 → `SKILL-EFFECTIVENESS.md` ([ADR-018](docs/adr/ADR-018-memory-layer-activation.md))    |
+| `/calibrate`          | —    | H8 Find Your Voice    | Self-assessment → `~/.claude/habit-profile.md` ([ADR-008](docs/adr/ADR-008-user-maturity-calibration-design.md))                   |
+| `/workflow`           | —    | All                   | Guided 7-step walkthrough                                                                                                          |
 
 ## Proposed (awaiting evidence)
 
 Rules below have no traceable lesson, ADR, or memory obs ID yet. Per [ADR-018](docs/adr/ADR-018-memory-layer-activation.md) "Earn each line" discipline and [ADR-016](docs/adr/ADR-016-t2-bag-drop-date-eviction-policy.md) eviction convention: **drop date 2026-11-24**. If no citation accumulates by then, the rule is dropped (soft fail, not silent deletion). If a lesson cites the rule, ratchet back into "Key Conventions" with the citation.
 
-- **Bash tool minimization in skills** — new skills default to `Read/Glob/Grep` only; Bash is added only with justification. Currently used by `/review-ai`, `/eu-ai-act-check`, `/ai-dev-log`. Rationale is least-privilege but no failure mode has been recorded.
+- **Bash tool minimization in skills** — new skills default to `Read/Glob/Grep` only; Bash is added only with justification. Currently used by 10 skills: `ai-dev-log`, `deploy-guide`, `diagnose`, `eu-ai-act-check`, `monitor-setup`, `post-mortem`, `reflect`, `review-ai`, `scrutinize`, `security-check` (most justify it via git/test/deploy/scan workflows; `eu-ai-act-check` is now a redirect stub per ADR-012 and is the one questionable carry — tracked as a least-privilege follow-up in #343). Rationale is least-privilege but no failure mode has been recorded.
 - **Reference directories are skill-immutable** — `habits/`, `guides/`, `rules/` are reference content; skills must never generate or modify them. No incident has been recorded of a skill attempting this; rule stands on convention alone.


### PR DESCRIPTION
## Summary

Closes the **F5** Spirit gap from #343: CLAUDE.md's "Proposed" section listed only **3** Bash skills (`/review-ai`, `/eu-ai-act-check`, `/ai-dev-log`) when **10** actually carry `Bash` in `allowed-tools` (Fable review F5 + adversarial pass).

- Updated the bullet to **list all 10** accurately: `ai-dev-log`, `deploy-guide`, `diagnose`, `eu-ai-act-check`, `monitor-setup`, `post-mortem`, `reflect`, `review-ai`, `scrutinize`, `security-check`.
- Flagged `eu-ai-act-check` (now a redirect stub per ADR-012) as the **one questionable carry** — tracked as a separate least-privilege follow-up in #343 (not bundled here; would need a consumer-doctrine version bump).

**Note on the diff size:** beyond the 1-line semantic edit (line 86), the diff includes the markdown formatter re-aligning the Skills→Habits table to consistent column widths (cosmetic, ~40 lines of whitespace). This is a one-time normalization — the table in `main` predated the formatter; future CLAUDE.md edits won't re-trigger it.

Doc-only; no `skills/` change, no version bump (CLAUDE.md is root, not consumer-doctrine). Mirrored to `plugin/CLAUDE.md`.

## Test plan
- [x] Semantic edit intact: `grep "Currently used by 10 skills" CLAUDE.md` ✓
- [x] `bash tests/validate-structure.sh` + `validate-content.sh` → ALL PASS
- [x] Mirror parity: `cmp CLAUDE.md plugin/CLAUDE.md` identical
- [x] No secrets in diff
- [ ] CI *Validate* + *linkcheck* green on this PR

Refs #343.