### PR TITLE
docs(wiki): Architecture.md validation surface freshness (/doc-check)

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -57,10 +57,14 @@ The graph is validated by repository tests so skill references do not silently d
 
 | Script                         | Purpose                                                            |
 | ------------------------------ | ------------------------------------------------------------------ |
-| `tests/validate-structure.sh`  | Frontmatter, names, version sync, graph fields, packaging surfaces |
-| `tests/validate-content.sh`    | Markdown integrity, internal links, ADR shape, doctrine checks     |
+| `tests/validate-structure.sh`  | Frontmatter, names, version sync, graph fields, packaging surfaces, CLAUDE.md table completeness (Check 32), ci-local lock-step (Check 33) |
+| `tests/validate-content.sh`    | Markdown integrity, internal links, ADR shape, doctrine checks, release-surface freshness (Check 19) |
 | `tests/test-skill-graph.sh`    | Handoff graph integrity                                            |
 | `tests/test-verbosity-hook.sh` | Claude hook output and token budget                                |
+| `tests/test-pre-commit-hook.sh` | Fail-closed verdict paths of the opt-in pre-commit example (v2.21.35) |
+| `tests/ci-local.sh`            | One-shot runner for the exact CI suite set (lock-step-guarded)     |
+
+CI additionally runs a full-history gitleaks secret scan (`.github/workflows/secret-scan.yml`) with Dependabot bumping the SHA-pinned actions weekly.
 
 ## Documentation Surfaces
 
@@ -100,8 +104,8 @@ Illustrative layout (skill/ADR counts grow between releases — browse the repo 
 ├── hooks/                          # SessionStart workflow reminder
 ├── habits/                         # h1..h8 reference content (loaded on-demand)
 ├── guides/                         # Checklists, templates, cross-verify-packs
-├── tests/                          # validate-structure / validate-content / test-skill-graph
-├── scripts/                        # sync-mirror.sh, windows-preflight.ps1
+├── tests/                          # 5 validator suites + ci-local.sh one-shot runner
+├── scripts/                        # sync-mirror.sh, generators, windows-preflight.ps1
 ├── docs/                           # adr/, wiki/, out-of-scope/, compatibility matrix
 ├── plugin/                         # Codex child-package mirror (kept in sync via sync-mirror.sh)
 ├── rules/effective-development.md  # Auto-loaded Claude Code rules

--- a/plugin/docs/wiki/Architecture.md
+++ b/plugin/docs/wiki/Architecture.md
@@ -57,10 +57,14 @@ The graph is validated by repository tests so skill references do not silently d
 
 | Script                         | Purpose                                                            |
 | ------------------------------ | ------------------------------------------------------------------ |
-| `tests/validate-structure.sh`  | Frontmatter, names, version sync, graph fields, packaging surfaces |
-| `tests/validate-content.sh`    | Markdown integrity, internal links, ADR shape, doctrine checks     |
+| `tests/validate-structure.sh`  | Frontmatter, names, version sync, graph fields, packaging surfaces, CLAUDE.md table completeness (Check 32), ci-local lock-step (Check 33) |
+| `tests/validate-content.sh`    | Markdown integrity, internal links, ADR shape, doctrine checks, release-surface freshness (Check 19) |
 | `tests/test-skill-graph.sh`    | Handoff graph integrity                                            |
 | `tests/test-verbosity-hook.sh` | Claude hook output and token budget                                |
+| `tests/test-pre-commit-hook.sh` | Fail-closed verdict paths of the opt-in pre-commit example (v2.21.35) |
+| `tests/ci-local.sh`            | One-shot runner for the exact CI suite set (lock-step-guarded)     |
+
+CI additionally runs a full-history gitleaks secret scan (`.github/workflows/secret-scan.yml`) with Dependabot bumping the SHA-pinned actions weekly.
 
 ## Documentation Surfaces
 
@@ -100,8 +104,8 @@ Illustrative layout (skill/ADR counts grow between releases — browse the repo 
 ├── hooks/                          # SessionStart workflow reminder
 ├── habits/                         # h1..h8 reference content (loaded on-demand)
 ├── guides/                         # Checklists, templates, cross-verify-packs
-├── tests/                          # validate-structure / validate-content / test-skill-graph
-├── scripts/                        # sync-mirror.sh, windows-preflight.ps1
+├── tests/                          # 5 validator suites + ci-local.sh one-shot runner
+├── scripts/                        # sync-mirror.sh, generators, windows-preflight.ps1
 ├── docs/                           # adr/, wiki/, out-of-scope/, compatibility matrix
 ├── plugin/                         # Codex child-package mirror (kept in sync via sync-mirror.sh)
 ├── rules/effective-development.md  # Auto-loaded Claude Code rules


### PR DESCRIPTION
## Summary

/doc-check sweep after v2.21.38: version sync PASS on all 7 surfaces (canonical 2.21.38), CHANGELOG clean (0 files since tag), Skills-Reference covers all 24 skills — one real staleness found:

- **wiki Architecture.md** Validation table listed only 4 test scripts — missing `test-pre-commit-hook.sh` (added v2.21.35) and `tests/ci-local.sh`. This is the exact "four scripts, not five" drift class the 2026-06-28 lesson recorded — a reader trusting the table under-runs the suite. Now lists all 5 suites + runner, names Checks 19/32/33, and notes the gitleaks/Dependabot CI layer. Tree comments updated.

## Test plan

- [x] `bash tests/ci-local.sh` — ALL 5 SUITES PASSED
- [x] Mirror synced (plugin/docs/wiki twin)
- [ ] CI green (incl. Check 27 consumer-doctrine classification of docs/wiki — if it demands a bump, will add v2.21.39 per defer-the-release-not-the-bump)