### PR TITLE
fix(qa): close pre-tag Codex QA findings on the v2.21.37 bundle

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -98,12 +98,12 @@ Stated so posture is not overstated:
   eliminate) the blast radius; this is an accepted-but-undocumented risk, not a
   formal risk acceptance.
 
-Closed since the first version of this document ([#361](https://github.com/pitimon/8-habit-ai-dev/issues/361), 2026-07-03):
+## 5.1 Controls added since the first version ([#361](https://github.com/pitimon/8-habit-ai-dev/issues/361), 2026-07-03)
 
-- ~~No Dependabot / Renovate~~ → `.github/dependabot.yml` bumps the SHA-pinned
-  actions weekly (`github-actions` ecosystem).
-- ~~No automated secret scan in CI~~ → `.github/workflows/secret-scan.yml` runs
-  gitleaks (SHA-pinned v3.0.0) on every PR and push to main with
+- **Dependabot for pinned actions** — `.github/dependabot.yml` bumps the
+  SHA-pinned actions weekly (`github-actions` ecosystem).
+- **Automated secret scanning in CI** — `.github/workflows/secret-scan.yml`
+  runs gitleaks (SHA-pinned v3.0.0) on every PR and push to main with
   `fetch-depth: 0`, scanning the **full git history** continuously — the §4
   point-in-time spot-check is now a standing gate, and the §3.1 "git-history
   secrets" residual drops Medium → Low. GitHub's built-in secret scanning /

--- a/guides/release-surface.md
+++ b/guides/release-surface.md
@@ -8,7 +8,9 @@
 
 **Check 27** (`tests/validate-structure.sh`): any PR that changes a consumer-doctrine path since the last git tag must carry the version bump **in the same PR** — "Bundle later" defers the _tag_, never the _bump_ (lesson 2026-06-28). Once the version differs from the latest tag, follow-up PRs in the same bundle need no further bump; they extend the same version's notes instead.
 
-## Version-bearing files (Check: `validate-structure.sh` version-consistency)
+## Version-bearing files
+
+Files 1–5 are cross-checked by `validate-structure.sh` version-consistency (Check 4); file 6's header/footer freshness is enforced by `validate-content.sh` Check 19 (git-tag-derived), not by Check 4.
 
 | #   | File                               | What to change                                                              |
 | --- | ---------------------------------- | --------------------------------------------------------------------------- |

--- a/plugin/docs/security/threat-model.md
+++ b/plugin/docs/security/threat-model.md
@@ -98,12 +98,12 @@ Stated so posture is not overstated:
   eliminate) the blast radius; this is an accepted-but-undocumented risk, not a
   formal risk acceptance.
 
-Closed since the first version of this document ([#361](https://github.com/pitimon/8-habit-ai-dev/issues/361), 2026-07-03):
+## 5.1 Controls added since the first version ([#361](https://github.com/pitimon/8-habit-ai-dev/issues/361), 2026-07-03)
 
-- ~~No Dependabot / Renovate~~ → `.github/dependabot.yml` bumps the SHA-pinned
-  actions weekly (`github-actions` ecosystem).
-- ~~No automated secret scan in CI~~ → `.github/workflows/secret-scan.yml` runs
-  gitleaks (SHA-pinned v3.0.0) on every PR and push to main with
+- **Dependabot for pinned actions** — `.github/dependabot.yml` bumps the
+  SHA-pinned actions weekly (`github-actions` ecosystem).
+- **Automated secret scanning in CI** — `.github/workflows/secret-scan.yml`
+  runs gitleaks (SHA-pinned v3.0.0) on every PR and push to main with
   `fetch-depth: 0`, scanning the **full git history** continuously — the §4
   point-in-time spot-check is now a standing gate, and the §3.1 "git-history
   secrets" residual drops Medium → Low. GitHub's built-in secret scanning /

--- a/plugin/guides/release-surface.md
+++ b/plugin/guides/release-surface.md
@@ -8,7 +8,9 @@
 
 **Check 27** (`tests/validate-structure.sh`): any PR that changes a consumer-doctrine path since the last git tag must carry the version bump **in the same PR** — "Bundle later" defers the _tag_, never the _bump_ (lesson 2026-06-28). Once the version differs from the latest tag, follow-up PRs in the same bundle need no further bump; they extend the same version's notes instead.
 
-## Version-bearing files (Check: `validate-structure.sh` version-consistency)
+## Version-bearing files
+
+Files 1–5 are cross-checked by `validate-structure.sh` version-consistency (Check 4); file 6's header/footer freshness is enforced by `validate-content.sh` Check 19 (git-tag-derived), not by Check 4.
 
 | #   | File                               | What to change                                                              |
 | --- | ---------------------------------- | --------------------------------------------------------------------------- |

--- a/tests/validate-structure.sh
+++ b/tests/validate-structure.sh
@@ -1182,7 +1182,9 @@ echo "--- Check 32: CLAUDE.md skill-table completeness (Fable F3, #358) ---"
 for claudemd in CLAUDE.md plugin/CLAUDE.md; do
   [ -f "$claudemd" ] || continue
   SKILL_DIR_COUNT=$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-  TABLE_ROW_COUNT=$(grep -c '^| `/' "$claudemd" || true)
+  # awk, not `grep -c ... || true` — the || true shape is the banned
+  # false-success class (QA-caught pre-tag); awk prints 0 without masking.
+  TABLE_ROW_COUNT=$(awk '/^\| `\//{c++} END{print c+0}' "$claudemd")
   if [ "$SKILL_DIR_COUNT" -eq "$TABLE_ROW_COUNT" ]; then
     pass "$claudemd Skills→Habits table has $TABLE_ROW_COUNT rows == $SKILL_DIR_COUNT skill dirs"
   else


### PR DESCRIPTION
## Summary

Pre-tag Codex QA (7-gate strict pass, 149k tokens) on `v2.21.36..HEAD` returned 3 Fix + 1 Risk — all citations verified before acting:

- **Goal (Check 32 `|| true`)**: `tests/validate-structure.sh:1185` used `grep -c ... || true` — the banned false-success class. Replaced with a single `awk` count (no pipe, no masking — also the repo's testing convention). Negative test re-run: synthetic 23-row CLAUDE.md → FAIL, restored → green.
- **Accuracy (release-surface.md overclaim)**: guide said validate-structure version-consistency covers all 6 files; Check 4 actually covers 5 — SELF-CHECK.md is enforced by validate-content Check 19. Wording corrected (verified: `sed -n '93,109p'` has 0 SELF-CHECK hits).
- **Security/Privacy (stale strings)**: threat-model §5 kept literal `No Dependabot / Renovate` + `No automated secret scan in CI` strings under strikethrough; restated as positive §5.1 "Controls added since first version" — grep for stale variants now returns nothing in either mirror copy.
- **Edge (sandbox Risk)**: `bash tests/ci-local.sh` re-run in writable shell — ALL 5 SUITES PASSED.

QA gates otherwise: UX/Flow, Copy, Handoff = Pass (word budget 1519/2000; F8 spot-checks traceable; mirror parity clean; gitleaks/dependabot configs verified).

## Test plan

- [x] `bash tests/ci-local.sh` — ALL 5 SUITES PASSED
- [x] Check 32 negative test post-awk: FAIL on 23≠24, PASS restored
- [x] `grep "No Dependabot\|o automated secret scan" docs/security/threat-model.md` → no matches
- [ ] CI green → then ask maintainer for the v2.21.37 tag go

Refs #358 #360 #361